### PR TITLE
fix: harden friction publishing and sync

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -71,27 +71,45 @@ Deployed as a Cloudflare Worker. The endpoint is a Fetch handler, so it needs no
 
    `PRIVATE_KEY` is the PEM key. Real newlines are fine; escaped `\n` is also accepted.
 
-3. **Deploy**, then point the App's webhook URL at the resulting `https://<worker>.workers.dev/`:
+3. **Create the delivery and dead-letter queues**:
+
+   ```sh
+   pnpm exec wrangler queues create frog-webhooks
+   pnpm exec wrangler queues create frog-webhooks-dlq
+   ```
+
+4. **Deploy**, then point the App's webhook URL at the resulting `https://<worker>.workers.dev/`:
 
    ```sh
    pnpm deploy
    ```
 
-4. **Install** the App on the repositories that record friction, and on any repository that should
+5. **Install** the App on the repositories that record friction, and on any repository that should
    receive friction from them.
 
-5. **Run `frog init`** in each repository, so the App has a config and a directory to read.
+6. **Run `frog init`** in each repository, so the App has a config and a directory to read.
 
 `nodejs_compat` is enabled because the title hash uses `node:crypto`, and the package layer imports
 `node:fs` for the disk reads the App never takes. The bundle is around 200 KiB gzipped.
 
 Run it locally against a real workerd with `pnpm dev`.
 
-## Redelivery is safe
+## Delivery and retries
 
-A handler that throws returns 500, and GitHub redelivers. Every handler is idempotent: filing comments
-on the issue already covering a friction rather than opening another, and reconciliation converges, so a
-redelivery repeats the work harmlessly.
+The endpoint verifies the exact signed bytes, projects only the fields Frog reads, and awaits a durable
+Queue write before returning `202`. Issue events carry only their repository and number; the consumer
+fetches current issue state after claiming the delivery, so a delayed close cannot undo a later reopen.
+
+Queue retries each failed message independently with bounded backoff. A Durable Object remembers
+completed GitHub delivery ids and serializes repository mutations, while occurrence markers make an
+ambiguous issue or comment write replay-safe. After 20 retries, Queue moves a poison message to
+`frog-webhooks-dlq`, which deliberately has no consumer. Inspect and re-send its messages from the
+Cloudflare dashboard before retention expires: 24 hours on Free, or four days by default on Paid.
+
+If the initial Queue write itself fails, the endpoint returns `503`. GitHub does not automatically retry
+failed webhook deliveries; redeliver one from the App's **Recent deliveries** page after resolving the
+outage. The same manual redelivery also recovers a dead-lettered event when its GitHub delivery is still
+available.
 
 ## Tests
 

--- a/app/src/App.ts
+++ b/app/src/App.ts
@@ -31,8 +31,9 @@ export function create(options: create.Options): App {
       const client = await app.getInstallationOctokit(found.data.id)
       clients.set(repo, client)
       return client
-    } catch {
-      return undefined
+    } catch (error) {
+      if ((error as { status?: number }).status === 404) return undefined
+      throw error
     }
   }
 

--- a/app/src/App.ts
+++ b/app/src/App.ts
@@ -2,6 +2,7 @@ import { App, type Octokit } from 'octokit'
 import { issues } from './handlers/issues.js'
 import { pullRequest } from './handlers/pullRequest.js'
 import { push } from './handlers/push.js'
+import * as serialization from './internal/serialize.js'
 
 /**
  * Builds the App and registers every handler.
@@ -10,11 +11,11 @@ import { push } from './handlers/push.js'
  * repository with no installation resolves to `undefined`, and that is the consent gate: the App
  * physically cannot file where it has not been installed.
  *
- * Handlers are allowed to throw. GitHub redelivers a failed webhook, and every handler is idempotent,
- * so a redelivery repeats the work harmlessly rather than duplicating it.
+ * Handlers are allowed to throw. Delivery claims are only completed after the handler succeeds, and
+ * replay markers keep a repeated external mutation from duplicating an issue or comment.
  */
 export function create(options: create.Options): App {
-  const { appId, privateKey, registry, secret } = options
+  const { appId, coordinator, privateKey, registry, secret } = options
 
   const app = new App({ appId, privateKey, webhooks: { secret } })
 
@@ -46,24 +47,28 @@ export function create(options: create.Options): App {
     return identity
   }
 
+  const serialize = (delivery: string) => serialization.repositories(coordinator, delivery)
+
   app.webhooks.on(
     ['pull_request.opened', 'pull_request.reopened', 'pull_request.synchronize'],
-    async ({ octokit, payload }) => {
+    async ({ id, octokit, payload }) => {
       const author = payload.pull_request.user?.login
       await pullRequest({
         ...(author ? { actor: `@${author}` } : {}),
         base: payload.repository.full_name,
         baseRef: payload.pull_request.base.ref,
         client: octokit,
+        delivery: id,
         head: payload.pull_request.head.sha,
         installation,
         pr: payload.number,
         ...(registry ? { registry } : {}),
+        serialize: serialize(id),
       })
     },
   )
 
-  app.webhooks.on('push', async ({ octokit, payload }) => {
+  app.webhooks.on('push', async ({ id, octokit, payload }) => {
     const branch = payload.repository.default_branch
     // Only the default branch: a topic branch's entries are handled as a pull request.
     if (payload.ref !== `refs/heads/${branch}`) return
@@ -75,15 +80,17 @@ export function create(options: create.Options): App {
     await push({
       branch,
       client: octokit,
+      delivery: id,
       installation,
       repo: payload.repository.full_name,
       ...(registry ? { registry } : {}),
+      serialize: serialize(id),
     })
   })
 
   app.webhooks.on(
     ['issues.closed', 'issues.edited', 'issues.reopened'],
-    async ({ octokit, payload }) => {
+    async ({ id, octokit, payload }) => {
       await issues({
         client: octokit,
         installation,
@@ -100,6 +107,7 @@ export function create(options: create.Options): App {
           title: payload.issue.title,
         },
         repo: payload.repository.full_name,
+        serialize: serialize(id),
       })
     },
   )
@@ -112,6 +120,8 @@ export declare namespace create {
   type Options = {
     /** GitHub App id. */
     appId: number | string
+    /** Durable coordinator binding for delivery and repository serialization. */
+    coordinator: serialization.Namespace
     /** GitHub App private key, PEM encoded. */
     privateKey: string
     /** Registry base URL. Overridden in tests. */

--- a/app/src/Delivery.test.ts
+++ b/app/src/Delivery.test.ts
@@ -1,0 +1,177 @@
+import * as Delivery from './Delivery.js'
+
+const common = {
+  installation: { id: 42 },
+  repository: { full_name: 'acme/app' },
+}
+
+test('behavior: compacts a pull request delivery to the fields its handler reads', () => {
+  expect(
+    Delivery.fromWebhook({
+      id: 'delivery-1',
+      name: 'pull_request',
+      payload: {
+        action: 'synchronize',
+        installation: common.installation,
+        number: 7,
+        pull_request: {
+          base: { ref: 'main', repository: { ignored: true } },
+          body: 'ignored',
+          head: { repo: { ignored: true }, sha: 'abc123' },
+          user: { avatar_url: 'ignored', login: 'contributor' },
+        },
+        repository: { ...common.repository, description: 'ignored' },
+      },
+    }),
+  ).toEqual({
+    id: 'delivery-1',
+    name: 'pull_request',
+    payload: {
+      action: 'synchronize',
+      installation: { id: 42 },
+      number: 7,
+      pull_request: {
+        base: { ref: 'main' },
+        head: { sha: 'abc123' },
+        user: { login: 'contributor' },
+      },
+      repository: { full_name: 'acme/app' },
+    },
+    v: 1,
+  })
+})
+
+test('behavior: strips push commits before measuring the queue message', () => {
+  const delivery = Delivery.fromWebhook({
+    id: 'delivery-2',
+    name: 'push',
+    payload: {
+      ...common,
+      commits: [{ message: 'x'.repeat(Delivery.maxBytes * 2) }],
+      ref: 'refs/heads/main',
+      repository: { ...common.repository, default_branch: 'main' },
+      sender: { avatar_url: 'ignored', login: 'frog[bot]' },
+    },
+  })
+
+  expect(delivery).toEqual({
+    id: 'delivery-2',
+    name: 'push',
+    payload: {
+      installation: { id: 42 },
+      ref: 'refs/heads/main',
+      repository: { default_branch: 'main', full_name: 'acme/app' },
+      sender: { login: 'frog[bot]' },
+    },
+    v: 1,
+  })
+  expect(Delivery.bytes(delivery!)).toBeLessThan(Delivery.maxBytes)
+})
+
+test('behavior: queues an issue identity instead of its potentially oversized body', () => {
+  const delivery = Delivery.fromWebhook({
+    id: 'delivery-3',
+    name: 'issues',
+    payload: {
+      action: 'edited',
+      ...common,
+      issue: { body: '🐸'.repeat(Delivery.maxBytes), number: 9, title: 'Ignored until hydration' },
+    },
+  })
+
+  expect(delivery).toEqual({
+    id: 'delivery-3',
+    name: 'issues',
+    payload: {
+      installation: { id: 42 },
+      issue: { number: 9 },
+      repository: { full_name: 'acme/app' },
+    },
+    v: 1,
+  })
+  expect(Delivery.bytes(delivery!)).toBeLessThan(Delivery.maxBytes)
+})
+
+test('behavior: unsupported webhook actions are accepted without queueing', () => {
+  expect(
+    Delivery.fromWebhook({
+      id: 'delivery-4',
+      name: 'pull_request',
+      payload: {
+        action: 'closed',
+        ...common,
+        number: 7,
+        pull_request: {
+          base: { ref: 'main' },
+          head: { sha: 'abc123' },
+          user: null,
+        },
+      },
+    }),
+  ).toBeUndefined()
+})
+
+test('error: rejects malformed signed payloads and unknown queue versions', () => {
+  expect(() =>
+    Delivery.fromWebhook({
+      id: 'delivery-5',
+      name: 'push',
+      payload: { ...common, ref: '', repository: { ...common.repository, default_branch: 'main' } },
+    }),
+  ).toThrow(Delivery.InvalidError)
+
+  expect(() =>
+    Delivery.fromQueue({
+      id: 'delivery-5',
+      name: 'issues',
+      payload: {
+        installation: { id: 42 },
+        issue: { number: 9 },
+        repository: { full_name: 'acme/app' },
+      },
+      v: 2,
+    }),
+  ).toThrow('Expected queue format version 1')
+})
+
+test('behavior: issue hydration uses current state after a delayed event', async () => {
+  const delivery = Delivery.fromQueue({
+    id: 'delivery-6',
+    name: 'issues',
+    payload: {
+      installation: { id: 42 },
+      issue: { number: 9 },
+      repository: { full_name: 'acme/app' },
+    },
+    v: 1,
+  })
+  const issue = vi.fn(async () => ({
+    body: 'Current body.',
+    labels: ['friction'],
+    number: 9,
+    state: 'open',
+    title: 'Current title',
+  }))
+
+  await expect(Delivery.toEvent(delivery, { issue })).resolves.toEqual({
+    id: 'delivery-6',
+    name: 'issues',
+    payload: {
+      action: 'edited',
+      installation: { id: 42 },
+      issue: {
+        body: 'Current body.',
+        labels: ['friction'],
+        number: 9,
+        state: 'open',
+        title: 'Current title',
+      },
+      repository: { full_name: 'acme/app' },
+    },
+  })
+  expect(issue).toHaveBeenCalledWith({
+    installation: 42,
+    issue: 9,
+    repo: 'acme/app',
+  })
+})

--- a/app/src/Delivery.ts
+++ b/app/src/Delivery.ts
@@ -1,0 +1,276 @@
+import type { Github } from 'frog'
+
+/** Queue format version. */
+const version = 1 as const
+
+/** Maximum encoded body size after reserving Queue's internal metadata overhead. */
+export const maxBytes = 127_800
+
+type Installation = { id: number }
+type Repository = { full_name: string }
+
+/** The compact, versioned webhook projection persisted in Queue. */
+export type Delivery =
+  | {
+      id: string
+      name: 'issues'
+      payload: {
+        installation: Installation
+        issue: { number: number }
+        repository: Repository
+      }
+      v: typeof version
+    }
+  | {
+      id: string
+      name: 'pull_request'
+      payload: {
+        action: 'opened' | 'reopened' | 'synchronize'
+        installation: Installation
+        number: number
+        pull_request: {
+          base: { ref: string }
+          head: { sha: string }
+          user: { login: string } | null
+        }
+        repository: Repository
+      }
+      v: typeof version
+    }
+  | {
+      id: string
+      name: 'push'
+      payload: {
+        installation: Installation
+        ref: string
+        repository: Repository & { default_branch: string }
+        sender: { login: string } | null
+      }
+      v: typeof version
+    }
+
+type WithoutVersion<Value> = Value extends { v: typeof version } ? Omit<Value, 'v'> : never
+
+/** Minimal event shape consumed by the registered Octokit handlers. */
+export type Event =
+  | WithoutVersion<Extract<Delivery, { name: 'pull_request' | 'push' }>>
+  | {
+      id: string
+      name: 'issues'
+      payload: {
+        action: 'closed' | 'edited'
+        installation: Installation
+        issue: Github.Issue
+        repository: Repository
+      }
+    }
+
+type ObjectValue = Record<string, unknown>
+
+function object(value: unknown, field: string): ObjectValue {
+  if (!value || typeof value !== 'object' || Array.isArray(value))
+    throw new InvalidError(`Expected \`${field}\` to be an object.`)
+  return value as ObjectValue
+}
+
+function string(value: unknown, field: string): string {
+  if (typeof value !== 'string' || value.length === 0)
+    throw new InvalidError(`Expected \`${field}\` to be a non-empty string.`)
+  return value
+}
+
+function integer(value: unknown, field: string): number {
+  if (!Number.isSafeInteger(value) || (value as number) <= 0)
+    throw new InvalidError(`Expected \`${field}\` to be a positive integer.`)
+  return value as number
+}
+
+function installation(payload: ObjectValue): Installation {
+  const value = object(payload['installation'], 'installation')
+  return { id: integer(value['id'], 'installation.id') }
+}
+
+function repository(payload: ObjectValue): Repository {
+  const value = object(payload['repository'], 'repository')
+  const fullName = string(value['full_name'], 'repository.full_name')
+  if (!/^[\w.-]+\/[\w.-]+$/.test(fullName))
+    throw new InvalidError('Expected `repository.full_name` as `owner/name`.')
+  return { full_name: fullName }
+}
+
+function login(value: unknown, field: string): { login: string } | null {
+  if (value === null || value === undefined) return null
+  const user = object(value, field)
+  return typeof user['login'] === 'string' && user['login'] ? { login: user['login'] } : null
+}
+
+function action<Action extends string>(
+  value: unknown,
+  allowed: readonly Action[],
+  field: string,
+): Action | undefined {
+  const name = string(value, field)
+  return allowed.find((candidate) => candidate === name)
+}
+
+/** Whether an event header names a webhook Frog handles. */
+export function supports(name: string): name is Delivery['name'] {
+  return name === 'issues' || name === 'pull_request' || name === 'push'
+}
+
+/**
+ * Validates and projects a signed GitHub payload before it enters Queue.
+ *
+ * Unsupported actions return `undefined`, matching Octokit's unregistered-event behavior.
+ */
+export function fromWebhook(options: {
+  id: string
+  name: Delivery['name']
+  payload: unknown
+}): Delivery | undefined {
+  const id = string(options.id, 'id')
+  const payload = object(options.payload, 'payload')
+  const installed = installation(payload)
+  const repo = repository(payload)
+
+  if (options.name === 'pull_request') {
+    const selected = action(
+      payload['action'],
+      ['opened', 'reopened', 'synchronize'] as const,
+      'action',
+    )
+    if (!selected) return undefined
+
+    const pull = object(payload['pull_request'], 'pull_request')
+    const base = object(pull['base'], 'pull_request.base')
+    const head = object(pull['head'], 'pull_request.head')
+    return {
+      id,
+      name: options.name,
+      payload: {
+        action: selected,
+        installation: installed,
+        number: integer(payload['number'], 'number'),
+        pull_request: {
+          base: { ref: string(base['ref'], 'pull_request.base.ref') },
+          head: { sha: string(head['sha'], 'pull_request.head.sha') },
+          user: login(pull['user'], 'pull_request.user'),
+        },
+        repository: repo,
+      },
+      v: version,
+    }
+  }
+
+  if (options.name === 'push') {
+    const rawRepository = object(payload['repository'], 'repository')
+    return {
+      id,
+      name: options.name,
+      payload: {
+        installation: installed,
+        ref: string(payload['ref'], 'ref'),
+        repository: {
+          ...repo,
+          default_branch: string(rawRepository['default_branch'], 'repository.default_branch'),
+        },
+        sender: login(payload['sender'], 'sender'),
+      },
+      v: version,
+    }
+  }
+
+  const selected = action(payload['action'], ['closed', 'edited', 'reopened'] as const, 'action')
+  if (!selected) return undefined
+  const issue = object(payload['issue'], 'issue')
+  return {
+    id,
+    name: options.name,
+    payload: {
+      installation: installed,
+      issue: { number: integer(issue['number'], 'issue.number') },
+      repository: repo,
+    },
+    v: version,
+  }
+}
+
+/** Validates a value read back from Queue, rejecting unknown format versions. */
+export function fromQueue(value: unknown): Delivery {
+  const delivery = object(value, 'delivery')
+  if (delivery['v'] !== version) throw new InvalidError(`Expected queue format version ${version}.`)
+  const id = string(delivery['id'], 'id')
+  const name = string(delivery['name'], 'name')
+  if (!supports(name)) throw new InvalidError('Expected a supported event name.')
+
+  const payload = object(delivery['payload'], 'payload')
+  if (name === 'issues') {
+    const issue = object(payload['issue'], 'issue')
+    return {
+      id,
+      name,
+      payload: {
+        installation: installation(payload),
+        issue: { number: integer(issue['number'], 'issue.number') },
+        repository: repository(payload),
+      },
+      v: version,
+    }
+  }
+
+  const normalized = fromWebhook({ id, name, payload })
+  if (!normalized) throw new InvalidError('Expected a supported event action.')
+  return normalized
+}
+
+/** Encoded Queue message size in bytes. */
+export function bytes(delivery: Delivery): number {
+  return new TextEncoder().encode(JSON.stringify(delivery)).byteLength
+}
+
+/**
+ * Expands a queued delivery into the minimal event Octokit's handlers consume.
+ *
+ * Issue events are rehydrated only after the durable delivery claim is acquired. This supplies the
+ * current marker for routing; reconciliation refetches again under the origin repository lease.
+ */
+export async function toEvent(
+  delivery: Delivery,
+  options: {
+    issue: (reference: {
+      installation: number
+      issue: number
+      repo: string
+    }) => Promise<Github.Issue>
+  },
+): Promise<Event> {
+  if (delivery.name !== 'issues') {
+    const { v: _, ...event } = delivery
+    return event
+  }
+
+  const issue = await options.issue({
+    installation: delivery.payload.installation.id,
+    issue: delivery.payload.issue.number,
+    repo: delivery.payload.repository.full_name,
+  })
+  return {
+    id: delivery.id,
+    name: delivery.name,
+    payload: {
+      action: issue.state === 'closed' ? 'closed' : 'edited',
+      installation: delivery.payload.installation,
+      issue,
+      repository: delivery.payload.repository,
+    },
+  }
+}
+
+/** A signed or queued delivery does not match Frog's supported projection. */
+export class InvalidError extends Error {
+  override readonly name = 'Delivery.InvalidError'
+
+  constructor(detail: string) {
+    super(`Invalid webhook delivery. ${detail}`)
+  }
+}

--- a/app/src/WebhookCoordinator.ts
+++ b/app/src/WebhookCoordinator.ts
@@ -1,0 +1,52 @@
+import { DurableObject } from 'cloudflare:workers'
+import * as state from './internal/coordinatorState.js'
+
+const key = 'state'
+
+/**
+ * Durable delivery claims and per-repository mutation leases.
+ *
+ * Instances are addressed by either a delivery id or repository name. Storage input gates make each
+ * read-modify-write transition atomic without holding `blockConcurrencyWhile` across GitHub requests.
+ */
+export class WebhookCoordinator extends DurableObject<Record<string, never>> {
+  async claim(owner: string): Promise<'claimed' | 'completed' | 'processing'> {
+    const current = await this.ctx.storage.get<state.State>(key)
+    const transition = state.claim(current, { now: Date.now(), owner })
+    if (transition.state !== current) await this.ctx.storage.put(key, transition.state)
+    return transition.result
+  }
+
+  async complete(owner: string): Promise<boolean> {
+    const current = await this.ctx.storage.get<state.State>(key)
+    const transition = state.complete(current, owner)
+    if (transition.state !== current && transition.state)
+      await this.ctx.storage.put(key, transition.state)
+    if (transition.result && current?.kind === 'delivery' && current.status !== 'completed')
+      await this.ctx.storage.setAlarm(Date.now() + state.retention)
+    return transition.result
+  }
+
+  async abandon(owner: string): Promise<void> {
+    const current = await this.ctx.storage.get<state.State>(key)
+    const next = state.abandon(current, owner)
+    if (next !== current && next === undefined) await this.ctx.storage.delete(key)
+  }
+
+  async acquire(owner: string): Promise<boolean> {
+    const current = await this.ctx.storage.get<state.State>(key)
+    const transition = state.acquire(current, { now: Date.now(), owner })
+    if (transition.state !== current) await this.ctx.storage.put(key, transition.state)
+    return transition.result
+  }
+
+  async release(owner: string): Promise<void> {
+    const current = await this.ctx.storage.get<state.State>(key)
+    const next = state.release(current, owner)
+    if (next !== current && next === undefined) await this.ctx.storage.delete(key)
+  }
+
+  async alarm(): Promise<void> {
+    await this.ctx.storage.deleteAll()
+  }
+}

--- a/app/src/handlers/issues.test.ts
+++ b/app/src/handlers/issues.test.ts
@@ -1,4 +1,4 @@
-import { Github, Store } from 'frog'
+import { Github, Mirrors, Store } from 'frog'
 import { Octokit } from 'octokit'
 import { github } from '../../../test/github.js'
 import { issues } from './issues.js'
@@ -22,6 +22,14 @@ function entry(options: { issue?: string; target?: string } = {}): string {
     .map(([key, value]) => `${key}: '${value}'`)
     .join('\n')
   return `---\n${fields}\n---\n\nThe filter was swallowed.\n`
+}
+
+function journal(issue: string, id = 'a'): string {
+  return Mirrors.serialize(
+    Mirrors.update(Mirrors.empty(), {
+      remember: [{ issue, path: Store.toPath(id) }],
+    }),
+  )
 }
 
 /** An issue body carrying the marker that names its mirror. */
@@ -49,6 +57,10 @@ describe('same repository', () => {
 
     expect(outcome.plan?.remove).toEqual(['a'])
     expect(instance.files(consumer)[`${dir}/a/friction.md`]).toBeUndefined()
+    expect(Mirrors.from(JSON.parse(instance.files(consumer)[Mirrors.file] ?? ''))).toEqual({
+      mirrors: [{ issue: `${consumer}#1`, path: Store.toPath('a') }],
+      version: 1,
+    })
     expect(instance.messages(consumer)).toEqual(['initial', 'chore: sync friction log'])
   })
 
@@ -75,24 +87,32 @@ describe('same repository', () => {
     })
 
     // Nothing under the entry survives, and nothing outside it is touched.
-    expect(Object.keys(instance.files(consumer))).toEqual(['README.md'])
+    expect(Object.keys(instance.files(consumer)).sort()).toEqual([Mirrors.file, 'README.md'].sort())
   })
 
   test('behavior: a reopened issue rebuilds the entry that was deleted', async () => {
     const instance = await github(
-      { [consumer]: [{ body: body(consumer), title }] },
-      { files: { [consumer]: { 'README.md': '# app' } } },
+      { [consumer]: [{ body: body(consumer, 'forged'), title }] },
+      {
+        files: {
+          [consumer]: {
+            [Mirrors.file]: journal(`${consumer}#1`),
+            'README.md': '# app',
+          },
+        },
+      },
     )
 
     const outcome = await issues({
       client: client(instance.url),
       installation: async () => undefined,
-      issue: { body: body(consumer), number: 1, state: 'open', title },
+      issue: { body: body(consumer, 'forged'), number: 1, state: 'open', title },
       repo: consumer,
     })
 
     expect(outcome.plan?.write.map((value) => value.id)).toEqual(['a'])
     expect(instance.files(consumer)[`${dir}/a/friction.md`]).toContain(title)
+    expect(instance.files(consumer)[Mirrors.file]).toBeUndefined()
   })
 
   test('behavior: a matching issue and entry need no commit', async () => {
@@ -182,6 +202,54 @@ describe('cross-repo', () => {
 
     expect(outcome.ignored).toBe('frog is not installed on `acme/app`')
     expect(instance.files(consumer)[`${dir}/a/friction.md`]).toBeTruthy()
+  })
+})
+
+test('security: an unrecorded marker cannot authorize repository writes', async () => {
+  const instance = await github(
+    { [upstream]: [{ body: body(consumer, 'forged'), state: 'closed', title }] },
+    { files: { [consumer]: { 'README.md': '# app' } } },
+  )
+  const octokit = client(instance.url)
+
+  const outcome = await issues({
+    client: octokit,
+    installation: async (repo) => (repo === consumer ? octokit : undefined),
+    issue: { body: body(consumer, 'forged'), number: 1, state: 'closed', title },
+    repo: upstream,
+  })
+
+  expect(outcome.ignored).toBe('untrusted frog marker')
+  expect(instance.files(consumer)).toEqual({ 'README.md': '# app' })
+  expect(instance.messages(consumer)).toEqual(['initial'])
+})
+
+test('security: a marker cannot redirect a trusted mirror path', async () => {
+  const instance = await github(
+    { [consumer]: [{ body: body(consumer, 'forged'), state: 'closed', title }] },
+    {
+      files: {
+        [consumer]: {
+          [`${dir}/a/friction.md`]: entry({ issue: `${consumer}#1` }),
+          'README.md': '# app',
+        },
+      },
+    },
+  )
+
+  const outcome = await issues({
+    client: client(instance.url),
+    installation: async () => undefined,
+    issue: { body: body(consumer, 'forged'), number: 1, state: 'closed', title },
+    repo: consumer,
+  })
+
+  expect(outcome.plan?.remove).toEqual(['a'])
+  expect(instance.files(consumer)[`${dir}/a/friction.md`]).toBeUndefined()
+  expect(instance.files(consumer)[`${dir}/forged/friction.md`]).toBeUndefined()
+  expect(Mirrors.from(JSON.parse(instance.files(consumer)[Mirrors.file] ?? ''))).toEqual({
+    mirrors: [{ issue: `${consumer}#1`, path: Store.toPath('a') }],
+    version: 1,
   })
 })
 

--- a/app/src/handlers/issues.test.ts
+++ b/app/src/handlers/issues.test.ts
@@ -1,6 +1,7 @@
 import { Github, Mirrors, Store } from 'frog'
 import { Octokit } from 'octokit'
 import { github } from '../../../test/github.js'
+import type { Serialize } from '../internal/serialize.js'
 import { issues } from './issues.js'
 
 const consumer = 'acme/app'
@@ -47,12 +48,18 @@ describe('same repository', () => {
       { files: { [consumer]: { [`${dir}/a/friction.md`]: entry({ issue: `${consumer}#1` }) } } },
     )
     const octokit = client(instance.url)
+    const repositories: string[] = []
+    const serialize: Serialize = async (repo, operation) => {
+      repositories.push(repo)
+      return operation()
+    }
 
     const outcome = await issues({
       client: octokit,
       installation: async () => undefined,
       issue: { body: body(consumer), number: 1, state: 'closed', title },
       repo: consumer,
+      serialize,
     })
 
     expect(outcome.plan?.remove).toEqual(['a'])
@@ -62,6 +69,7 @@ describe('same repository', () => {
       version: 1,
     })
     expect(instance.messages(consumer)).toEqual(['initial', 'chore: sync friction log'])
+    expect(repositories).toEqual([consumer])
   })
 
   test('behavior: closing takes the reproduction with it', async () => {

--- a/app/src/handlers/issues.test.ts
+++ b/app/src/handlers/issues.test.ts
@@ -140,6 +140,26 @@ describe('same repository', () => {
     expect(instance.messages(consumer)).toEqual(['initial'])
   })
 
+  test('behavior: a delayed close event cannot overwrite current reopened state', async () => {
+    const instance = await github(
+      { [consumer]: [{ body: body(consumer), state: 'open', title }] },
+      { files: { [consumer]: { [`${dir}/a/friction.md`]: entry({ issue: `${consumer}#1` }) } } },
+    )
+
+    const outcome = await issues({
+      client: client(instance.url),
+      installation: async () => undefined,
+      // This is the older queued snapshot. `Sync.state` must refetch after acquiring the lease.
+      issue: { body: body(consumer), number: 1, state: 'closed', title },
+      repo: consumer,
+    })
+
+    expect(outcome.plan?.remove).toEqual([])
+    expect(outcome.committed).toBeUndefined()
+    expect(instance.files(consumer)[`${dir}/a/friction.md`]).toBeTruthy()
+    expect(instance.messages(consumer)).toEqual(['initial'])
+  })
+
   // Runs on every issue event, so a second pass must change nothing.
   test('behavior: reconciling twice makes one commit', async () => {
     const instance = await github(

--- a/app/src/handlers/issues.ts
+++ b/app/src/handlers/issues.ts
@@ -2,6 +2,7 @@ import { Entry, Github, Mirrors, Store, Sync } from 'frog'
 import type { Octokit } from 'octokit'
 import * as config from '../internal/config.js'
 import * as mirrors from '../internal/mirrors.js'
+import * as serialization from '../internal/serialize.js'
 import * as Repository from '../Repository.js'
 
 /** What reconciling an issue event did. */
@@ -30,7 +31,7 @@ export type Outcome = {
  * @returns What happened, or why nothing did.
  */
 export async function issues(options: issues.Options): Promise<Outcome> {
-  const { client, installation, issue, repo } = options
+  const { client, installation, issue, repo, serialize = serialization.direct } = options
 
   // A marker is only a routing hint. Committed state below decides whether the issue is ours to act on.
   const marker = Github.parseMarker(issue.body)
@@ -40,97 +41,99 @@ export async function issues(options: issues.Options): Promise<Outcome> {
   const source = origin === repo ? client : await installation(origin)
   if (!source) return { ignored: `frog is not installed on \`${origin}\``, origin }
 
-  const branch = await Github.defaultBranch(source.rest, { repo: origin })
-  if (!branch) return { ignored: `cannot read \`${origin}\``, origin }
+  return serialize(origin, async () => {
+    const branch = await Github.defaultBranch(source.rest, { repo: origin })
+    if (!branch) return { ignored: `cannot read \`${origin}\``, origin }
 
-  const settings = await config.read(source, { repo: origin })
-  const { entries } = await Repository.read(source, { ref: branch, repo: origin })
-  const remembered = await mirrors.read(source, { ref: branch, repo: origin })
+    const settings = await config.read(source, { repo: origin })
+    const { entries } = await Repository.read(source, { ref: branch, repo: origin })
+    const remembered = await mirrors.read(source, { ref: branch, repo: origin })
 
-  const bindings: Mirrors.Mirror[] = remembered.mirrors.filter(
-    (binding) => Github.parseLink(binding.issue)?.repo === repo,
-  )
-  for (const entry of entries) {
-    if (!entry.issue) continue
-    const link = Github.parseLink(entry.issue)
-    if (link?.repo === repo) bindings.push({ issue: entry.issue, path: Store.toPath(entry.id) })
-  }
+    const bindings: Mirrors.Mirror[] = remembered.mirrors.filter(
+      (binding) => Github.parseLink(binding.issue)?.repo === repo,
+    )
+    for (const entry of entries) {
+      if (!entry.issue) continue
+      const link = Github.parseLink(entry.issue)
+      if (link?.repo === repo) bindings.push({ issue: entry.issue, path: Store.toPath(entry.id) })
+    }
 
-  const current = Github.toLink({ issue: issue.number, repo })
-  if (!bindings.some((binding) => binding.issue === current))
-    return { ignored: 'untrusted frog marker', origin }
+    const current = Github.toLink({ issue: issue.number, repo })
+    if (!bindings.some((binding) => binding.issue === current))
+      return { ignored: 'untrusted frog marker', origin }
 
-  // Listed from the repository the issue is in, which is not where the files are. `Sync.state` confirms
-  // any linked issue the listing misses, so a label edit is not mistaken for a deletion.
-  const target = await config.read(client, { repo })
-  const label = target.inbound.labels?.[0] ?? settings.labels[0] ?? 'friction'
+    // Listed from the repository the issue is in, which is not where the files are. `Sync.state`
+    // confirms any linked issue the listing misses, so a label edit is not mistaken for a deletion.
+    const target = await config.read(client, { repo })
+    const label = target.inbound.labels?.[0] ?? settings.labels[0] ?? 'friction'
 
-  const state = await Sync.state({
-    entries,
-    get: (number) => Github.get(client.rest, { issue: number, repo }),
-    list: () => Github.list(client.rest, { label, repo }),
-    remembered: bindings
-      .map((binding) => Github.parseLink(binding.issue)?.issue)
-      .filter((number): number is number => number !== undefined),
-    repo,
+    const state = await Sync.state({
+      entries,
+      get: (number) => Github.get(client.rest, { issue: number, repo }),
+      list: () => Github.list(client.rest, { label, repo }),
+      remembered: bindings
+        .map((binding) => Github.parseLink(binding.issue)?.issue)
+        .filter((number): number is number => number !== undefined),
+      repo,
+    })
+
+    const trusted = new Set(
+      bindings
+        .map((binding) => Github.parseLink(binding.issue)?.issue)
+        .filter((number): number is number => number !== undefined),
+    )
+    const plan = Sync.plan({
+      entries,
+      issues: state.filter((candidate) => trusted.has(candidate.number)),
+      labels: settings.labels,
+      mirrors: bindings,
+      // The files are in `origin`; issues are in `repo`. They differ when reporting upstream.
+      origin,
+      repo,
+      severityLabels: settings.severityLabels,
+    })
+
+    const byId = new Map(entries.map((entry) => [entry.id, entry]))
+    const remember: Mirrors.Mirror[] = []
+    for (const id of plan.remove) {
+      const entry = byId.get(id)
+      if (entry?.issue) remember.push({ issue: entry.issue, path: Store.toPath(entry.id) })
+    }
+
+    const found = new Set(state.map((candidate) => candidate.number))
+    const forget = [
+      ...remembered.mirrors.filter((binding) => {
+        const link = Github.parseLink(binding.issue)
+        return link?.repo === repo && !found.has(link.issue)
+      }),
+      ...plan.write
+        .filter((entry): entry is typeof entry & { issue: string } => Boolean(entry.issue))
+        .map((entry) => ({ issue: entry.issue, path: Store.toPath(entry.id) })),
+    ]
+    const nextMirrors = Mirrors.update(remembered, { forget, remember })
+    const mirrorsChanged = Mirrors.serialize(nextMirrors) !== Mirrors.serialize(remembered)
+
+    if (Sync.empty(plan) && !mirrorsChanged) return { origin, plan }
+
+    const committed = await Repository.commit(source, {
+      branch,
+      deletes: mirrorsChanged && nextMirrors.mirrors.length === 0 ? [Mirrors.file] : [],
+      directories: plan.remove.map(Store.toDir),
+      message: 'chore: sync friction log',
+      repo: origin,
+      writes: [
+        ...[...plan.write, ...plan.clearLink].map((entry) => ({
+          contents: Entry.serialize(entry),
+          path: Store.toPath(entry.id),
+        })),
+        ...(mirrorsChanged && nextMirrors.mirrors.length > 0
+          ? [{ contents: Mirrors.serialize(nextMirrors), path: Mirrors.file }]
+          : []),
+      ],
+    })
+
+    return { origin, plan, ...(committed ? { committed } : {}) }
   })
-
-  const trusted = new Set(
-    bindings
-      .map((binding) => Github.parseLink(binding.issue)?.issue)
-      .filter((number): number is number => number !== undefined),
-  )
-  const plan = Sync.plan({
-    entries,
-    issues: state.filter((candidate) => trusted.has(candidate.number)),
-    labels: settings.labels,
-    mirrors: bindings,
-    // The files are in `origin`; the issues are in `repo`. They differ for anything reported upstream.
-    origin,
-    repo,
-    severityLabels: settings.severityLabels,
-  })
-
-  const byId = new Map(entries.map((entry) => [entry.id, entry]))
-  const remember: Mirrors.Mirror[] = []
-  for (const id of plan.remove) {
-    const entry = byId.get(id)
-    if (entry?.issue) remember.push({ issue: entry.issue, path: Store.toPath(entry.id) })
-  }
-
-  const found = new Set(state.map((candidate) => candidate.number))
-  const forget = [
-    ...remembered.mirrors.filter((binding) => {
-      const link = Github.parseLink(binding.issue)
-      return link?.repo === repo && !found.has(link.issue)
-    }),
-    ...plan.write
-      .filter((entry): entry is typeof entry & { issue: string } => Boolean(entry.issue))
-      .map((entry) => ({ issue: entry.issue, path: Store.toPath(entry.id) })),
-  ]
-  const nextMirrors = Mirrors.update(remembered, { forget, remember })
-  const mirrorsChanged = Mirrors.serialize(nextMirrors) !== Mirrors.serialize(remembered)
-
-  if (Sync.empty(plan) && !mirrorsChanged) return { origin, plan }
-
-  const committed = await Repository.commit(source, {
-    branch,
-    deletes: mirrorsChanged && nextMirrors.mirrors.length === 0 ? [Mirrors.file] : [],
-    directories: plan.remove.map(Store.toDir),
-    message: 'chore: sync friction log',
-    repo: origin,
-    writes: [
-      ...[...plan.write, ...plan.clearLink].map((entry) => ({
-        contents: Entry.serialize(entry),
-        path: Store.toPath(entry.id),
-      })),
-      ...(mirrorsChanged && nextMirrors.mirrors.length > 0
-        ? [{ contents: Mirrors.serialize(nextMirrors), path: Mirrors.file }]
-        : []),
-    ],
-  })
-
-  return { origin, plan, ...(committed ? { committed } : {}) }
 }
 
 export declare namespace issues {
@@ -149,5 +152,7 @@ export declare namespace issues {
     issue: Github.Issue
     /** Repository the issue is in, as `owner/name`. */
     repo: string
+    /** Serializes conflicting writes by repository. */
+    serialize?: serialization.Serialize | undefined
   }
 }

--- a/app/src/handlers/issues.ts
+++ b/app/src/handlers/issues.ts
@@ -62,8 +62,8 @@ export async function issues(options: issues.Options): Promise<Outcome> {
     if (!bindings.some((binding) => binding.issue === current))
       return { ignored: 'untrusted frog marker', origin }
 
-    // Listed from the repository the issue is in, which is not where the files are. `Sync.state`
-    // confirms any linked issue the listing misses, so a label edit is not mistaken for a deletion.
+    // This runs inside the origin lease and refetches current issue state. The delivered snapshot only
+    // routes us here, so an older close cannot overwrite a newer reopen.
     const target = await config.read(client, { repo })
     const label = target.inbound.labels?.[0] ?? settings.labels[0] ?? 'friction'
 

--- a/app/src/handlers/issues.ts
+++ b/app/src/handlers/issues.ts
@@ -1,6 +1,7 @@
-import { Entry, Github, Store, Sync } from 'frog'
+import { Entry, Github, Mirrors, Store, Sync } from 'frog'
 import type { Octokit } from 'octokit'
 import * as config from '../internal/config.js'
+import * as mirrors from '../internal/mirrors.js'
 import * as Repository from '../Repository.js'
 
 /** What reconciling an issue event did. */
@@ -9,7 +10,7 @@ export type Outcome = {
   committed?: string | undefined
   /** Why nothing was done, when nothing was. */
   ignored?: string | undefined
-  /** Repository holding the mirroring files, from the marker. */
+  /** Repository holding the mirroring files, after repository-owned provenance is verified. */
   origin?: string | undefined
   /** The plan that was applied. */
   plan?: Sync.Plan | undefined
@@ -18,10 +19,10 @@ export type Outcome = {
 /**
  * Reconciles the files mirroring an issue after it changes.
  *
- * The marker on the issue names both the file and the repository holding it, so a closed issue finds its
- * mirror in one step and without scanning. That `origin` is what makes this work across repositories: an
- * issue closed on an upstream project deletes the entry in the consumer that reported it, so a
- * consumer's directory stays a list of friction that is still unresolved.
+ * The marker names a candidate repository, then a committed entry or recovery record must prove that
+ * repository already mirrors this exact issue. Paths always come from that repository-owned state.
+ * This lets an upstream issue delete or restore its consumer mirror without allowing editable issue
+ * text to authorize arbitrary writes.
  *
  * The decisions come from `Sync.plan`, unchanged, so the App and the CLI cannot disagree about what a
  * closed or reopened issue means.
@@ -31,8 +32,7 @@ export type Outcome = {
 export async function issues(options: issues.Options): Promise<Outcome> {
   const { client, installation, issue, repo } = options
 
-  // Only an issue frog itself filed can be reconciled: without a marker there is no file to find, and
-  // an issue somebody labelled by hand is not ours to act on.
+  // A marker is only a routing hint. Committed state below decides whether the issue is ours to act on.
   const marker = Github.parseMarker(issue.body)
   if (!marker?.path) return { ignored: 'no frog marker' }
 
@@ -45,6 +45,20 @@ export async function issues(options: issues.Options): Promise<Outcome> {
 
   const settings = await config.read(source, { repo: origin })
   const { entries } = await Repository.read(source, { ref: branch, repo: origin })
+  const remembered = await mirrors.read(source, { ref: branch, repo: origin })
+
+  const bindings: Mirrors.Mirror[] = remembered.mirrors.filter(
+    (binding) => Github.parseLink(binding.issue)?.repo === repo,
+  )
+  for (const entry of entries) {
+    if (!entry.issue) continue
+    const link = Github.parseLink(entry.issue)
+    if (link?.repo === repo) bindings.push({ issue: entry.issue, path: Store.toPath(entry.id) })
+  }
+
+  const current = Github.toLink({ issue: issue.number, repo })
+  if (!bindings.some((binding) => binding.issue === current))
+    return { ignored: 'untrusted frog marker', origin }
 
   // Listed from the repository the issue is in, which is not where the files are. `Sync.state` confirms
   // any linked issue the listing misses, so a label edit is not mistaken for a deletion.
@@ -55,29 +69,65 @@ export async function issues(options: issues.Options): Promise<Outcome> {
     entries,
     get: (number) => Github.get(client.rest, { issue: number, repo }),
     list: () => Github.list(client.rest, { label, repo }),
+    remembered: bindings
+      .map((binding) => Github.parseLink(binding.issue)?.issue)
+      .filter((number): number is number => number !== undefined),
     repo,
   })
 
+  const trusted = new Set(
+    bindings
+      .map((binding) => Github.parseLink(binding.issue)?.issue)
+      .filter((number): number is number => number !== undefined),
+  )
   const plan = Sync.plan({
     entries,
-    issues: state,
+    issues: state.filter((candidate) => trusted.has(candidate.number)),
     labels: settings.labels,
+    mirrors: bindings,
     // The files are in `origin`; the issues are in `repo`. They differ for anything reported upstream.
     origin,
     repo,
     severityLabels: settings.severityLabels,
   })
-  if (Sync.empty(plan)) return { origin, plan }
+
+  const byId = new Map(entries.map((entry) => [entry.id, entry]))
+  const remember: Mirrors.Mirror[] = []
+  for (const id of plan.remove) {
+    const entry = byId.get(id)
+    if (entry?.issue) remember.push({ issue: entry.issue, path: Store.toPath(entry.id) })
+  }
+
+  const found = new Set(state.map((candidate) => candidate.number))
+  const forget = [
+    ...remembered.mirrors.filter((binding) => {
+      const link = Github.parseLink(binding.issue)
+      return link?.repo === repo && !found.has(link.issue)
+    }),
+    ...plan.write
+      .filter((entry): entry is typeof entry & { issue: string } => Boolean(entry.issue))
+      .map((entry) => ({ issue: entry.issue, path: Store.toPath(entry.id) })),
+  ]
+  const nextMirrors = Mirrors.update(remembered, { forget, remember })
+  const mirrorsChanged = Mirrors.serialize(nextMirrors) !== Mirrors.serialize(remembered)
+
+  if (Sync.empty(plan) && !mirrorsChanged) return { origin, plan }
 
   const committed = await Repository.commit(source, {
     branch,
+    deletes: mirrorsChanged && nextMirrors.mirrors.length === 0 ? [Mirrors.file] : [],
     directories: plan.remove.map(Store.toDir),
     message: 'chore: sync friction log',
     repo: origin,
-    writes: [...plan.write, ...plan.clearLink].map((entry) => ({
-      contents: Entry.serialize(entry),
-      path: Store.toPath(entry.id),
-    })),
+    writes: [
+      ...[...plan.write, ...plan.clearLink].map((entry) => ({
+        contents: Entry.serialize(entry),
+        path: Store.toPath(entry.id),
+      })),
+      ...(mirrorsChanged && nextMirrors.mirrors.length > 0
+        ? [{ contents: Mirrors.serialize(nextMirrors), path: Mirrors.file }]
+        : []),
+    ],
   })
 
   return { origin, plan, ...(committed ? { committed } : {}) }

--- a/app/src/handlers/pullRequest.test.ts
+++ b/app/src/handlers/pullRequest.test.ts
@@ -2,6 +2,7 @@ import { Github } from 'frog'
 import { Octokit } from 'octokit'
 import { github } from '../../../test/github.js'
 import { marker } from '../internal/comment.js'
+import type { Serialize } from '../internal/serialize.js'
 import { pullRequest } from './pullRequest.js'
 
 const base = 'acme/app'
@@ -27,18 +28,44 @@ function entry(title: string, frontmatter: Record<string, string> = {}): string 
 }
 
 /** Runs the handler against one repository, with no other installation available. */
-async function run(url: string, options: { installed?: Record<string, Octokit> | undefined } = {}) {
+async function run(
+  url: string,
+  options: {
+    delivery?: string | undefined
+    installed?: Record<string, Octokit> | undefined
+    serialize?: Serialize | undefined
+  } = {},
+) {
   const octokit = client(url)
   return pullRequest({
     actor: '@contributor',
     base,
     baseRef: 'main',
     client: octokit,
+    ...(options.delivery ? { delivery: options.delivery } : {}),
     head: 'main',
     installation: async (repo) => options.installed?.[repo],
     pr: 42,
     registry: `${url}/registry`,
+    ...(options.serialize ? { serialize: options.serialize } : {}),
   })
+}
+
+function serial(): Serialize {
+  let tail = Promise.resolve()
+  return async (_repo, operation) => {
+    const previous = tail
+    let release = () => {}
+    tail = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    await previous
+    try {
+      return await operation()
+    } finally {
+      release()
+    }
+  }
 }
 
 test('behavior: files pending entries and comments once', async () => {
@@ -94,6 +121,23 @@ test('behavior: a second run opens no issue and adds no comment', async () => {
 
   expect(second.commented).toEqual([{ id: 'a', issue: `${base}#1` }])
   expect(instance.issues.get(base)).toHaveLength(1)
+  expect(instance.comments(base, 42)).toHaveLength(1)
+})
+
+test('behavior: concurrent deliveries with the same title open one issue', async () => {
+  const instance = await github(
+    {},
+    { files: { [base]: { [`${dir}/a/friction.md`]: entry('Filters ignored') } } },
+  )
+  const serialize = serial()
+
+  await Promise.all([
+    run(instance.url, { delivery: 'delivery-1', serialize }),
+    run(instance.url, { delivery: 'delivery-2', serialize }),
+  ])
+
+  expect(instance.issues.get(base)).toHaveLength(1)
+  expect(instance.comments(base, 1)).toHaveLength(1)
   expect(instance.comments(base, 42)).toHaveLength(1)
 })
 

--- a/app/src/handlers/pullRequest.test.ts
+++ b/app/src/handlers/pullRequest.test.ts
@@ -158,6 +158,32 @@ test('behavior: entries over the ceiling are deferred', async () => {
   expect(report.deferred).toEqual([{ id: 'b', reason: 'over the ceiling of 1 per run' }])
 })
 
+test('behavior: a refused entry does not consume the ceiling', async () => {
+  const instance = await github(
+    {},
+    {
+      files: {
+        [base]: {
+          [`${dir}/a/friction.md`]: entry('Cannot resolve', { target: 'missing' }),
+          [`${dir}/b/friction.md`]: entry('Can file'),
+          [`${dir}/config.json`]: JSON.stringify({ maxPerRun: 1 }),
+        },
+      },
+    },
+  )
+
+  const report = await run(instance.url)
+
+  expect(report.created).toEqual([{ id: 'b', issue: `${base}#1` }])
+  expect(report.deferred).toEqual([
+    {
+      id: 'a',
+      reason:
+        '`missing` is not installed, or declares no GitHub repository. Name the repository instead, as `owner/name`.',
+    },
+  ])
+})
+
 describe('cross-repo', () => {
   /**
    * A consumer with one upstream-targeted entry, and an upstream that has committed its consent.

--- a/app/src/handlers/pullRequest.ts
+++ b/app/src/handlers/pullRequest.ts
@@ -2,6 +2,7 @@ import type { Octokit } from 'octokit'
 import * as comment from '../internal/comment.js'
 import * as config from '../internal/config.js'
 import * as filing from '../internal/file.js'
+import * as serialization from '../internal/serialize.js'
 import * as Repository from '../Repository.js'
 
 /**
@@ -18,7 +19,17 @@ import * as Repository from '../Repository.js'
  * @returns What happened, already reported on the pull request.
  */
 export async function pullRequest(options: pullRequest.Options): Promise<comment.Report> {
-  const { base, baseRef, client, head, installation, pr, registry } = options
+  const {
+    base,
+    baseRef,
+    client,
+    delivery,
+    head,
+    installation,
+    pr,
+    registry,
+    serialize = serialization.direct,
+  } = options
 
   const settings = await config.read(client, { ref: baseRef, repo: base })
   const { entries, malformed } = await Repository.read(client, { ref: head, repo: base })
@@ -32,7 +43,9 @@ export async function pullRequest(options: pullRequest.Options): Promise<comment
     origin: base,
     pr: `${base}#${pr}`,
     ...(options.actor ? { actor: options.actor } : {}),
+    ...(delivery ? { delivery } : {}),
     ...(registry ? { registry } : {}),
+    serialize,
   })
 
   const report: comment.Report = {
@@ -44,7 +57,7 @@ export async function pullRequest(options: pullRequest.Options): Promise<comment
   }
 
   const body = comment.render(report)
-  if (body) await comment.upsert(client, { body, pr, repo: base })
+  if (body) await serialize(base, () => comment.upsert(client, { body, pr, repo: base }))
 
   return report
 }
@@ -64,6 +77,8 @@ export declare namespace pullRequest {
     baseRef: string
     /** Installation client for the base repository. */
     client: Octokit
+    /** GitHub delivery id used to make issue publishing replay-safe. */
+    delivery?: string | undefined
     /** Head commit sha, reachable from the base repository even for a fork. */
     head: string
     /**
@@ -77,5 +92,7 @@ export declare namespace pullRequest {
     pr: number
     /** Registry base URL. Overridden in tests. */
     registry?: string | undefined
+    /** Serializes conflicting writes by repository. */
+    serialize?: serialization.Serialize | undefined
   }
 }

--- a/app/src/handlers/pullRequest.ts
+++ b/app/src/handlers/pullRequest.ts
@@ -22,7 +22,7 @@ export async function pullRequest(options: pullRequest.Options): Promise<comment
 
   const settings = await config.read(client, { ref: baseRef, repo: base })
   const { entries, malformed } = await Repository.read(client, { ref: head, repo: base })
-  const { deferred, linked, pending } = filing.partition(entries, settings.maxPerRun)
+  const { linked, pending } = filing.partition(entries)
 
   const filed = await filing.file({
     client,
@@ -38,7 +38,7 @@ export async function pullRequest(options: pullRequest.Options): Promise<comment
   const report: comment.Report = {
     commented: filed.commented,
     created: filed.created,
-    deferred: [...deferred, ...filed.deferred],
+    deferred: filed.deferred,
     linked,
     malformed,
   }

--- a/app/src/handlers/push.test.ts
+++ b/app/src/handlers/push.test.ts
@@ -1,6 +1,8 @@
 import { Entry, Github } from 'frog'
 import { Octokit } from 'octokit'
 import { github } from '../../../test/github.js'
+import type { Serialize } from '../internal/serialize.js'
+import * as Repository from '../Repository.js'
 import { push } from './push.js'
 
 const repo = 'acme/app'
@@ -23,13 +25,22 @@ function entry(title: string, frontmatter: Record<string, string> = {}): string 
   return `---\n${fields}\n---\n\nThe filter was swallowed.\n`
 }
 
-async function run(url: string, options: { installed?: Record<string, Octokit> } = {}) {
+async function run(
+  url: string,
+  options: {
+    delivery?: string | undefined
+    installed?: Record<string, Octokit> | undefined
+    serialize?: Serialize | undefined
+  } = {},
+) {
   return push({
     branch: 'main',
     client: client(url),
+    ...(options.delivery ? { delivery: options.delivery } : {}),
     installation: async (name) => options.installed?.[name],
     registry: `${url}/registry`,
     repo,
+    ...(options.serialize ? { serialize: options.serialize } : {}),
   })
 }
 
@@ -147,4 +158,34 @@ test('behavior: an upstream filing writes the link into this repository', async 
   expect(outcome.created).toEqual([{ id: 'a', issue: `${upstream}#1` }])
   const written = instance.files(repo)[`${dir}/a/friction.md`] ?? ''
   expect(Entry.parse(written, { id: 'a' }).issue).toBe(`${upstream}#1`)
+})
+
+test('behavior: a stale push snapshot does not overwrite a concurrent entry edit', async () => {
+  const instance = await github(
+    {},
+    { files: { [repo]: { [`${dir}/a/friction.md`]: entry('Filters ignored') } } },
+  )
+  const octokit = client(instance.url)
+  let mutations = 0
+  const serialize: Serialize = async (_repo, operation) => {
+    mutations += 1
+    if (mutations === 2)
+      await Repository.commit(octokit, {
+        branch: 'main',
+        message: 'chore: edit friction',
+        repo,
+        writes: [{ contents: entry('Edited concurrently'), path: `${dir}/a/friction.md` }],
+      })
+    return operation()
+  }
+
+  const outcome = await run(instance.url, { serialize })
+
+  expect(outcome.created).toEqual([{ id: 'a', issue: `${repo}#1` }])
+  expect(outcome.committed).toBeUndefined()
+  expect(instance.messages(repo)).toEqual(['initial', 'chore: edit friction'])
+  const written = instance.files(repo)[`${dir}/a/friction.md`] ?? ''
+  const parsed = Entry.parse(written, { id: 'a' })
+  expect(parsed.title).toBe('Edited concurrently')
+  expect(parsed).not.toHaveProperty('issue')
 })

--- a/app/src/handlers/push.ts
+++ b/app/src/handlers/push.ts
@@ -3,6 +3,7 @@ import type { Octokit } from 'octokit'
 import type * as comment from '../internal/comment.js'
 import * as config from '../internal/config.js'
 import * as filing from '../internal/file.js'
+import * as serialization from '../internal/serialize.js'
 import * as Repository from '../Repository.js'
 
 /** What a push run did. */
@@ -34,7 +35,15 @@ export type Outcome = {
  * @returns What happened.
  */
 export async function push(options: push.Options): Promise<Outcome> {
-  const { branch, client, installation, registry, repo } = options
+  const {
+    branch,
+    client,
+    delivery,
+    installation,
+    registry,
+    repo,
+    serialize = serialization.direct,
+  } = options
 
   const settings = await config.read(client, { ref: branch, repo })
   const { entries } = await Repository.read(client, { ref: branch, repo })
@@ -49,24 +58,32 @@ export async function push(options: push.Options): Promise<Outcome> {
     installation,
     origin: repo,
     ...(options.actor ? { actor: options.actor } : {}),
+    ...(delivery ? { delivery } : {}),
     ...(registry ? { registry } : {}),
+    serialize,
   })
 
-  const writes: { contents: string; path: string }[] = []
-  for (const entry of pending) {
-    const issue = filed.links.get(entry.id)
-    if (!issue) continue
-    writes.push({
-      contents: Entry.serialize({ ...entry, issue }),
-      path: Store.toPath(entry.id),
-    })
-  }
+  const initial = new Map(pending.map((entry) => [entry.id, Entry.serialize(entry)]))
+  const committed = await serialize(repo, async () => {
+    // Filing can take several requests. Re-read under the repository lease so a concurrent sync or
+    // push cannot be overwritten with the stale snapshot from the start of this delivery.
+    const current = await Repository.read(client, { ref: branch, repo })
+    const writes: { contents: string; path: string }[] = []
+    for (const entry of current.entries) {
+      const issue = filed.links.get(entry.id)
+      if (!issue || entry.issue || Entry.serialize(entry) !== initial.get(entry.id)) continue
+      writes.push({
+        contents: Entry.serialize({ ...entry, issue }),
+        path: Store.toPath(entry.id),
+      })
+    }
 
-  const committed = await Repository.commit(client, {
-    branch,
-    message: 'chore: link friction log to issues',
-    repo,
-    writes,
+    return Repository.commit(client, {
+      branch,
+      message: 'chore: link friction log to issues',
+      repo,
+      writes,
+    })
   })
 
   return {
@@ -86,11 +103,15 @@ export declare namespace push {
     branch: string
     /** Installation client for the repository. */
     client: Octokit
+    /** GitHub delivery id used to make issue publishing replay-safe. */
+    delivery?: string | undefined
     /** Resolves an installation client for another repository. */
     installation: (repo: string) => Promise<Octokit | undefined>
     /** Registry base URL. Overridden in tests. */
     registry?: string | undefined
     /** Repository pushed to, as `owner/name`. */
     repo: string
+    /** Serializes conflicting writes by repository. */
+    serialize?: serialization.Serialize | undefined
   }
 }

--- a/app/src/handlers/push.ts
+++ b/app/src/handlers/push.ts
@@ -38,9 +38,9 @@ export async function push(options: push.Options): Promise<Outcome> {
 
   const settings = await config.read(client, { ref: branch, repo })
   const { entries } = await Repository.read(client, { ref: branch, repo })
-  const { deferred, pending } = filing.partition(entries, settings.maxPerRun)
+  const { pending } = filing.partition(entries)
 
-  if (pending.length === 0) return { commented: [], created: [], deferred }
+  if (pending.length === 0) return { commented: [], created: [], deferred: [] }
 
   const filed = await filing.file({
     client,
@@ -72,7 +72,7 @@ export async function push(options: push.Options): Promise<Outcome> {
   return {
     commented: filed.commented,
     created: filed.created,
-    deferred: [...deferred, ...filed.deferred],
+    deferred: filed.deferred,
     ...(committed ? { committed } : {}),
   }
 }

--- a/app/src/internal/cache.ts
+++ b/app/src/internal/cache.ts
@@ -4,7 +4,7 @@ import type { Cache } from 'frog'
  * A cache in memory.
  *
  * There is no filesystem here. An isolate stays warm across deliveries, so this still spares repeated
- * lookups of the same host, and a cold start simply fetches again.
+ * lookups of the same repository, and a cold start simply fetches again.
  */
 export function memory(store = new Map<string, string>()): Cache.Cache {
   return {

--- a/app/src/internal/config.test.ts
+++ b/app/src/internal/config.test.ts
@@ -1,0 +1,19 @@
+import { Octokit } from 'octokit'
+import { github } from '../../../test/github.js'
+import { read } from './config.js'
+
+const repo = 'acme/app'
+
+function client(url: string): Octokit {
+  return new Octokit({
+    auth: 'token',
+    baseUrl: url,
+    retry: { enabled: false },
+    throttle: { enabled: false },
+  })
+}
+
+test('error: propagates a transient config failure', async () => {
+  const instance = await github({}, { errors: { [repo]: 503 } })
+  await expect(read(client(instance.url), { repo })).rejects.toMatchObject({ status: 503 })
+})

--- a/app/src/internal/config.ts
+++ b/app/src/internal/config.ts
@@ -18,7 +18,7 @@ export async function read(client: Octokit, options: read.Options): Promise<Conf
     path: Config.file,
     repo,
     ...(ref ? { ref } : {}),
-  }).catch(() => undefined)
+  })
 
   try {
     return contents ? Config.from(JSON.parse(contents)) : Config.from({})

--- a/app/src/internal/coordinatorState.test.ts
+++ b/app/src/internal/coordinatorState.test.ts
@@ -1,0 +1,63 @@
+import * as coordinator from './coordinatorState.js'
+
+describe('delivery state', () => {
+  test('behavior: a live claim excludes another attempt and expires', () => {
+    const first = coordinator.claim(undefined, { now: 100, owner: 'first' })
+
+    expect(first.result).toBe('claimed')
+    expect(coordinator.claim(first.state, { now: 101, owner: 'second' }).result).toBe('processing')
+
+    const reclaimed = coordinator.claim(first.state, {
+      now: 100 + coordinator.lease,
+      owner: 'second',
+    })
+    expect(reclaimed).toMatchObject({
+      result: 'claimed',
+      state: { kind: 'delivery', owner: 'second', status: 'processing' },
+    })
+  })
+
+  test('behavior: only the current owner can complete or abandon a claim', () => {
+    const claimed = coordinator.claim(undefined, { now: 100, owner: 'first' }).state
+
+    expect(coordinator.complete(claimed, 'second')).toEqual({
+      result: false,
+      state: claimed,
+    })
+    expect(coordinator.abandon(claimed, 'second')).toBe(claimed)
+
+    const completed = coordinator.complete(claimed, 'first')
+    expect(completed).toEqual({
+      result: true,
+      state: { kind: 'delivery', status: 'completed' },
+    })
+    expect(coordinator.claim(completed.state, { now: 1_000, owner: 'second' }).result).toBe(
+      'completed',
+    )
+  })
+})
+
+describe('repository state', () => {
+  test('behavior: a live lease excludes another mutation and expires', () => {
+    const first = coordinator.acquire(undefined, { now: 100, owner: 'first' })
+
+    expect(first.result).toBe(true)
+    expect(coordinator.acquire(first.state, { now: 101, owner: 'second' }).result).toBe(false)
+    expect(
+      coordinator.acquire(first.state, {
+        now: 100 + coordinator.lease,
+        owner: 'second',
+      }),
+    ).toMatchObject({
+      result: true,
+      state: { kind: 'repository', owner: 'second' },
+    })
+  })
+
+  test('behavior: only the current owner can release a lease', () => {
+    const acquired = coordinator.acquire(undefined, { now: 100, owner: 'first' }).state
+
+    expect(coordinator.release(acquired, 'second')).toBe(acquired)
+    expect(coordinator.release(acquired, 'first')).toBeUndefined()
+  })
+})

--- a/app/src/internal/coordinatorState.ts
+++ b/app/src/internal/coordinatorState.ts
@@ -1,0 +1,88 @@
+/** How long an active delivery or repository mutation owns its lease. */
+export const lease = 15 * 60 * 1_000
+
+/** Delivery ids outlive GitHub's three-day manual-redelivery window. */
+export const retention = 7 * 24 * 60 * 60 * 1_000
+
+/** State held by one deterministically named coordinator object. */
+export type State =
+  | {
+      expiresAt: number
+      kind: 'delivery'
+      owner: string
+      status: 'processing'
+    }
+  | {
+      kind: 'delivery'
+      status: 'completed'
+    }
+  | {
+      expiresAt: number
+      kind: 'repository'
+      owner: string
+    }
+
+/** A state transition and the result returned to its caller. */
+export type Transition<Result> = {
+  result: Result
+  state: State | undefined
+}
+
+/** Claims a delivery unless it is already complete or another live attempt owns it. */
+export function claim(
+  current: State | undefined,
+  options: { now: number; owner: string },
+): Transition<'claimed' | 'completed' | 'processing'> {
+  if (current?.kind === 'repository') throw new Error('Repository coordinator used for a delivery.')
+  if (current?.status === 'completed') return { result: 'completed', state: current }
+  if (current && current.expiresAt > options.now) return { result: 'processing', state: current }
+
+  return {
+    result: 'claimed',
+    state: {
+      expiresAt: options.now + lease,
+      kind: 'delivery',
+      owner: options.owner,
+      status: 'processing',
+    },
+  }
+}
+
+/** Marks a claimed delivery complete, if the caller still owns it. */
+export function complete(current: State | undefined, owner: string): Transition<boolean> {
+  if (current?.kind !== 'delivery') return { result: false, state: current }
+  if (current.status === 'completed') return { result: true, state: current }
+  if (current.owner !== owner) return { result: false, state: current }
+  return { result: true, state: { kind: 'delivery', status: 'completed' } }
+}
+
+/** Releases a failed delivery claim without disturbing a newer attempt. */
+export function abandon(current: State | undefined, owner: string): State | undefined {
+  if (current?.kind !== 'delivery' || current.status !== 'processing') return current
+  return current.owner === owner ? undefined : current
+}
+
+/** Acquires an expired or absent repository mutation lease. */
+export function acquire(
+  current: State | undefined,
+  options: { now: number; owner: string },
+): Transition<boolean> {
+  if (current?.kind === 'delivery')
+    throw new Error('Delivery coordinator used as a repository lock.')
+  if (current && current.expiresAt > options.now) return { result: false, state: current }
+
+  return {
+    result: true,
+    state: {
+      expiresAt: options.now + lease,
+      kind: 'repository',
+      owner: options.owner,
+    },
+  }
+}
+
+/** Releases a repository mutation lease without disturbing a newer owner. */
+export function release(current: State | undefined, owner: string): State | undefined {
+  if (current?.kind !== 'repository') return current
+  return current.owner === owner ? undefined : current
+}

--- a/app/src/internal/dispatch.test.ts
+++ b/app/src/internal/dispatch.test.ts
@@ -1,0 +1,105 @@
+import type * as Delivery from '../Delivery.js'
+import * as dispatch from './dispatch.js'
+import type * as serialization from './serialize.js'
+
+const delivery: Delivery.Delivery = {
+  id: 'delivery-1',
+  name: 'issues',
+  payload: {
+    installation: { id: 42 },
+    issue: { number: 9 },
+    repository: { full_name: 'acme/app' },
+  },
+  v: 1,
+}
+
+function namespace(
+  claim: 'claimed' | 'completed' | 'processing',
+  order: string[] = [],
+): serialization.Namespace {
+  const coordinator: serialization.Coordinator = {
+    abandon: vi.fn(async () => {
+      order.push('abandon')
+    }),
+    acquire: vi.fn(async () => true),
+    claim: vi.fn(async () => {
+      order.push('claim')
+      return claim
+    }),
+    complete: vi.fn(async () => {
+      order.push('complete')
+      return true
+    }),
+    release: vi.fn(async () => {}),
+  }
+  return { getByName: vi.fn(() => coordinator) }
+}
+
+test.each(['completed', 'processing'] as const)(
+  'behavior: a %s claim does not hydrate or dispatch',
+  async (claim) => {
+    const expand = vi.fn(async () => {
+      throw new Error('unreachable')
+    })
+    const receive = vi.fn(async () => {})
+
+    await expect(dispatch.queued(namespace(claim), delivery, { expand, receive })).resolves.toEqual(
+      {
+        status: claim,
+      },
+    )
+    expect(expand).not.toHaveBeenCalled()
+    expect(receive).not.toHaveBeenCalled()
+  },
+)
+
+test('behavior: an acquired claim hydrates before dispatch and preserves its delivery id', async () => {
+  const order: string[] = []
+  const event: Delivery.Event = {
+    id: delivery.id,
+    name: 'issues',
+    payload: {
+      action: 'edited',
+      installation: { id: 42 },
+      issue: { number: 9, state: 'open', title: 'Current title' },
+      repository: { full_name: 'acme/app' },
+    },
+  }
+  const expand = vi.fn(async () => {
+    order.push('expand')
+    return event
+  })
+  const receive = vi.fn(async (received: Delivery.Event) => {
+    order.push('receive')
+    expect(received.id).toBe('delivery-1')
+  })
+
+  await expect(
+    dispatch.queued(namespace('claimed', order), delivery, { expand, receive }),
+  ).resolves.toEqual({ result: undefined, status: 'processed' })
+  expect(order).toEqual(['claim', 'expand', 'receive', 'complete'])
+})
+
+test('error: changing the delivery id prevents dispatch and abandons the claim', async () => {
+  const order: string[] = []
+  const receive = vi.fn(async () => {})
+
+  await expect(
+    dispatch.queued(namespace('claimed', order), delivery, {
+      expand: async () =>
+        ({
+          id: 'different',
+          name: 'issues',
+          payload: {
+            action: 'edited',
+            installation: { id: 42 },
+            issue: { number: 9, state: 'open', title: 'Current title' },
+            repository: { full_name: 'acme/app' },
+          },
+        }) satisfies Delivery.Event,
+      receive,
+    }),
+  ).rejects.toThrow('Expanded delivery id changed')
+  expect(receive).not.toHaveBeenCalled()
+  expect(order).toEqual(['claim', 'abandon'])
+})

--- a/app/src/internal/dispatch.ts
+++ b/app/src/internal/dispatch.ts
@@ -1,0 +1,33 @@
+import * as Delivery from '../Delivery.js'
+import * as serialization from './serialize.js'
+
+/**
+ * Claims a queued delivery before expanding or dispatching it.
+ *
+ * Expansion may perform GitHub reads, so completed and concurrently processing duplicates must be
+ * decided first. The expanded event must retain the original GitHub delivery id.
+ */
+export function queued(
+  namespace: serialization.Namespace,
+  delivery: Delivery.Delivery,
+  options: queued.Options,
+) {
+  return serialization.delivery(namespace, {
+    id: delivery.id,
+    operation: async () => {
+      const event = await options.expand(delivery)
+      if (event.id !== delivery.id)
+        throw new Error(`Expanded delivery id changed from \`${delivery.id}\` to \`${event.id}\`.`)
+      await options.receive(event)
+    },
+  })
+}
+
+export declare namespace queued {
+  type Options = {
+    /** Expands the compact projection after its claim is acquired. */
+    expand: (delivery: Delivery.Delivery) => Promise<Delivery.Event>
+    /** Dispatches the expanded event through Octokit's registered handlers. */
+    receive: (event: Delivery.Event) => Promise<void>
+  }
+}

--- a/app/src/internal/file.ts
+++ b/app/src/internal/file.ts
@@ -25,9 +25,17 @@ export type Filing = {
 export async function file(options: file.Options): Promise<Filing> {
   const { actor, client, config, entries, installation, origin, pr, registry } = options
 
+  const clients = new Map<string, Octokit | undefined>([[origin, client]])
+  const installed = async (repo: string): Promise<Octokit | undefined> => {
+    if (clients.has(repo)) return clients.get(repo)
+    const target = await installation(repo)
+    clients.set(repo, target)
+    return target
+  }
+
   const stack = resolvers.resolvers({
     allowedRepos: config.outbound.allowedRepos,
-    client,
+    installation: installed,
     self: origin,
     ...(registry ? { registry } : {}),
   })
@@ -41,7 +49,14 @@ export async function file(options: file.Options): Promise<Filing> {
   }[] = []
 
   for (const entry of entries) {
-    const resolution = await Target.resolve(entry.target, stack)
+    const resolution = await Target.resolve(entry.target, stack).catch((error: unknown) => {
+      if (error instanceof resolvers.InstallationMissingError) {
+        deferred.push({ id: entry.id, reason: error.message })
+        return undefined
+      }
+      throw error
+    })
+    if (!resolution) continue
     if (!resolution.ok) {
       deferred.push({ id: entry.id, reason: resolution.message })
       continue
@@ -66,26 +81,21 @@ export async function file(options: file.Options): Promise<Filing> {
   const created: comment.Link[] = []
   const links = new Map<string, string>()
 
-  const clients = new Map<string, Octokit>([[origin, client]])
   for (const destination of new Set(candidates.map((candidate) => candidate.destination))) {
-    if (clients.has(destination)) continue
-
-    const target = await installation(destination)
-    if (target) clients.set(destination, target)
-    else {
-      for (const candidate of candidates.filter((entry) => entry.destination === destination))
-        deferred.push({
-          id: candidate.entry.id,
-          reason: `frog is not installed on \`${destination}\`.`,
-        })
-    }
+    const target = await installed(destination)
+    if (target) continue
+    for (const candidate of candidates.filter((entry) => entry.destination === destination))
+      deferred.push({
+        id: candidate.entry.id,
+        reason: `frog is not installed on \`${destination}\`.`,
+      })
   }
 
   /** Grouped after every gate, so deferred entries do not consume the per-run ceiling. */
   const groups = new Map<string, { entries: Entry.Entry[]; labels?: readonly string[] }>()
   let accepted = 0
   for (const candidate of candidates) {
-    if (!clients.has(candidate.destination)) continue
+    if (!clients.get(candidate.destination)) continue
     if (accepted >= config.maxPerRun) {
       deferred.push({
         id: candidate.entry.id,

--- a/app/src/internal/file.ts
+++ b/app/src/internal/file.ts
@@ -3,6 +3,7 @@ import { Github, Store, Target } from 'frog'
 import type { Octokit } from 'octokit'
 import type * as comment from './comment.js'
 import * as resolvers from './resolvers.js'
+import * as serialization from './serialize.js'
 
 /** What filing a set of entries did. */
 export type Filing = {
@@ -23,7 +24,18 @@ export type Filing = {
  * comments, the other writes the links back. The gates themselves must not differ between them.
  */
 export async function file(options: file.Options): Promise<Filing> {
-  const { actor, client, config, entries, installation, origin, pr, registry } = options
+  const {
+    actor,
+    client,
+    config,
+    delivery,
+    entries,
+    installation,
+    origin,
+    pr,
+    registry,
+    serialize = serialization.direct,
+  } = options
 
   const clients = new Map<string, Octokit | undefined>([[origin, client]])
   const installed = async (repo: string): Promise<Octokit | undefined> => {
@@ -117,38 +129,41 @@ export async function file(options: file.Options): Promise<Filing> {
     const target = clients.get(destination)
     if (!target) continue
 
-    const applied = group.labels?.length ? group.labels : config.labels
-    const matcher = await Github.matcher(target.rest, {
-      label: applied[0] ?? 'friction',
-      repo: destination,
-    })
-    /** Filed during this run, so two entries with one title collapse onto one issue. */
-    const seen = new Map<string, Github.Issue>()
-
-    for (const entry of group.entries) {
-      const hash = Github.hash(entry.title)
-      const existing = seen.get(hash) ?? (await matcher.match(entry.title))
-
-      const result = await Github.publish(target.rest, {
-        entry: entry,
-        labels: Github.toLabels({
-          entry: entry,
-          labels: applied,
-          severityLabels: config.severityLabels,
-        }),
-        // `origin` is where the file lives, which is not the destination when reporting upstream.
-        marker: { hash, origin, path: Store.toPath(entry.id) },
-        provenance: { ...(actor ? { author: actor } : {}), ...(pr ? { pr } : {}) },
+    await serialize(destination, async () => {
+      const applied = group.labels?.length ? group.labels : config.labels
+      const matcher = await Github.matcher(target.rest, {
+        label: applied[0] ?? 'friction',
         repo: destination,
-        ...(existing ? { existing } : {}),
       })
+      /** Filed during this run, so two entries with one title collapse onto one issue. */
+      const seen = new Map<string, Github.Issue>()
 
-      const issue = Github.toLink({ issue: result.issue, repo: destination })
-      links.set(entry.id, issue)
-      ;(result.status === 'commented' ? commented : created).push({ id: entry.id, issue })
+      for (const entry of group.entries) {
+        const hash = Github.hash(entry.title)
+        const existing = seen.get(hash) ?? (await matcher.match(entry.title))
 
-      if (!existing) seen.set(hash, { number: result.issue, state: 'open', title: entry.title })
-    }
+        const result = await Github.publish(target.rest, {
+          entry,
+          labels: Github.toLabels({
+            entry,
+            labels: applied,
+            severityLabels: config.severityLabels,
+          }),
+          // `origin` is where the file lives, which is not the destination when reporting upstream.
+          marker: { hash, origin, path: Store.toPath(entry.id) },
+          provenance: { ...(actor ? { author: actor } : {}), ...(pr ? { pr } : {}) },
+          repo: destination,
+          ...(delivery ? { occurrence: `${delivery}:${entry.id}` } : {}),
+          ...(existing ? { existing } : {}),
+        })
+
+        const issue = Github.toLink({ issue: result.issue, repo: destination })
+        links.set(entry.id, issue)
+        ;(result.status === 'commented' ? commented : created).push({ id: entry.id, issue })
+
+        if (!existing) seen.set(hash, { number: result.issue, state: 'open', title: entry.title })
+      }
+    })
   }
 
   return { commented, created, deferred, links }
@@ -163,6 +178,8 @@ export declare namespace file {
     client: Octokit
     /** Normalized config, read from the default branch. */
     config: Config.Config
+    /** GitHub delivery id used to make each external publish occurrence replay-safe. */
+    delivery?: string | undefined
     /** Entries to resolve and file. Already free of linked ones. */
     entries: readonly Entry.Entry[]
     /** Resolves an installation client for another repository. */
@@ -173,6 +190,8 @@ export declare namespace file {
     pr?: string | undefined
     /** Registry base URL. Overridden in tests. */
     registry?: string | undefined
+    /** Serializes conflicting writes by destination repository. */
+    serialize?: serialization.Serialize | undefined
   }
 }
 

--- a/app/src/internal/file.ts
+++ b/app/src/internal/file.ts
@@ -34,8 +34,11 @@ export async function file(options: file.Options): Promise<Filing> {
 
   const deferred: { id: string; reason: string }[] = []
 
-  /** Grouped by destination, so one destination costs one dedupe preparation however many entries. */
-  const groups = new Map<string, { entries: Entry.Entry[]; labels?: readonly string[] }>()
+  const candidates: {
+    destination: string
+    entry: Entry.Entry
+    labels?: readonly string[] | undefined
+  }[] = []
 
   for (const entry of entries) {
     const resolution = await Target.resolve(entry.target, stack)
@@ -56,27 +59,53 @@ export async function file(options: file.Options): Promise<Filing> {
       continue
     }
 
-    const group = groups.get(destination) ?? { entries: [], ...(labels ? { labels } : {}) }
-    group.entries.push(entry)
-    groups.set(destination, group)
+    candidates.push({ destination, entry, ...(labels ? { labels } : {}) })
   }
 
   const commented: comment.Link[] = []
   const created: comment.Link[] = []
   const links = new Map<string, string>()
 
-  for (const [destination, group] of groups) {
-    // Cross-repo needs its own installation token. Without an installation there is no token, so the
-    // App cannot file there at all: consent enforced by GitHub rather than by us.
-    const target = destination === origin ? client : await installation(destination)
-    if (!target) {
-      for (const entry of group.entries)
+  const clients = new Map<string, Octokit>([[origin, client]])
+  for (const destination of new Set(candidates.map((candidate) => candidate.destination))) {
+    if (clients.has(destination)) continue
+
+    const target = await installation(destination)
+    if (target) clients.set(destination, target)
+    else {
+      for (const candidate of candidates.filter((entry) => entry.destination === destination))
         deferred.push({
-          id: entry.id,
+          id: candidate.entry.id,
           reason: `frog is not installed on \`${destination}\`.`,
         })
+    }
+  }
+
+  /** Grouped after every gate, so deferred entries do not consume the per-run ceiling. */
+  const groups = new Map<string, { entries: Entry.Entry[]; labels?: readonly string[] }>()
+  let accepted = 0
+  for (const candidate of candidates) {
+    if (!clients.has(candidate.destination)) continue
+    if (accepted >= config.maxPerRun) {
+      deferred.push({
+        id: candidate.entry.id,
+        reason: `over the ceiling of ${config.maxPerRun} per run`,
+      })
       continue
     }
+    accepted += 1
+
+    const group = groups.get(candidate.destination) ?? {
+      entries: [],
+      ...(candidate.labels ? { labels: candidate.labels } : {}),
+    }
+    group.entries.push(candidate.entry)
+    groups.set(candidate.destination, group)
+  }
+
+  for (const [destination, group] of groups) {
+    const target = clients.get(destination)
+    if (!target) continue
 
     const applied = group.labels?.length ? group.labels : config.labels
     const matcher = await Github.matcher(target.rest, {
@@ -124,7 +153,7 @@ export declare namespace file {
     client: Octokit
     /** Normalized config, read from the default branch. */
     config: Config.Config
-    /** Entries to file. Already capped and already free of linked ones. */
+    /** Entries to resolve and file. Already free of linked ones. */
     entries: readonly Entry.Entry[]
     /** Resolves an installation client for another repository. */
     installation: (repo: string) => Promise<Octokit | undefined>
@@ -137,12 +166,8 @@ export declare namespace file {
   }
 }
 
-/** Splits entries into those already linked and those still to file, applying the per-run ceiling. */
-export function partition(
-  entries: readonly Entry.Entry[],
-  maxPerRun: number,
-): {
-  deferred: { id: string; reason: string }[]
+/** Splits entries into those already linked and those still to file. */
+export function partition(entries: readonly Entry.Entry[]): {
   linked: comment.Link[]
   pending: readonly Entry.Entry[]
 } {
@@ -154,10 +179,7 @@ export function partition(
   }
 
   return {
-    deferred: unlinked
-      .slice(maxPerRun)
-      .map((entry) => ({ id: entry.id, reason: `over the ceiling of ${maxPerRun} per run` })),
     linked,
-    pending: unlinked.slice(0, maxPerRun),
+    pending: unlinked,
   }
 }

--- a/app/src/internal/mirrors.ts
+++ b/app/src/internal/mirrors.ts
@@ -1,0 +1,28 @@
+import { Github, Mirrors } from 'frog'
+import type { Octokit } from 'octokit'
+
+/** Reads a repository's committed mirror recovery journal. */
+export async function read(client: Octokit, options: read.Options): Promise<Mirrors.State> {
+  const contents = await Github.fetchFile(client.rest, {
+    path: Mirrors.file,
+    repo: options.repo,
+    ...(options.ref ? { ref: options.ref } : {}),
+  })
+  if (contents === undefined) return Mirrors.empty()
+
+  try {
+    return Mirrors.from(JSON.parse(contents))
+  } catch (error) {
+    if (error instanceof Mirrors.InvalidError) throw error
+    throw new Mirrors.MalformedError(error as Error)
+  }
+}
+
+export declare namespace read {
+  type Options = {
+    /** Branch to read from. Defaults to the repository's default branch. */
+    ref?: string | undefined
+    /** Repository holding the journal. */
+    repo: string
+  }
+}

--- a/app/src/internal/queue.test.ts
+++ b/app/src/internal/queue.test.ts
@@ -1,0 +1,110 @@
+import * as queue from './queue.js'
+
+function body(id = 'delivery-1') {
+  return {
+    id,
+    name: 'push',
+    payload: {
+      installation: { id: 42 },
+      ref: 'refs/heads/main',
+      repository: { default_branch: 'main', full_name: 'acme/app' },
+      sender: null,
+    },
+    v: 1,
+  }
+}
+
+function message(value: unknown = body(), attempts = 1): queue.consume.Message {
+  return {
+    ack: vi.fn(),
+    attempts,
+    body: value,
+    retry: vi.fn(),
+  }
+}
+
+test.each(['processed', 'completed'] as const)(
+  'behavior: %s deliveries are acknowledged',
+  async (status) => {
+    const delivery = message()
+    const process = vi.fn(async () => ({ status }))
+
+    await queue.consume([delivery], { process })
+
+    expect(delivery.ack).toHaveBeenCalledOnce()
+    expect(delivery.retry).not.toHaveBeenCalled()
+  },
+)
+
+test('behavior: an active delivery claim is retried instead of acknowledged', async () => {
+  const delivery = message(body(), 3)
+
+  await queue.consume([delivery], {
+    process: vi.fn(async () => ({ status: 'processing' as const })),
+  })
+
+  expect(delivery.ack).not.toHaveBeenCalled()
+  expect(delivery.retry).toHaveBeenCalledWith({ delaySeconds: 120 })
+})
+
+test('behavior: a failed attempt can later succeed without poisoning its delivery', async () => {
+  const delivery = message()
+  const failure = new Error('GitHub unavailable')
+  const process = vi
+    .fn<queue.consume.Options['process']>()
+    .mockRejectedValueOnce(failure)
+    .mockResolvedValueOnce({ status: 'processed' })
+
+  await queue.consume([delivery], { process })
+  expect(delivery.retry).toHaveBeenCalledOnce()
+  expect(delivery.ack).not.toHaveBeenCalled()
+
+  await queue.consume([delivery], { process })
+  expect(delivery.ack).toHaveBeenCalledOnce()
+})
+
+test('behavior: one failed message does not retry the successful remainder of its batch', async () => {
+  const failed = message(body('delivery-1'))
+  const passed = message(body('delivery-2'))
+  const process = vi.fn(async (delivery: { id: string }) => {
+    if (delivery.id === 'delivery-1') throw new Error('failed')
+    return { status: 'processed' as const }
+  })
+
+  await queue.consume([failed, passed], { process })
+
+  expect(failed.retry).toHaveBeenCalledOnce()
+  expect(failed.ack).not.toHaveBeenCalled()
+  expect(passed.ack).toHaveBeenCalledOnce()
+  expect(passed.retry).not.toHaveBeenCalled()
+})
+
+test('error: unknown queue versions retry toward the dead-letter queue', async () => {
+  const delivery = message({ ...body(), v: 2 }, 5)
+  const error = vi.fn()
+  const process = vi.fn(async () => ({ status: 'processed' as const }))
+
+  await queue.consume([delivery], { error, process })
+
+  expect(process).not.toHaveBeenCalled()
+  expect(delivery.ack).not.toHaveBeenCalled()
+  expect(delivery.retry).toHaveBeenCalledWith({ delaySeconds: 480 })
+  expect(error).toHaveBeenCalledWith(
+    expect.any(Error),
+    expect.objectContaining({ attempt: 5, delivery: 'delivery-1', event: 'push' }),
+  )
+})
+
+test('behavior: retry backoff is capped below Queue retention', () => {
+  expect(queue.retryDelay(1)).toBe(30)
+  expect(queue.retryDelay(7)).toBe(1_920)
+  expect(queue.retryDelay(8)).toBe(3_600)
+  expect(queue.retryDelay(100)).toBe(3_600)
+
+  const budget = Array.from({ length: 20 }, (_, index) => queue.retryDelay(index + 1)).reduce(
+    (total, delay) => total + delay,
+    0,
+  )
+  expect(budget).toBeGreaterThan(12 * 60 * 60)
+  expect(budget).toBeLessThan(24 * 60 * 60)
+})

--- a/app/src/internal/queue.ts
+++ b/app/src/internal/queue.ts
@@ -1,0 +1,68 @@
+import * as Delivery from '../Delivery.js'
+
+const maximumDelay = 60 * 60
+
+/** Retry delay for one failed Queue attempt, with a one-hour ceiling. */
+export function retryDelay(attempts: number): number {
+  return Math.min(30 * 2 ** Math.max(0, attempts - 1), maximumDelay)
+}
+
+/** Processes a Queue batch one message at a time with explicit acknowledgement and retry. */
+export async function consume(
+  messages: readonly consume.Message[],
+  options: consume.Options,
+): Promise<void> {
+  for (const message of messages) {
+    try {
+      const delivery = Delivery.fromQueue(message.body)
+      const result = await options.process(delivery)
+      if (result.status === 'processing') {
+        // The active owner can still fail. Preserve this duplicate until that lease completes or
+        // expires instead of acknowledging the only attempt capable of recovery.
+        message.retry({ delaySeconds: retryDelay(message.attempts) })
+      } else {
+        message.ack()
+      }
+    } catch (error) {
+      const value =
+        message.body && typeof message.body === 'object'
+          ? (message.body as { id?: unknown; name?: unknown })
+          : undefined
+      options.error?.(error, {
+        attempt: message.attempts,
+        ...(typeof value?.id === 'string' ? { delivery: value.id } : {}),
+        ...(typeof value?.name === 'string' ? { event: value.name } : {}),
+      })
+      message.retry({ delaySeconds: retryDelay(message.attempts) })
+    }
+  }
+}
+
+export declare namespace consume {
+  type Message = {
+    /** Explicitly acknowledges successful processing. */
+    ack: () => void
+    /** Number of times Queue has delivered this message. */
+    attempts: number
+    /** Versioned delivery body. Treated as untrusted across deployments. */
+    body: unknown
+    /** Explicitly schedules another attempt. */
+    retry: (options: { delaySeconds: number }) => void
+  }
+
+  type Options = {
+    /** Reports a failed attempt without exposing the queued payload. */
+    error?: (
+      error: unknown,
+      context: {
+        attempt: number
+        delivery?: string | undefined
+        event?: string | undefined
+      },
+    ) => void
+    /** Claims and dispatches one validated delivery. */
+    process: (
+      delivery: Delivery.Delivery,
+    ) => Promise<{ status: 'completed' | 'processed' | 'processing' }>
+  }
+}

--- a/app/src/internal/resolvers.test.ts
+++ b/app/src/internal/resolvers.test.ts
@@ -33,8 +33,48 @@ describe('fromRegistry', () => {
 describe('resolvers', () => {
   test('error: propagates a transient target config failure', async () => {
     const instance = await github({}, { errors: { [upstream]: 503 } })
-    const stack = resolvers({ allowedRepos: [upstream], client: client(instance.url), self })
+    const stack = resolvers({
+      allowedRepos: [upstream],
+      installation: async () => client(instance.url),
+      self,
+    })
 
     await expect(stack.readConfig(upstream)).rejects.toMatchObject({ status: 503 })
+  })
+
+  test('behavior: reads private consent with the target installation client', async () => {
+    const sender = await github()
+    const target = await github(
+      {},
+      {
+        files: {
+          [upstream]: {
+            '.agents/friction-log/config.json': JSON.stringify({ inbound: { enabled: true } }),
+          },
+        },
+      },
+    )
+    const stack = resolvers({
+      allowedRepos: [upstream],
+      installation: async () => client(target.url),
+      self,
+    })
+
+    await expect(stack.readConfig(upstream)).resolves.toEqual({ enabled: true })
+    expect(sender.requests).toEqual([])
+    expect(target.requests.some((request) => request.path.includes('/contents/'))).toBe(true)
+  })
+
+  test('error: reports a missing target installation', async () => {
+    const stack = resolvers({
+      allowedRepos: [upstream],
+      installation: async () => undefined,
+      self,
+    })
+
+    await expect(stack.readConfig(upstream)).rejects.toMatchObject({
+      message: 'frog is not installed on `wevm/viem`.',
+      repo: upstream,
+    })
   })
 })

--- a/app/src/internal/resolvers.test.ts
+++ b/app/src/internal/resolvers.test.ts
@@ -1,0 +1,40 @@
+import { Octokit } from 'octokit'
+import { github } from '../../../test/github.js'
+import { fromRegistry, resolvers } from './resolvers.js'
+
+const self = 'acme/app'
+const upstream = 'wevm/viem'
+
+function client(url: string): Octokit {
+  return new Octokit({
+    auth: 'token',
+    baseUrl: url,
+    retry: { enabled: false },
+    throttle: { enabled: false },
+  })
+}
+
+describe('fromRegistry', () => {
+  test('behavior: undefined when a package does not exist', async () => {
+    const instance = await github()
+    await expect(
+      fromRegistry('missing', { url: `${instance.url}/registry` }),
+    ).resolves.toBeUndefined()
+  })
+
+  test('error: propagates a transient registry failure', async () => {
+    const instance = await github({}, { registryErrors: { viem: 503 } })
+    await expect(fromRegistry('viem', { url: `${instance.url}/registry` })).rejects.toThrow(
+      'npm registry returned 503',
+    )
+  })
+})
+
+describe('resolvers', () => {
+  test('error: propagates a transient target config failure', async () => {
+    const instance = await github({}, { errors: { [upstream]: 503 } })
+    const stack = resolvers({ allowedRepos: [upstream], client: client(instance.url), self })
+
+    await expect(stack.readConfig(upstream)).rejects.toMatchObject({ status: 503 })
+  })
+})

--- a/app/src/internal/resolvers.ts
+++ b/app/src/internal/resolvers.ts
@@ -25,19 +25,17 @@ export async function fromRegistry(
   const { timeout = 5_000, url = registry } = options
 
   // Only the slash is escaped: the registry expects `@scope%2Fname`, not a fully encoded path.
-  const response = await globalThis
-    .fetch(`${url}/${name.replace('/', '%2F')}/latest`, { signal: AbortSignal.timeout(timeout) })
-    .catch(() => undefined)
-  if (!response?.ok) return undefined
+  const response = await globalThis.fetch(`${url}/${name.replace('/', '%2F')}/latest`, {
+    signal: AbortSignal.timeout(timeout),
+  })
+  if (response.status === 404) return undefined
+  if (!response.ok) throw new Error(`npm registry returned ${response.status} for \`${name}\`.`)
 
-  const document = (await response.json().catch(() => undefined)) as
-    | {
-        bugs?: { url?: string } | string
-        homepage?: string
-        repository?: { url?: string } | string
-      }
-    | undefined
-  if (!document) return undefined
+  const document = (await response.json()) as {
+    bugs?: { url?: string } | string
+    homepage?: string
+    repository?: { url?: string } | string
+  }
 
   const { bugs, homepage, repository } = document
   const candidates = [
@@ -65,9 +63,7 @@ export function resolvers(options: resolvers.Options): Target.resolve.Options {
   return {
     allowedRepos,
     async readConfig(repo) {
-      const contents = await Github.fetchFile(client.rest, { path: Config.file, repo }).catch(
-        () => undefined,
-      )
+      const contents = await Github.fetchFile(client.rest, { path: Config.file, repo })
       if (!contents) return undefined
       try {
         return Config.from(JSON.parse(contents)).inbound

--- a/app/src/internal/resolvers.ts
+++ b/app/src/internal/resolvers.ts
@@ -58,11 +58,14 @@ export async function fromRegistry(
  * unchanged, which is the point of `Target` taking them as arguments.
  */
 export function resolvers(options: resolvers.Options): Target.resolve.Options {
-  const { allowedRepos, client, registry: url, self } = options
+  const { allowedRepos, installation, registry: url, self } = options
 
   return {
     allowedRepos,
     async readConfig(repo) {
+      const client = await installation(repo)
+      if (!client) throw new InstallationMissingError(repo)
+
       const contents = await Github.fetchFile(client.rest, { path: Config.file, repo })
       if (!contents) return undefined
       try {
@@ -81,11 +84,23 @@ export declare namespace resolvers {
   type Options = {
     /** Targets the sender may file against, from its base-branch config. */
     allowedRepos: readonly string[]
-    /** Installation client for the sender repository. */
-    client: Octokit
+    /** Resolves the installation client authorized to read each target repository. */
+    installation: (repo: string) => Promise<Octokit | undefined>
     /** Registry base URL. Overridden in tests. */
     registry?: string | undefined
     /** The sender repository, as `owner/name`. */
     self: string
+  }
+}
+
+/** Signals that target consent could not be read because the App is not installed there. */
+export class InstallationMissingError extends Error {
+  /** Repository whose installation is missing. */
+  repo: string
+
+  constructor(repo: string) {
+    super(`frog is not installed on \`${repo}\`.`)
+    this.name = 'InstallationMissingError'
+    this.repo = repo
   }
 }

--- a/app/src/internal/serialize.test.ts
+++ b/app/src/internal/serialize.test.ts
@@ -1,0 +1,109 @@
+import * as serialization from './serialize.js'
+
+function namespace(coordinator: serialization.Coordinator) {
+  const getByName = vi.fn((_name: string) => coordinator)
+  return { binding: { getByName } satisfies serialization.Namespace, getByName }
+}
+
+function coordinator(
+  overrides: Partial<serialization.Coordinator> = {},
+): serialization.Coordinator {
+  return {
+    abandon: vi.fn(async () => {}),
+    acquire: vi.fn(async () => true),
+    claim: vi.fn(async () => 'claimed' as const),
+    complete: vi.fn(async () => true),
+    release: vi.fn(async () => {}),
+    ...overrides,
+  }
+}
+
+describe('delivery', () => {
+  test('behavior: a completed delivery does not run again', async () => {
+    const operation = vi.fn(async () => 'unreachable')
+    const { binding, getByName } = namespace(
+      coordinator({ claim: vi.fn(async () => 'completed' as const) }),
+    )
+
+    await expect(
+      serialization.delivery(binding, { id: 'delivery-1', operation, owner: 'attempt-1' }),
+    ).resolves.toEqual({ status: 'completed' })
+    expect(operation).not.toHaveBeenCalled()
+    expect(getByName).toHaveBeenCalledWith('delivery:delivery-1')
+  })
+
+  test('behavior: a processing delivery preserves its retryable status', async () => {
+    const operation = vi.fn(async () => 'unreachable')
+    const { binding } = namespace(coordinator({ claim: vi.fn(async () => 'processing' as const) }))
+
+    await expect(
+      serialization.delivery(binding, { id: 'delivery-1', operation, owner: 'attempt-2' }),
+    ).resolves.toEqual({ status: 'processing' })
+    expect(operation).not.toHaveBeenCalled()
+  })
+
+  test('behavior: success completes the claim and failure abandons it', async () => {
+    const successful = coordinator()
+    await expect(
+      serialization.delivery(namespace(successful).binding, {
+        id: 'delivery-1',
+        operation: async () => 42,
+        owner: 'attempt-1',
+      }),
+    ).resolves.toEqual({ result: 42, status: 'processed' })
+    expect(successful.complete).toHaveBeenCalledWith('attempt-1')
+    expect(successful.abandon).not.toHaveBeenCalled()
+
+    const failed = coordinator()
+    const error = new Error('failed after claiming')
+    await expect(
+      serialization.delivery(namespace(failed).binding, {
+        id: 'delivery-2',
+        operation: async () => {
+          throw error
+        },
+        owner: 'attempt-2',
+      }),
+    ).rejects.toBe(error)
+    expect(failed.abandon).toHaveBeenCalledWith('attempt-2')
+    expect(failed.complete).not.toHaveBeenCalled()
+  })
+})
+
+describe('repositories', () => {
+  test('behavior: a mutation holds and releases its normalized repository lease', async () => {
+    const lock = coordinator()
+    const { binding, getByName } = namespace(lock)
+    const serialize = serialization.repositories(binding, 'delivery-1')
+
+    await expect(serialize('Wevm/Frog', async () => 42)).resolves.toBe(42)
+    expect(getByName).toHaveBeenCalledWith('repository:wevm/frog')
+    expect(lock.acquire).toHaveBeenCalledOnce()
+    expect(lock.release).toHaveBeenCalledWith(expect.stringContaining('delivery-1:'))
+  })
+
+  test('behavior: lock contention prevents a conflicting mutation', async () => {
+    const operation = vi.fn(async () => 42)
+    const lock = coordinator({ acquire: vi.fn(async () => false) })
+    const serialize = serialization.repositories(namespace(lock).binding, 'delivery-2')
+
+    await expect(serialize('wevm/frog', operation)).rejects.toThrow(
+      serialization.RepositoryBusyError,
+    )
+    expect(operation).not.toHaveBeenCalled()
+    expect(lock.release).not.toHaveBeenCalled()
+  })
+
+  test('behavior: failure still releases the lease', async () => {
+    const error = new Error('mutation failed')
+    const lock = coordinator()
+    const serialize = serialization.repositories(namespace(lock).binding, 'delivery-3')
+
+    await expect(
+      serialize('wevm/frog', async () => {
+        throw error
+      }),
+    ).rejects.toBe(error)
+    expect(lock.release).toHaveBeenCalledOnce()
+  })
+})

--- a/app/src/internal/serialize.ts
+++ b/app/src/internal/serialize.ts
@@ -1,0 +1,68 @@
+import type { WebhookCoordinator } from '../WebhookCoordinator.js'
+
+/** Runs one mutation while holding its repository's coordinator lease. */
+export type Serialize = <Result>(repo: string, operation: () => Promise<Result>) => Promise<Result>
+
+/** The coordinator RPC surface used by the Worker and its tests. */
+export type Coordinator = Pick<
+  WebhookCoordinator,
+  'abandon' | 'acquire' | 'claim' | 'complete' | 'release'
+>
+
+/** A typed subset of the Durable Object namespace binding. */
+export type Namespace = {
+  getByName(name: string): Coordinator
+}
+
+/** Another delivery currently owns a conflicting repository mutation. */
+export class RepositoryBusyError extends Error {
+  override readonly name = 'RepositoryBusyError'
+
+  constructor(repo: string) {
+    super(`Another webhook delivery is mutating \`${repo}\`.`)
+  }
+}
+
+/** Runs a delivery once, preserving completed ids across Worker restarts. */
+export async function delivery<Result>(
+  namespace: Namespace,
+  options: {
+    id: string
+    operation: () => Promise<Result>
+    owner?: string | undefined
+  },
+): Promise<{ status: 'completed' | 'processing' } | { result: Result; status: 'processed' }> {
+  const owner = options.owner ?? crypto.randomUUID()
+  const coordinator = namespace.getByName(`delivery:${options.id}`)
+  const claim = await coordinator.claim(owner)
+  if (claim !== 'claimed') return { status: claim }
+
+  try {
+    const result = await options.operation()
+    if (!(await coordinator.complete(owner)))
+      throw new Error(`Delivery \`${options.id}\` lost its processing lease.`)
+    return { result, status: 'processed' }
+  } catch (error) {
+    await coordinator.abandon(owner)
+    throw error
+  }
+}
+
+/** Builds a serializer whose locks are scoped to one webhook delivery. */
+export function repositories(namespace: Namespace, delivery: string): Serialize {
+  const owner = `${delivery}:${crypto.randomUUID()}`
+
+  return async (repo, operation) => {
+    const coordinator = namespace.getByName(`repository:${repo.toLowerCase()}`)
+    if (!(await coordinator.acquire(owner))) throw new RepositoryBusyError(repo)
+
+    try {
+      return await operation()
+    } finally {
+      await coordinator.release(owner)
+    }
+  }
+}
+
+/** Direct execution for CLI calls and focused handler tests. */
+export const direct: Serialize = (_repo, operation) => operation()

--- a/app/src/internal/webhook.test.ts
+++ b/app/src/internal/webhook.test.ts
@@ -1,0 +1,165 @@
+import * as Delivery from '../Delivery.js'
+import { receive } from './webhook.js'
+
+const headers = {
+  'x-github-delivery': 'delivery-1',
+  'x-github-event': 'push',
+  'x-hub-signature-256': 'sha256=valid',
+}
+
+const push = {
+  installation: { id: 42 },
+  ref: 'refs/heads/main',
+  repository: { default_branch: 'main', full_name: 'acme/app' },
+  sender: { login: 'contributor' },
+}
+
+function request(payload: unknown = push, overrides: Record<string, string> = {}): Request {
+  return new Request('https://frog.test/', {
+    body: typeof payload === 'string' ? payload : JSON.stringify(payload),
+    headers: { ...headers, ...overrides },
+    method: 'POST',
+  })
+}
+
+function options(overrides: Partial<receive.Options> = {}): receive.Options {
+  return {
+    enqueue: vi.fn(async () => {}),
+    verify: vi.fn(async () => true),
+    ...overrides,
+  }
+}
+
+function pushOfSize(bytes: number): typeof push {
+  const projected = Delivery.fromWebhook({
+    id: 'delivery-1',
+    name: 'push',
+    payload: push,
+  })
+  if (!projected) throw new Error('Expected a push delivery.')
+  const fixed = Delivery.bytes(projected) - push.ref.length
+  return { ...push, ref: 'x'.repeat(bytes - fixed) }
+}
+
+test('security: an invalid signature is rejected before parsing or queueing', async () => {
+  const enqueue = vi.fn(async () => {})
+  const verify = vi.fn(async () => false)
+
+  const response = await receive(request('{not json'), { enqueue, verify })
+
+  expect(response.status).toBe(401)
+  expect(verify).toHaveBeenCalledWith('{not json', 'sha256=valid')
+  expect(enqueue).not.toHaveBeenCalled()
+})
+
+test('behavior: a supported delivery is compacted and durably accepted', async () => {
+  const enqueue = vi.fn(async (_delivery: Delivery.Delivery) => {})
+
+  const response = await receive(
+    request({ ...push, commits: [{ message: 'x'.repeat(300_000) }] }),
+    options({ enqueue }),
+  )
+
+  expect(response.status).toBe(202)
+  expect(await response.json()).toEqual({ accepted: true, queued: true })
+  expect(enqueue).toHaveBeenCalledWith({
+    id: 'delivery-1',
+    name: 'push',
+    payload: {
+      installation: { id: 42 },
+      ref: 'refs/heads/main',
+      repository: { default_branch: 'main', full_name: 'acme/app' },
+      sender: { login: 'contributor' },
+    },
+    v: 1,
+  })
+})
+
+test('behavior: the response waits until Queue accepts the delivery', async () => {
+  const queued = Promise.withResolvers<void>()
+  const enqueue = vi.fn(async () => queued.promise)
+  const pending = receive(request(), options({ enqueue }))
+
+  await vi.waitFor(() => expect(enqueue).toHaveBeenCalledOnce())
+  let settled = false
+  void pending.then(() => {
+    settled = true
+  })
+  await Promise.resolve()
+  expect(settled).toBe(false)
+
+  queued.resolve()
+  await expect(pending).resolves.toMatchObject({ status: 202 })
+})
+
+test('behavior: unsupported events and actions are accepted without queueing', async () => {
+  const enqueue = vi.fn(async () => {})
+  const unsupportedEvent = await receive(
+    request('{not json', { 'x-github-event': 'ping' }),
+    options({ enqueue }),
+  )
+  const unsupportedAction = await receive(
+    request(
+      {
+        action: 'closed',
+        installation: { id: 42 },
+        number: 7,
+        pull_request: {
+          base: { ref: 'main' },
+          head: { sha: 'abc123' },
+          user: null,
+        },
+        repository: { full_name: 'acme/app' },
+      },
+      { 'x-github-event': 'pull_request' },
+    ),
+    options({ enqueue }),
+  )
+
+  expect(unsupportedEvent.status).toBe(202)
+  expect(unsupportedAction.status).toBe(202)
+  expect(enqueue).not.toHaveBeenCalled()
+})
+
+test('error: malformed supported payloads are rejected without queueing', async () => {
+  const enqueue = vi.fn(async () => {})
+
+  const invalidJson = await receive(request('{not json'), options({ enqueue }))
+  const invalidShape = await receive(request({ ...push, ref: '' }), options({ enqueue }))
+
+  expect(invalidJson.status).toBe(400)
+  expect(invalidShape.status).toBe(400)
+  expect(enqueue).not.toHaveBeenCalled()
+})
+
+test('error: the Queue body boundary reserves metadata headroom without truncation', async () => {
+  const enqueue = vi.fn(async () => {})
+
+  const accepted = await receive(request(pushOfSize(Delivery.maxBytes)), options({ enqueue }))
+  const rejected = await receive(request(pushOfSize(Delivery.maxBytes + 1)), options({ enqueue }))
+
+  expect(accepted.status).toBe(202)
+  expect(rejected.status).toBe(413)
+  expect(enqueue).toHaveBeenCalledOnce()
+})
+
+test('error: an enqueue failure is visible and reports identifiers only', async () => {
+  const failure = new Error('queue unavailable')
+  const error = vi.fn()
+
+  const response = await receive(
+    request(),
+    options({
+      enqueue: vi.fn(async () => {
+        throw failure
+      }),
+      error,
+    }),
+  )
+
+  expect(response.status).toBe(503)
+  expect(error).toHaveBeenCalledWith(failure, {
+    delivery: 'delivery-1',
+    event: 'push',
+  })
+})

--- a/app/src/internal/webhook.ts
+++ b/app/src/internal/webhook.ts
@@ -1,0 +1,59 @@
+import * as Delivery from '../Delivery.js'
+
+/** Verifies and durably enqueues one supported webhook delivery. */
+export async function receive(request: Request, options: receive.Options): Promise<Response> {
+  if (request.method !== 'POST') return new Response('Method Not Allowed', { status: 405 })
+
+  const id = request.headers.get('x-github-delivery')
+  const name = request.headers.get('x-github-event')
+  const signature = request.headers.get('x-hub-signature-256')
+  if (!id || !name || !signature) return new Response('Bad Request', { status: 400 })
+
+  const body = await request.text()
+  if (!(await options.verify(body, signature))) return new Response('Unauthorized', { status: 401 })
+
+  // GitHub sends many event actions the App does not subscribe to. A verified unsupported delivery
+  // is accepted without parsing or queueing, as Octokit's dispatcher did before Queue was introduced.
+  if (!Delivery.supports(name))
+    return Response.json({ accepted: true, queued: false }, { status: 202 })
+
+  let payload: unknown
+  try {
+    payload = JSON.parse(body)
+  } catch {
+    return new Response('Bad Request', { status: 400 })
+  }
+
+  let delivery: Delivery.Delivery | undefined
+  try {
+    delivery = Delivery.fromWebhook({ id, name, payload })
+  } catch (error) {
+    if (error instanceof Delivery.InvalidError) return new Response('Bad Request', { status: 400 })
+    throw error
+  }
+
+  if (!delivery) return Response.json({ accepted: true, queued: false }, { status: 202 })
+  if (Delivery.bytes(delivery) > Delivery.maxBytes)
+    return new Response('Payload Too Large', { status: 413 })
+
+  // Awaiting this write is the durability boundary. Returning before Queue accepts the message would
+  // lose a delivery because GitHub does not automatically redeliver failed webhooks.
+  try {
+    await options.enqueue(delivery)
+  } catch (error) {
+    options.error?.(error, { delivery: id, event: name })
+    return new Response('Service Unavailable', { status: 503 })
+  }
+  return Response.json({ accepted: true, queued: true }, { status: 202 })
+}
+
+export declare namespace receive {
+  type Options = {
+    /** Persists a compact delivery in Cloudflare Queue. */
+    enqueue: (delivery: Delivery.Delivery) => Promise<unknown>
+    /** Reports an enqueue failure without exposing the payload or signature. */
+    error?: (error: unknown, context: { delivery: string; event: string }) => void
+    /** Verifies the exact request bytes against GitHub's signature. */
+    verify: (body: string, signature: string) => Promise<boolean>
+  }
+}

--- a/app/src/worker.ts
+++ b/app/src/worker.ts
@@ -1,6 +1,11 @@
+import { Github } from 'frog'
 import { create } from './App.js'
+import * as Delivery from './Delivery.js'
 import { WebhookCoordinator } from './WebhookCoordinator.js'
+import * as dispatch from './internal/dispatch.js'
+import * as deliveryQueue from './internal/queue.js'
 import * as serialization from './internal/serialize.js'
+import * as webhook from './internal/webhook.js'
 
 /** Bindings the Worker needs, set as secrets. */
 export type Env = {
@@ -12,6 +17,8 @@ export type Env = {
   WEBHOOK_SECRET: string
   /** Persistent delivery claims and repository mutation leases. */
   COORDINATOR: serialization.Namespace
+  /** Durable queue of verified, compact webhook deliveries. */
+  WEBHOOKS: Queue<Delivery.Delivery>
 }
 
 /**
@@ -37,53 +44,65 @@ function app(env: Env): ReturnType<typeof create> {
 }
 
 /** A verified event accepted by Octokit's webhook dispatcher. */
-export type Delivery = Parameters<ReturnType<typeof create>['webhooks']['receive']>[0]
+export type WebhookEvent = Parameters<ReturnType<typeof create>['webhooks']['receive']>[0]
+
+function runDelivery(env: Env, id: string, operation: () => Promise<void>) {
+  return serialization.delivery(env.COORDINATOR, { id, operation })
+}
 
 /** Dispatches one verified delivery behind its persistent idempotency claim. */
-export function processDelivery(env: Env, event: Delivery) {
-  return serialization.delivery(env.COORDINATOR, {
-    id: event.id,
-    operation: () => app(env).webhooks.receive(event),
+export function processDelivery(env: Env, event: WebhookEvent) {
+  return runDelivery(env, event.id, () => app(env).webhooks.receive(event))
+}
+
+async function processQueued(env: Env, delivery: Delivery.Delivery) {
+  return dispatch.queued(env.COORDINATOR, delivery, {
+    expand: (queued) =>
+      Delivery.toEvent(queued, {
+        issue: async (reference) => {
+          const client = await app(env).getInstallationOctokit(reference.installation)
+          const response = await client.rest.issues.get({
+            ...Github.split(reference.repo),
+            issue_number: reference.issue,
+          })
+          return response.data
+        },
+      }),
+    // The projection deliberately contains only fields our handlers read. Keep the OpenAPI escape
+    // hatch at this one boundary rather than letting unvalidated payloads flow through the App.
+    receive: (event) => app(env).webhooks.receive(event as unknown as WebhookEvent),
   })
 }
 
 /**
- * Receives webhook deliveries.
+ * Accepts and consumes webhook deliveries.
  *
- * Deliveries are verified and dispatched directly rather than through `createNodeMiddleware`, which
- * mounts its own routes under a path prefix and would fight a single endpoint. `request.text()` gives
- * the exact bytes GitHub signed; a parsed body re-serialized would not reliably match.
+ * Fetch verifies the exact signed bytes and durably enqueues a compact projection. Queue claims each
+ * delivery before expanding and dispatching it through Octokit's registered handlers.
  */
-export default {
+const worker = {
   async fetch(request: Request, env: Env): Promise<Response> {
-    if (request.method !== 'POST') return new Response('Method Not Allowed', { status: 405 })
-
     const id = request.headers.get('x-github-delivery')
     const name = request.headers.get('x-github-event')
-    const signature = request.headers.get('x-hub-signature-256')
-    if (!id || !name || !signature) return new Response('Bad Request', { status: 400 })
-
-    const body = await request.text()
-    if (!(await app(env).webhooks.verify(body, signature)))
-      return new Response('Bad Request', { status: 400 })
-
-    let payload: unknown
     try {
-      payload = JSON.parse(body)
-    } catch {
-      return new Response('Bad Request', { status: 400 })
-    }
-
-    try {
-      // The signature proves the payload came from GitHub. Octokit validates and routes the event name.
-      const event = { id, name, payload } as Delivery
-      const result = await processDelivery(env, event)
-      return Response.json({ ok: true }, { status: result.status === 'processing' ? 202 : 200 })
+      return await webhook.receive(request, {
+        enqueue: (delivery) => env.WEBHOOKS.send(delivery, { contentType: 'json' }),
+        error: (error, context) => console.error('Webhook enqueue failed.', context, error),
+        verify: (body, signature) => app(env).webhooks.verify(body, signature),
+      })
     } catch (error) {
-      console.error(error)
-      return new Response('Internal Server Error', { status: 500 })
+      console.error('Webhook ingress failed.', { delivery: id, event: name }, error)
+      return new Response('Service Unavailable', { status: 503 })
     }
   },
-}
+
+  async queue(batch: MessageBatch<Delivery.Delivery>, env: Env): Promise<void> {
+    await deliveryQueue.consume(batch.messages, {
+      error: (error, context) => console.error('Webhook processing failed.', context, error),
+      process: (delivery) => processQueued(env, delivery),
+    })
+  },
+} satisfies ExportedHandler<Env, Delivery.Delivery>
 
 export { WebhookCoordinator }
+export default worker

--- a/app/src/worker.ts
+++ b/app/src/worker.ts
@@ -1,4 +1,6 @@
 import { create } from './App.js'
+import { WebhookCoordinator } from './WebhookCoordinator.js'
+import * as serialization from './internal/serialize.js'
 
 /** Bindings the Worker needs, set as secrets. */
 export type Env = {
@@ -8,6 +10,8 @@ export type Env = {
   PRIVATE_KEY: string
   /** Webhook secret, used to verify every delivery. */
   WEBHOOK_SECRET: string
+  /** Persistent delivery claims and repository mutation leases. */
+  COORDINATOR: serialization.Namespace
 }
 
 /**
@@ -23,12 +27,24 @@ function app(env: Env): ReturnType<typeof create> {
 
   const created = create({
     appId: env.APP_ID,
+    coordinator: env.COORDINATOR,
     // Newlines do not survive an environment variable, so they are restored here.
     privateKey: env.PRIVATE_KEY.replace(/\\n/g, '\n'),
     secret: env.WEBHOOK_SECRET,
   })
   apps.set(env.APP_ID, created)
   return created
+}
+
+/** A verified event accepted by Octokit's webhook dispatcher. */
+export type Delivery = Parameters<ReturnType<typeof create>['webhooks']['receive']>[0]
+
+/** Dispatches one verified delivery behind its persistent idempotency claim. */
+export function processDelivery(env: Env, event: Delivery) {
+  return serialization.delivery(env.COORDINATOR, {
+    id: event.id,
+    operation: () => app(env).webhooks.receive(event),
+  })
 }
 
 /**
@@ -47,21 +63,27 @@ export default {
     const signature = request.headers.get('x-hub-signature-256')
     if (!id || !name || !signature) return new Response('Bad Request', { status: 400 })
 
+    const body = await request.text()
+    if (!(await app(env).webhooks.verify(body, signature)))
+      return new Response('Bad Request', { status: 400 })
+
+    let payload: unknown
     try {
-      await app(env).webhooks.verifyAndReceive({
-        id,
-        // The delivered event set is wider than what is registered; unregistered names are ignored.
-        name: name as 'push',
-        payload: await request.text(),
-        signature,
-      })
+      payload = JSON.parse(body)
+    } catch {
+      return new Response('Bad Request', { status: 400 })
+    }
+
+    try {
+      // The signature proves the payload came from GitHub. Octokit validates and routes the event name.
+      const event = { id, name, payload } as Delivery
+      const result = await processDelivery(env, event)
+      return Response.json({ ok: true }, { status: result.status === 'processing' ? 202 : 200 })
     } catch (error) {
-      // GitHub redelivers a failed delivery, and every handler is idempotent, so a 500 is the correct
-      // way to ask for that retry.
       console.error(error)
       return new Response('Internal Server Error', { status: 500 })
     }
-
-    return Response.json({ ok: true })
   },
 }
+
+export { WebhookCoordinator }

--- a/app/wrangler.jsonc
+++ b/app/wrangler.jsonc
@@ -3,6 +3,20 @@
   "name": "frog",
   "main": "src/worker.ts",
   "compatibility_date": "2026-07-01",
+  "durable_objects": {
+    "bindings": [
+      {
+        "name": "COORDINATOR",
+        "class_name": "WebhookCoordinator",
+      },
+    ],
+  },
+  "exports": {
+    "WebhookCoordinator": {
+      "type": "durable-object",
+      "storage": "sqlite",
+    },
+  },
   // Octokit reaches for Node built-ins, and the package layer imports `node:fs` for the offline
   // package lookup the App never takes.
   "compatibility_flags": ["nodejs_compat"],

--- a/app/wrangler.jsonc
+++ b/app/wrangler.jsonc
@@ -17,6 +17,24 @@
       "storage": "sqlite",
     },
   },
+  "queues": {
+    "producers": [
+      {
+        "binding": "WEBHOOKS",
+        "queue": "frog-webhooks",
+      },
+    ],
+    "consumers": [
+      {
+        "queue": "frog-webhooks",
+        "max_batch_size": 10,
+        "max_batch_timeout": 1,
+        "max_retries": 20,
+        "dead_letter_queue": "frog-webhooks-dlq",
+        "retry_delay": 30,
+      },
+    ],
+  },
   // Octokit reaches for Node built-ins, and the package layer imports `node:fs` for the offline
   // package lookup the App never takes.
   "compatibility_flags": ["nodejs_compat"],

--- a/schema.json
+++ b/schema.json
@@ -18,7 +18,7 @@
           "type": "array",
           "items": {
             "type": "string",
-            "minLength": 1
+            "pattern": "^[\\w.-]+\\/(?:[\\w.-]+|\\*)$"
           }
         },
         "enabled": {
@@ -63,7 +63,7 @@
           "type": "array",
           "items": {
             "type": "string",
-            "minLength": 1
+            "pattern": "^[\\w.-]+\\/(?:[\\w.-]+|\\*)$"
           }
         },
         "auto": {
@@ -104,11 +104,6 @@
           "minLength": 1
         }
       }
-    },
-    "site": {
-      "description": "Site serving `/.well-known/frog.json`.",
-      "type": "string",
-      "format": "uri"
     },
     "sync": {
       "description": "How local files reconcile against issue state.",

--- a/src/Config.test.ts
+++ b/src/Config.test.ts
@@ -67,6 +67,13 @@ describe('from', () => {
     )
   })
 
+  test.each([
+    ['inbound.allowFrom', { inbound: { allowFrom: ['acme/*/typo'] } }],
+    ['outbound.allowedRepos', { outbound: { allowedRepos: ['wevm/*/typo'] } }],
+  ])('error: rejects a malformed %s entry', (_, value) => {
+    expect(() => Config.from(value)).toThrow(Config.InvalidError)
+  })
+
   test('error: rejects a non-positive maxPerRun', () => {
     expect(() => Config.from({ maxPerRun: 0 })).toThrowErrorMatchingInlineSnapshot(
       `[Config.InvalidError: \`.agents/friction-log/config.json\` is invalid. maxPerRun: Too small: expected number to be >0]`,

--- a/src/Config.test.ts
+++ b/src/Config.test.ts
@@ -1,3 +1,5 @@
+import fs from 'node:fs/promises'
+import { z } from 'incur'
 import { tmpdir, writeFile } from '../test/helpers.js'
 import * as Config from './Config.js'
 
@@ -106,6 +108,19 @@ describe('resolve', () => {
       `[Config.MalformedError: \`.agents/friction-log/config.json\` is not valid JSON.]`,
     )
   })
+})
+
+test('schema.json matches the written config schema', async () => {
+  const committed = JSON.parse(
+    await fs.readFile(new URL('../schema.json', import.meta.url), 'utf8'),
+  ) as unknown
+  const generated = {
+    $schema: 'http://json-schema.org/draft-07/schema#',
+    title: 'frog config',
+    ...z.toJSONSchema(Config.Schema, { io: 'input', target: 'draft-7' }),
+  }
+
+  expect(committed).toEqual(generated)
 })
 
 describe('allows', () => {

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -7,6 +7,7 @@ import { dir } from './Store.js'
 export const file = `${dir}/config.json`
 
 const repoPattern = /^[\w.-]+\/[\w.-]+$/
+const repoAllowPattern = /^[\w.-]+\/(?:[\w.-]+|\*)$/
 
 /**
  * One schema serves both shapes: `z.input` is what a user writes (everything optional), `z.output`
@@ -20,7 +21,7 @@ export const Schema = z.object({
   inbound: z
     .object({
       allowFrom: z
-        .array(z.string().min(1))
+        .array(z.string().regex(repoAllowPattern))
         .optional()
         .describe(
           'Sender repositories, or `owner/*` globs, allowed to report friction here. Absent means anyone.',
@@ -49,7 +50,7 @@ export const Schema = z.object({
   outbound: z
     .object({
       allowedRepos: z
-        .array(z.string().min(1))
+        .array(z.string().regex(repoAllowPattern))
         .default([])
         .describe(
           'Targets this repository may file against. Always read from the base branch, never a pull request head.',

--- a/src/Entry.ts
+++ b/src/Entry.ts
@@ -23,7 +23,7 @@ export type Frontmatter = {
   /** How much the friction hurt. Defaults to `minor`. */
   severity: Severity
   /**
-   * Where the issue belongs: an npm package, `owner/repo`, or a host.
+   * Where the issue belongs: an npm package or GitHub repository as `owner/repo`.
    *
    * Absent means this repository.
    */

--- a/src/Git.test.ts
+++ b/src/Git.test.ts
@@ -22,6 +22,9 @@ describe('repo', () => {
     ['https://github.com/wevm/viem', 'wevm/viem'],
     ['ssh://git@github.com/wevm/viem.git', 'wevm/viem'],
     ['git@github.com:wevm/frog.dev.git', 'wevm/frog.dev'],
+    ['owner/repo', undefined],
+    ['../upstream.git', undefined],
+    ['https://notgithub.com/wevm/viem.git', undefined],
     ['git@gitlab.com:wevm/viem.git', undefined],
     ['https://example.com/wevm/viem.git', undefined],
   ] as const)('behavior: %s', async ([remote, expected]) => {

--- a/src/Git.test.ts
+++ b/src/Git.test.ts
@@ -120,7 +120,7 @@ describe('add, rm, and commit', () => {
     const file = Store.toPath('one')
     await helpers.writeFile(file, entry, cwd)
     await Git.add([file], { cwd })
-    expect(await Git.commit('log friction', { cwd })).toBe(true)
+    expect(await Git.commit('log friction', { cwd, files: [file] })).toBe(true)
     expect(await helpers.git(['show', '--name-only', '--format=%s', 'HEAD'], cwd)).toContain(file)
   })
 
@@ -131,7 +131,7 @@ describe('add, rm, and commit', () => {
     await helpers.commit('log friction', cwd)
 
     await Git.rm([file], { cwd })
-    expect(await Git.commit('resolve friction', { cwd })).toBe(true)
+    expect(await Git.commit('resolve friction', { cwd, files: [file] })).toBe(true)
     expect(await helpers.git(['ls-files'], cwd)).not.toContain(file)
   })
 
@@ -139,7 +139,19 @@ describe('add, rm, and commit', () => {
     const cwd = await helpers.repo()
     await helpers.writeFile('a.txt', 'a', cwd)
     await helpers.commit('add a', cwd)
-    expect(await Git.commit('nothing to do', { cwd })).toBe(false)
+    expect(await Git.commit('nothing to do', { cwd, files: [Store.dir] })).toBe(false)
+  })
+
+  test('behavior: commit preserves unrelated staged changes', async () => {
+    const cwd = await helpers.repo()
+    const file = Store.toPath('one')
+    await helpers.writeFile(file, entry, cwd)
+    await helpers.writeFile('unrelated.txt', 'keep staged', cwd)
+    await Git.add([file, 'unrelated.txt'], { cwd })
+
+    expect(await Git.commit('log friction', { cwd, files: [file] })).toBe(true)
+    expect(await helpers.git(['show', '--name-only', '--format=', 'HEAD'], cwd)).toBe(file)
+    expect(await helpers.git(['diff', '--cached', '--name-only'], cwd)).toBe('unrelated.txt')
   })
 
   test('behavior: add and rm are no-ops for an empty list', async () => {

--- a/src/Git.ts
+++ b/src/Git.ts
@@ -36,7 +36,7 @@ export async function root(options: Options = {}): Promise<string | undefined> {
  */
 export async function repo(options: Options = {}): Promise<string | undefined> {
   const url = await git(['remote', 'get-url', 'origin'], options).catch(() => '')
-  return Github.parseRepository(url)
+  return Github.parseRepository(url, { shorthand: false })
 }
 
 /**

--- a/src/Git.ts
+++ b/src/Git.ts
@@ -154,15 +154,30 @@ export declare namespace rm {
 }
 
 /**
- * Commits staged changes.
+ * Commits staged changes within an explicit set of paths.
  *
  * @param message - Commit message.
- * @returns `true` when a commit was made, `false` when nothing was staged. Reporting rather than
- * throwing keeps a no-op run from looking like a failure.
+ * @returns `true` when a commit was made, `false` when none of the requested paths were staged.
+ * Reporting rather than throwing keeps a no-op run from looking like a failure.
  */
-export async function commit(message: string, options: Options = {}): Promise<boolean> {
-  const staged = await git(['diff', '--cached', '--name-only'], options)
-  if (!staged) return false
-  await git(['commit', '--no-verify', '--message', message], options)
+export async function commit(message: string, options: commit.Options): Promise<boolean> {
+  if (options.files.length === 0) return false
+
+  const staged = (await git(['diff', '--cached', '--name-only', '--', ...options.files], options))
+    .split('\n')
+    .filter(Boolean)
+  if (staged.length === 0) return false
+
+  await git(['commit', '--no-verify', '--message', message, '--only', '--', ...staged], options)
   return true
+}
+
+export declare namespace commit {
+  /** Paths whose staged changes belong in the commit. Other staged work is preserved. */
+  type Options = {
+    /** Directory to run git in. Defaults to `process.cwd()`. */
+    cwd?: string | undefined
+    /** Repository-relative paths to commit. */
+    files: readonly string[]
+  }
 }

--- a/src/Github.test.ts
+++ b/src/Github.test.ts
@@ -133,6 +133,19 @@ describe('renderBody and parseBody', () => {
     `)
   })
 
+  test('behavior: renders a stable replay marker without changing the parsed body', () => {
+    const rendered = Github.renderBody({
+      body: 'Body.',
+      marker: { hash: 'abc123' },
+      occurrence: 'delivery-1:entry-a',
+    })
+
+    expect(rendered).toContain(
+      '<!-- frog:occurrence:v1 1285780025c132555ee8a247a8a04563e822a8aa64727236c8bb42b72f963d60 -->',
+    )
+    expect(Github.parseBody(rendered)).toBe('Body.')
+  })
+
   // The reopen edge of sync rebuilds a file from its issue, so this inverse must hold exactly.
   test.for([
     'Body.',
@@ -326,13 +339,14 @@ describe('find', () => {
       ],
     })
 
-    // Deliberately a title the search would not match, so only the marker can identify it.
+    // Deliberately a different title, so only the marker can identify it.
     const found = await Github.find(client(instance.url), {
       hash: Github.hash(title),
       repo,
       title: 'Anything',
     })
     expect(found?.number).toBe(1)
+    expect(instance.requests).not.toContainEqual({ method: 'GET', path: '/search/issues' })
   })
 
   test('behavior: finds an unlabelled issue whose title normalizes the same', async () => {
@@ -533,5 +547,75 @@ describe('publish', () => {
     }
 
     expect(instance.issues.get(repo)).toHaveLength(1)
+  })
+
+  test('behavior: replay after issue creation does not add a hit-again comment', async () => {
+    const instance = await github({}, { pushAccess: [] })
+    const octokit = client(instance.url)
+    const occurrence = 'delivery-1:entry-a'
+
+    const first = await Github.publish(octokit, {
+      entry,
+      labels: ['friction'],
+      marker: { hash: Github.hash(title) },
+      occurrence,
+      repo,
+    })
+    const matcher = await Github.matcher(octokit, { label: 'friction', repo })
+    const existing = await matcher.match(title)
+    const replayed = await Github.publish(octokit, {
+      entry,
+      labels: ['friction'],
+      marker: { hash: Github.hash(title) },
+      occurrence,
+      repo,
+      ...(existing ? { existing } : {}),
+    })
+
+    expect(first).toEqual({ issue: 1, status: 'created' })
+    expect(replayed).toEqual({ issue: 1, status: 'created' })
+    expect(instance.issues.get(repo)).toHaveLength(1)
+    expect(instance.comments(repo, 1)).toEqual([])
+  })
+
+  test('behavior: replay after commenting does not add the comment twice', async () => {
+    const instance = await github({
+      [repo]: [{ body: Github.renderMarker({ hash: Github.hash(title) }), title }],
+    })
+    const octokit = client(instance.url)
+    const existing = (await Github.index(octokit, { label: 'friction', repo })).get(
+      Github.hash(title),
+    )
+    if (!existing) throw new Error('Expected seeded issue.')
+
+    for (let index = 0; index < 100; index++)
+      await octokit.issues.createComment({
+        ...Github.split(repo),
+        body: `Existing comment ${index}.`,
+        issue_number: existing.number,
+      })
+
+    const publish = (occurrence: string) =>
+      Github.publish(octokit, {
+        entry,
+        existing,
+        labels: ['friction'],
+        marker: { hash: Github.hash(title) },
+        occurrence,
+        repo,
+      })
+
+    await expect(publish('delivery-1:entry-a')).resolves.toEqual({
+      issue: 1,
+      status: 'commented',
+    })
+    await expect(publish('delivery-1:entry-a')).resolves.toEqual({
+      issue: 1,
+      status: 'commented',
+    })
+    expect(instance.comments(repo, 1)).toHaveLength(101)
+
+    await publish('delivery-2:entry-a')
+    expect(instance.comments(repo, 1)).toHaveLength(102)
   })
 })

--- a/src/Github.test.ts
+++ b/src/Github.test.ts
@@ -23,11 +23,14 @@ describe('parseRepository', () => {
     ['git@github.com:wevm/viem.git', 'wevm/viem'],
     ['ssh://git@github.com/wevm/viem.git', 'wevm/viem'],
     ['git://github.com/wevm/viem.git', 'wevm/viem'],
+    ['https://github.com:443/wevm/viem', 'wevm/viem'],
     // A monorepo package pointing at its own subdirectory rather than the repository root.
     ['https://github.com/changesets/changesets/tree/main/packages/config', 'changesets/changesets'],
     ['github:eemeli/yaml', 'eemeli/yaml'],
     ['lydell/js-tokens', 'lydell/js-tokens'],
     // Only GitHub resolves: an issue cannot be filed anywhere else.
+    ['https://notgithub.com/foo/bar', undefined],
+    ['https://example.com/github.com/foo/bar', undefined],
     ['https://gitlab.com/foo/bar.git', undefined],
     ['https://bitbucket.org/foo/bar', undefined],
     ['not a repository', undefined],
@@ -35,6 +38,10 @@ describe('parseRepository', () => {
     [undefined, undefined],
   ] as const)('behavior: %s', ([value, expected]) => {
     expect(Github.parseRepository(value)).toBe(expected)
+  })
+
+  test('behavior: npm shorthand can be disabled for git remotes', () => {
+    expect(Github.parseRepository('wevm/viem', { shorthand: false })).toBeUndefined()
   })
 })
 

--- a/src/Github.test.ts
+++ b/src/Github.test.ts
@@ -487,6 +487,34 @@ describe('publish', () => {
     `)
   })
 
+  test('behavior: reopens a closed issue before commenting', async () => {
+    const instance = await github({
+      [repo]: [
+        {
+          body: Github.renderMarker({ hash: Github.hash(title) }),
+          state: 'closed',
+          title: 'Already filed',
+        },
+      ],
+    })
+    const octokit = client(instance.url)
+    const existing = (await Github.index(octokit, { label: 'friction', repo })).get(
+      Github.hash(title),
+    )
+
+    const result = await Github.publish(octokit, {
+      entry,
+      labels: ['friction'],
+      marker: { hash: Github.hash(title) },
+      repo,
+      ...(existing ? { existing } : {}),
+    })
+
+    expect(result).toEqual({ issue: 1, status: 'commented' })
+    expect(instance.issues.get(repo)?.[0]?.state).toBe('open')
+    expect(instance.comments(repo, 1)).toHaveLength(1)
+  })
+
   test('behavior: publishing twice through the index never duplicates', async () => {
     const instance = await github()
     const octokit = client(instance.url)

--- a/src/Github.test.ts
+++ b/src/Github.test.ts
@@ -299,6 +299,25 @@ describe('permissions', () => {
   })
 })
 
+describe('defaultBranch', () => {
+  test('behavior: returns the default branch', async () => {
+    const instance = await github()
+    expect(await Github.defaultBranch(client(instance.url), { repo })).toBe('main')
+  })
+
+  test('behavior: undefined when the repository does not exist', async () => {
+    const instance = await github({}, { errors: { [repo]: 404 } })
+    expect(await Github.defaultBranch(client(instance.url), { repo })).toBeUndefined()
+  })
+
+  test('error: propagates a transient repository failure', async () => {
+    const instance = await github({}, { errors: { [repo]: 503 } })
+    await expect(Github.defaultBranch(client(instance.url), { repo })).rejects.toMatchObject({
+      status: 503,
+    })
+  })
+})
+
 describe('find', () => {
   test('behavior: finds an unlabelled issue by its marker', async () => {
     const instance = await github({

--- a/src/Github.ts
+++ b/src/Github.ts
@@ -8,7 +8,7 @@ import * as Entry from './Entry.js'
  * Narrow on purpose: the App passes Probot's client, which is the same endpoint-methods object, so
  * neither caller has to construct the other's.
  */
-export type Client = Pick<Octokit['rest'], 'issues' | 'repos' | 'search'>
+export type Client = Pick<Octokit['rest'], 'issues' | 'repos'>
 
 /** A label as GitHub returns it: either the bare name, or an object holding one. */
 export type Label =
@@ -160,6 +160,14 @@ export const markerVersion = 'v1'
 
 const markerRegex = /<!--\s*frog:v1\s+([^>]*?)\s*-->/
 
+/** Version of the marker that makes one external publish occurrence replay-safe. */
+const occurrenceVersion = 'v1'
+
+function renderOccurrence(occurrence: string): string {
+  const digest = createHash('sha256').update(occurrence).digest('hex')
+  return `<!-- frog:occurrence:${occurrenceVersion} ${digest} -->`
+}
+
 /**
  * Hidden state carried in an issue body.
  *
@@ -237,7 +245,7 @@ export type Provenance = {
  * @returns The issue body. {@link parseBody} inverts this exactly.
  */
 export function renderBody(options: renderBody.Options): string {
-  const { body, marker, provenance = {} } = options
+  const { body, marker, occurrence, provenance = {} } = options
 
   const credits = [
     provenance.author ? `Logged by ${provenance.author}` : 'Logged',
@@ -250,7 +258,11 @@ export function renderBody(options: renderBody.Options): string {
 
   const footer = `<sub>${credits}. Filed by [frog](https://github.com/wevm/frog).</sub>`
 
-  return `${body.trim()}\n\n${renderMarker(marker)}\n\n---\n\n${footer}\n`
+  const markers = [renderMarker(marker), occurrence ? renderOccurrence(occurrence) : undefined]
+    .filter(Boolean)
+    .join('\n')
+
+  return `${body.trim()}\n\n${markers}\n\n---\n\n${footer}\n`
 }
 
 export declare namespace renderBody {
@@ -260,6 +272,8 @@ export declare namespace renderBody {
     body: string
     /** Hidden state to embed. Its `origin` also appears in the footer. */
     marker: Marker
+    /** Stable key for one external publish occurrence. */
+    occurrence?: string | undefined
     /** Attribution for the footer. Omitted entirely when nothing is known. */
     provenance?: Provenance | undefined
   }
@@ -355,8 +369,12 @@ export declare namespace fromIssue {
  * before closed, then lowest number.
  */
 export async function index(client: Client, options: index.Options): Promise<Map<string, Issue>> {
+  return toIndex(await list(client, options))
+}
+
+function toIndex(issues: readonly Issue[]): Map<string, Issue> {
   const indexed = new Map<string, Issue>()
-  for (const issue of await list(client, options)) {
+  for (const issue of issues) {
     const key = parseMarker(issue.body)?.hash ?? hash(issue.title)
     // Prefer an open issue, then the lowest number, so comments land on the canonical one.
     const current = indexed.get(key)
@@ -519,24 +537,15 @@ export async function defaultBranch(
 /**
  * Finds the issue already covering a friction, without relying on a label.
  *
- * Searches by title, then confirms the marker hash. Slower and backed by an eventually consistent
- * index, so it is only used where {@link index} cannot work: a repository the token cannot label.
+ * Lists issues directly rather than using GitHub's eventually consistent search index. It is only
+ * used where {@link index} cannot work: a repository the token cannot label.
  *
  * @param client - Authenticated client for the repository.
  * @returns The issue covering this friction, or `undefined`.
  */
 export async function find(client: Client, options: find.Options): Promise<Issue | undefined> {
-  const { hash: key, repo, title } = options
-
-  // Searched normalized, not verbatim: the point is to find the same friction reported with different
-  // capitalization and punctuation, and GitHub tokenizes the phrase anyway.
-  const response = await client.search.issuesAndPullRequests({
-    per_page: 20,
-    q: `repo:${repo} is:issue in:title ${JSON.stringify(Entry.normalizeTitle(title))}`,
-  })
-  const candidates = response.data.items.filter(
-    (item) => !('pull_request' in item && item.pull_request),
-  )
+  const { hash: key, repo } = options
+  const candidates = await listAll(client, { repo })
 
   // A marker is proof. A matching normalized title is the fallback, which is what catches an issue
   // somebody filed by hand.
@@ -574,12 +583,33 @@ export async function list(client: Client, options: index.Options): Promise<read
   for (let page = 1; page <= 50; page++) {
     const response = await client.issues.listForRepo({
       ...split(repo),
+      direction: 'asc',
       labels: label,
       page,
       per_page: 100,
+      sort: 'created',
       state,
     })
     // `listForRepo` returns pull requests too.
+    collected.push(
+      ...response.data.filter((issue) => !('pull_request' in issue && issue.pull_request)),
+    )
+    if (response.data.length < 100) break
+  }
+  return collected
+}
+
+async function listAll(client: Client, options: { repo: string }): Promise<readonly Issue[]> {
+  const collected: Issue[] = []
+  for (let page = 1; ; page++) {
+    const response = await client.issues.listForRepo({
+      ...split(options.repo),
+      direction: 'asc',
+      page,
+      per_page: 100,
+      sort: 'created',
+      state: 'all',
+    })
     collected.push(
       ...response.data.filter((issue) => !('pull_request' in issue && issue.pull_request)),
     )
@@ -623,22 +653,30 @@ export type Matcher = {
 /**
  * Prepares dedupe for a repository, choosing a strategy the token can actually use.
  *
- * With push access, every issue is listed once by label and matched from memory. Without it, GitHub
- * will have dropped that label on creation, so each title is searched instead. Both adapters go through
- * here so the choice cannot drift between them.
+ * With push access, issues are indexed by label first. A miss falls back to one unfiltered listing,
+ * which also covers labels removed by users or dropped during creation. Without push access, that
+ * fallback is the primary index.
  *
  * @param client - Authenticated client for the repository.
  */
 export async function matcher(client: Client, options: index.Options): Promise<Matcher> {
   const { push } = await permissions(client, { repo: options.repo })
-  if (!push)
-    return {
-      labelled: false,
-      match: (title) => find(client, { hash: hash(title), repo: options.repo, title }),
-    }
+  const labelled = push ? await index(client, options) : new Map<string, Issue>()
+  let unlabelled: Promise<Map<string, Issue>> | undefined
 
-  const indexed = await index(client, options)
-  return { labelled: true, match: async (title) => indexed.get(hash(title)) }
+  return {
+    labelled: push,
+    match: async (title) => {
+      const key = hash(title)
+      const existing = labelled.get(key)
+      if (existing) return existing
+
+      // Even a token with push access can encounter an issue whose configured label was removed.
+      // Fall back once per filing group so a replay still finds the side effect immediately.
+      unlabelled ??= listAll(client, options).then(toIndex)
+      return (await unlabelled).get(key)
+    },
+  }
 }
 
 /**
@@ -651,14 +689,33 @@ export async function matcher(client: Client, options: index.Options): Promise<M
  * @returns The issue number and whether it was opened or commented on.
  */
 export async function publish(client: Client, options: publish.Options): Promise<Result> {
-  const { existing, entry, labels, marker, provenance, repo } = options
+  const { existing, entry, labels, marker, occurrence, provenance, repo } = options
   const body = renderBody({
     body: entry.body,
     marker,
+    ...(occurrence ? { occurrence } : {}),
     ...(provenance ? { provenance } : {}),
   })
 
   if (existing) {
+    if (occurrence) {
+      const occurrenceMarker = renderOccurrence(occurrence)
+      if (existing.body?.includes(occurrenceMarker))
+        return { issue: existing.number, status: 'created' }
+
+      for (let page = 1; ; page++) {
+        const response = await client.issues.listComments({
+          ...split(repo),
+          issue_number: existing.number,
+          page,
+          per_page: 100,
+        })
+        if (response.data.some((comment) => comment.body?.includes(occurrenceMarker)))
+          return { issue: existing.number, status: 'commented' }
+        if (response.data.length < 100) break
+      }
+    }
+
     if (existing.state !== 'open')
       await client.issues.update({
         ...split(repo),
@@ -677,7 +734,9 @@ export async function publish(client: Client, options: publish.Options): Promise
 
     await client.issues.createComment({
       ...split(repo),
-      body: `${note}.\n\n${entry.body.trim()}\n`,
+      body: `${note}.\n\n${entry.body.trim()}${
+        occurrence ? `\n\n${renderOccurrence(occurrence)}` : ''
+      }\n`,
       issue_number: existing.number,
     })
     return { issue: existing.number, status: 'commented' }
@@ -707,6 +766,8 @@ export declare namespace publish {
     labels: readonly string[]
     /** Hidden state to embed, from {@link hash} plus the file path and origin repository. */
     marker: Marker
+    /** Stable key used to suppress a replay of this exact create or comment. */
+    occurrence?: string | undefined
     /** Attribution for the footer and the comment. */
     provenance?: Provenance | undefined
     /** Repository to file in, as `owner/name`. */

--- a/src/Github.ts
+++ b/src/Github.ts
@@ -659,6 +659,13 @@ export async function publish(client: Client, options: publish.Options): Promise
   })
 
   if (existing) {
+    if (existing.state !== 'open')
+      await client.issues.update({
+        ...split(repo),
+        issue_number: existing.number,
+        state: 'open',
+      })
+
     const note = [
       'Hit again',
       provenance?.author ? `by ${provenance.author}` : undefined,

--- a/src/Github.ts
+++ b/src/Github.ts
@@ -57,13 +57,10 @@ export function split(target: string): { owner: string; repo: string } {
 /** npm's shorthand forms: `owner/name`, optionally prefixed with `github:`. */
 const shorthandRegex = /^(?:github:)?([\w.-]+)\/([\w.-]+)$/
 
-/**
- * Matches GitHub in ssh, scp, and https form, with an optional `.git` suffix.
- *
- * Anything after the repository is discarded, which is what handles a monorepo package pointing at its
- * own subdirectory rather than the repository root.
- */
-const urlRegex = /github\.com[:/]([\w.-]+)\/([\w.-]+?)(?:\.git)?(?:[/#?].*)?$/
+/** Git's scp-like SSH form, which `URL` cannot parse. */
+const scpRegex = /^(?:[^@\s]+@)?github\.com:([\w.-]+)\/([\w.-]+?)(?:\.git)?$/
+
+const componentRegex = /^[\w.-]+$/
 
 /**
  * Normalizes a repository reference into `owner/name`.
@@ -77,14 +74,39 @@ const urlRegex = /github\.com[:/]([\w.-]+)\/([\w.-]+?)(?:\.git)?(?:[/#?].*)?$/
  * @returns The repository as `owner/name`, or `undefined` when it is absent or not on GitHub. Only GitHub
  * resolves, because an issue can only be filed there.
  */
-export function parseRepository(value: string | undefined): string | undefined {
+export function parseRepository(
+  value: string | undefined,
+  options: parseRepository.Options = {},
+): string | undefined {
   if (!value) return undefined
 
-  const match = shorthandRegex.exec(value) ?? urlRegex.exec(value)
-  if (!match) return undefined
+  const shorthand = options.shorthand === false ? undefined : shorthandRegex.exec(value)
+  if (shorthand) return `${shorthand[1]}/${shorthand[2]}`
 
-  const [, owner, name] = match
-  return `${owner}/${name}`
+  const scp = scpRegex.exec(value)
+  if (scp) return `${scp[1]}/${scp[2]}`
+
+  try {
+    const url = new URL(value.startsWith('git+') ? value.slice(4) : value)
+    if (url.hostname.toLowerCase() !== 'github.com') return undefined
+
+    const [owner, rawName] = url.pathname.replace(/^\/+/, '').split('/')
+    const name = rawName?.replace(/\.git$/, '')
+    if (!owner || !name || !componentRegex.test(owner) || !componentRegex.test(name))
+      return undefined
+
+    return `${owner}/${name}`
+  } catch {
+    return undefined
+  }
+}
+
+export declare namespace parseRepository {
+  /** Parsing controls for contexts such as git remotes, where npm shorthand is not meaningful. */
+  type Options = {
+    /** Whether to accept npm's `owner/name` and `github:owner/name` shorthand. Defaults to `true`. */
+    shorthand?: boolean | undefined
+  }
 }
 
 /**

--- a/src/Github.ts
+++ b/src/Github.ts
@@ -510,8 +510,9 @@ export async function defaultBranch(
   try {
     const response = await client.repos.get(split(options.repo))
     return response.data.default_branch
-  } catch {
-    return undefined
+  } catch (error) {
+    if ((error as { status?: number }).status === 404) return undefined
+    throw error
   }
 }
 

--- a/src/Mirrors.test.ts
+++ b/src/Mirrors.test.ts
@@ -1,0 +1,42 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { tmpdir } from '../test/helpers.js'
+import * as Mirrors from './Mirrors.js'
+import * as Store from './Store.js'
+
+const first = { issue: 'wevm/viem#1', path: Store.toPath('a') }
+const second = { issue: 'wevm/viem#2', path: Store.toPath('b') }
+
+test('behavior: normalizes duplicate and unsorted records', () => {
+  expect(Mirrors.from({ mirrors: [second, first, first], version: 1 })).toEqual({
+    mirrors: [first, second],
+    version: 1,
+  })
+})
+
+test.each([
+  { mirrors: [], version: 2 },
+  { mirrors: [{ issue: 'invalid', path: Store.toPath('a') }], version: 1 },
+  { mirrors: [{ issue: 'wevm/viem#1', path: '../friction.md' }], version: 1 },
+])('error: rejects malformed state %#', (value) => {
+  expect(() => Mirrors.from(value)).toThrow(Mirrors.InvalidError)
+})
+
+test('behavior: remembers and forgets exact records', () => {
+  const remembered = Mirrors.update(Mirrors.empty(), { remember: [second, first, first] })
+  expect(remembered.mirrors).toEqual([first, second])
+  expect(Mirrors.update(remembered, { forget: [first] }).mirrors).toEqual([second])
+})
+
+test('behavior: a missing local journal is empty', async () => {
+  expect(await Mirrors.resolve({ root: await tmpdir() })).toEqual(Mirrors.empty())
+})
+
+test('behavior: writes and removes the local journal', async () => {
+  const root = await tmpdir()
+  await Mirrors.write(Mirrors.update(Mirrors.empty(), { remember: [first] }), { root })
+  expect(await Mirrors.resolve({ root })).toEqual({ mirrors: [first], version: 1 })
+
+  await Mirrors.write(Mirrors.empty(), { root })
+  await expect(fs.stat(path.join(root, Mirrors.file))).rejects.toMatchObject({ code: 'ENOENT' })
+})

--- a/src/Mirrors.ts
+++ b/src/Mirrors.ts
@@ -16,7 +16,9 @@ export type Mirror = {
 
 /** Versioned journal persisted in a repository. */
 export type State = {
+  /** Deleted mirrors available for restoration. */
   mirrors: readonly Mirror[]
+  /** Journal format version. */
   version: 1
 }
 
@@ -112,7 +114,9 @@ export async function write(state: State, options: Store.Options): Promise<void>
 
 /** Thrown when the journal is valid JSON but not a supported recovery state. */
 export class InvalidError extends Error {
+  /** Stable error name. */
   override name = 'Mirrors.InvalidError'
+  /** Machine-readable error code. */
   code = 'INVALID_SYNC_STATE' as const
 
   constructor(detail: string) {
@@ -122,7 +126,9 @@ export class InvalidError extends Error {
 
 /** Thrown when the journal is not parseable JSON. */
 export class MalformedError extends Error {
+  /** Stable error name. */
   override name = 'Mirrors.MalformedError'
+  /** Machine-readable error code. */
   code = 'MALFORMED_SYNC_STATE' as const
 
   constructor(cause: Error) {

--- a/src/Mirrors.ts
+++ b/src/Mirrors.ts
@@ -1,0 +1,131 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import * as Github from './Github.js'
+import * as Store from './Store.js'
+
+/** Repository-relative path of the committed mirror recovery journal. */
+export const file = `${Store.dir}/.sync.json`
+
+/** A deleted local mirror that can be restored if its issue reopens. */
+export type Mirror = {
+  /** Issue the entry mirrored, as `owner/name#number`. */
+  issue: string
+  /** Canonical path of the deleted entry write-up. */
+  path: string
+}
+
+/** Versioned journal persisted in a repository. */
+export type State = {
+  mirrors: readonly Mirror[]
+  version: 1
+}
+
+/** An empty recovery journal. */
+export function empty(): State {
+  return { mirrors: [], version: 1 }
+}
+
+function key(mirror: Mirror): string {
+  return `${mirror.issue}\u0000${mirror.path}`
+}
+
+function valid(mirror: unknown): mirror is Mirror {
+  if (!mirror || typeof mirror !== 'object' || Array.isArray(mirror)) return false
+  const value = mirror as Partial<Mirror>
+  if (typeof value.issue !== 'string' || !Github.parseLink(value.issue)) return false
+  if (typeof value.path !== 'string') return false
+  const id = Store.toId(value.path)
+  return Boolean(id && Store.toPath(id) === value.path)
+}
+
+function normalize(mirrors: readonly Mirror[]): readonly Mirror[] {
+  return [...new Map(mirrors.map((mirror) => [key(mirror), mirror])).values()].sort((a, b) =>
+    key(a).localeCompare(key(b)),
+  )
+}
+
+/**
+ * Validates and normalizes a loaded journal.
+ *
+ * Unknown versions fail closed so recovery state is never silently discarded by older code.
+ */
+export function from(value: unknown): State {
+  if (!value || typeof value !== 'object' || Array.isArray(value))
+    throw new InvalidError('Expected an object.')
+
+  const state = value as { mirrors?: unknown; version?: unknown }
+  if (state.version !== 1) throw new InvalidError('Expected version 1.')
+  if (!Array.isArray(state.mirrors) || !state.mirrors.every(valid))
+    throw new InvalidError('Expected canonical issue and entry path pairs.')
+
+  return { mirrors: normalize(state.mirrors), version: 1 }
+}
+
+/** Deterministic on-disk representation. */
+export function serialize(state: State): string {
+  return `${JSON.stringify({ version: 1, mirrors: normalize(state.mirrors) }, null, 2)}\n`
+}
+
+/** Adds and removes exact mirror records. */
+export function update(
+  state: State,
+  options: {
+    forget?: readonly Mirror[] | undefined
+    remember?: readonly Mirror[] | undefined
+  },
+): State {
+  const mirrors = new Map(state.mirrors.map((mirror) => [key(mirror), mirror]))
+  for (const mirror of options.forget ?? []) mirrors.delete(key(mirror))
+  for (const mirror of options.remember ?? []) mirrors.set(key(mirror), mirror)
+  return { mirrors: normalize([...mirrors.values()]), version: 1 }
+}
+
+/** Reads the local journal. A missing file is an empty journal. */
+export async function resolve(options: Store.Options): Promise<State> {
+  const contents = await fs
+    .readFile(path.join(options.root, file), 'utf8')
+    .catch((error: NodeJS.ErrnoException) => {
+      if (error.code === 'ENOENT') return undefined
+      throw error
+    })
+  if (contents === undefined) return empty()
+
+  try {
+    return from(JSON.parse(contents))
+  } catch (error) {
+    if (error instanceof InvalidError) throw error
+    throw new MalformedError(error as Error)
+  }
+}
+
+/** Writes the local journal, or removes it when no mirrors remain. */
+export async function write(state: State, options: Store.Options): Promise<void> {
+  const target = path.join(options.root, file)
+  if (state.mirrors.length === 0) {
+    await fs.rm(target, { force: true })
+    return
+  }
+
+  await fs.mkdir(path.dirname(target), { recursive: true })
+  await fs.writeFile(target, serialize(state), 'utf8')
+}
+
+/** Thrown when the journal is valid JSON but not a supported recovery state. */
+export class InvalidError extends Error {
+  override name = 'Mirrors.InvalidError'
+  code = 'INVALID_SYNC_STATE' as const
+
+  constructor(detail: string) {
+    super(`\`${file}\` is invalid. ${detail}`)
+  }
+}
+
+/** Thrown when the journal is not parseable JSON. */
+export class MalformedError extends Error {
+  override name = 'Mirrors.MalformedError'
+  code = 'MALFORMED_SYNC_STATE' as const
+
+  constructor(cause: Error) {
+    super(`\`${file}\` is not valid JSON.`, { cause })
+  }
+}

--- a/src/Sync.test.ts
+++ b/src/Sync.test.ts
@@ -1,5 +1,6 @@
 import type * as Entry from './Entry.js'
 import * as Github from './Github.js'
+import type * as Mirrors from './Mirrors.js'
 import * as Store from './Store.js'
 import * as Sync from './Sync.js'
 
@@ -29,8 +30,19 @@ function issue(overrides: Partial<Github.Issue> = {}): Github.Issue {
   }
 }
 
-function plan(entries: readonly Entry.Entry[], issues: readonly Github.Issue[]): Sync.Plan {
-  return Sync.plan({ entries, issues, labels, repo, severityLabels })
+function plan(
+  entries: readonly Entry.Entry[],
+  issues: readonly Github.Issue[],
+  mirrors?: readonly Mirrors.Mirror[],
+): Sync.Plan {
+  return Sync.plan({
+    entries,
+    issues,
+    labels,
+    ...(mirrors ? { mirrors } : {}),
+    repo,
+    severityLabels,
+  })
 }
 
 describe('plan', () => {
@@ -89,6 +101,26 @@ describe('plan', () => {
         title: 'Filters ignored',
       },
     ])
+  })
+
+  test('behavior: a remembered path overrides an edited issue marker', () => {
+    const edited = issue({
+      body: Github.renderBody({
+        body: 'Body.',
+        marker: { hash: 'x', origin: 'attacker/repo', path: Store.toPath('redirected') },
+      }),
+    })
+    const mirrors = [{ issue: `${repo}#1`, path: Store.toPath('trusted') }]
+
+    expect(plan([], [edited], mirrors).write.map((entry) => entry.id)).toEqual(['trusted'])
+  })
+
+  test('behavior: restores several remembered paths linked to one issue', () => {
+    const mirrors = [
+      { issue: `${repo}#1`, path: Store.toPath('a') },
+      { issue: `${repo}#1`, path: Store.toPath('b') },
+    ]
+    expect(plan([], [issue()], mirrors).write.map((entry) => entry.id)).toEqual(['a', 'b'])
   })
 
   test('behavior: a rebuilt entry with no extra labels omits them', () => {

--- a/src/Sync.ts
+++ b/src/Sync.ts
@@ -1,5 +1,6 @@
 import type * as Entry from './Entry.js'
 import * as Github from './Github.js'
+import type * as Mirrors from './Mirrors.js'
 import * as Store from './Store.js'
 
 /** Edits that bring local entries back in line with issue state. */
@@ -31,12 +32,20 @@ export type Plan = {
  * @returns The edits to apply. Applying a plan and re-planning yields an empty plan.
  */
 export function plan(options: plan.Options): Plan {
-  const { entries, issues, labels, repo, severityLabels } = options
+  const { entries, issues, labels, mirrors = [], repo, severityLabels } = options
   // Where the files are, which is only the same as where the issues are when reporting to yourself.
   const origin = options.origin ?? repo
 
   const byNumber = new Map(issues.map((issue) => [issue.number, issue]))
   const present = new Set(entries.map((entry) => Store.toPath(entry.id)))
+  const remembered = new Map<number, string[]>()
+  for (const mirror of mirrors) {
+    const link = Github.parseLink(mirror.issue)
+    if (!link || link.repo !== repo) continue
+    const paths = remembered.get(link.issue) ?? []
+    paths.push(mirror.path)
+    remembered.set(link.issue, paths)
+  }
 
   const clearLink: Entry.Entry[] = []
   const remove: string[] = []
@@ -69,17 +78,19 @@ export function plan(options: plan.Options): Plan {
   for (const issue of issues) {
     if (issue.state !== 'open') continue
 
-    // Only an issue frog itself filed can be rebuilt: the marker is what names the file. An issue
-    // somebody labelled by hand is left alone rather than materialized as an entry here.
     const marker = Github.parseMarker(issue.body)
-    if (!marker?.path) continue
-    // The marker names the repository holding the file, so this compares against `origin`. Comparing
-    // against `repo` would refuse to rebuild any file mirroring an upstream issue.
-    if (marker.origin && marker.origin !== origin) continue
-    if (present.has(marker.path)) continue
+    const paths = remembered.get(issue.number) ?? (marker?.path ? [marker.path] : [])
+    for (const path of paths) {
+      // Without a remembered binding, only an issue frog itself filed can be rebuilt. The marker
+      // names the repository holding the file, so compare it against `origin`, not the issue repo.
+      if (!remembered.has(issue.number) && marker?.origin && marker.origin !== origin) continue
+      if (present.has(path)) continue
 
-    const id = Store.toId(marker.path)
-    if (id) write.push(Github.fromIssue(issue, { id, labels, repo, severityLabels }))
+      const id = Store.toId(path)
+      if (!id) continue
+      write.push(Github.fromIssue(issue, { id, labels, repo, severityLabels }))
+      present.add(path)
+    }
   }
 
   return { clearLink, remove, write }
@@ -94,6 +105,8 @@ export declare namespace plan {
     issues: readonly Github.Issue[]
     /** Labels applied to every issue, from config. */
     labels: readonly string[]
+    /** Trusted issue-to-path bindings remembered when mirrors were deleted. */
+    mirrors?: readonly Mirrors.Mirror[] | undefined
     /**
      * Repository holding the entries, as `owner/name`. Defaults to `repo`.
      *
@@ -126,18 +139,21 @@ export function empty(plan: Plan): boolean {
  * @returns Every issue relevant to reconciling `repo`, listing plus confirmations.
  */
 export async function state(options: state.Options): Promise<readonly Github.Issue[]> {
-  const { entries, get, list, repo } = options
+  const { entries, get, list, remembered = [], repo } = options
 
   const listed = await list()
   const known = new Set(listed.map((issue) => issue.number))
 
   const unlisted = [
     ...new Set(
-      entries
-        .map((entry) => (entry.issue ? Github.parseLink(entry.issue) : undefined))
-        .filter((link) => link && link.repo === repo && !known.has(link.issue))
-        .map((link) => link?.issue)
-        .filter((issue): issue is number => issue !== undefined),
+      [
+        ...entries
+          .map((entry) => (entry.issue ? Github.parseLink(entry.issue) : undefined))
+          .filter((link) => link && link.repo === repo)
+          .map((link) => link?.issue)
+          .filter((issue): issue is number => issue !== undefined),
+        ...remembered,
+      ].filter((issue) => !known.has(issue)),
     ),
   ]
 
@@ -154,6 +170,8 @@ export declare namespace state {
     get: (issue: number) => Promise<Github.Issue | undefined>
     /** Lists the issues frog manages in `repo`. */
     list: () => Promise<readonly Github.Issue[]>
+    /** Issue numbers remembered after their final local mirrors were removed. */
+    remembered?: readonly number[] | undefined
     /** Repository being reconciled, as `owner/name`. */
     repo: string
   }

--- a/src/Target.test.ts
+++ b/src/Target.test.ts
@@ -133,6 +133,26 @@ describe('resolve', () => {
       )
       expect(result.ok === false && result.code).toBe('TARGET_NOT_ACCEPTING')
     })
+
+    test('error: rejects a repository target with extra path segments before lookup', async () => {
+      let looked = false
+      const result = await Target.resolve(
+        'wevm/viem/tree/main',
+        options({
+          allowedRepos: ['wevm/*'],
+          readConfig: async () => {
+            looked = true
+            return { enabled: true }
+          },
+        }),
+      )
+      expect(result).toEqual({
+        code: 'TARGET_UNKNOWN',
+        message: '`wevm/viem/tree/main` is not a repository. Name it as `owner/name`.',
+        ok: false,
+      })
+      expect(looked).toBe(false)
+    })
   })
 
   describe('urls', () => {

--- a/src/Target.ts
+++ b/src/Target.ts
@@ -3,6 +3,8 @@ import * as Config from './Config.js'
 /** How a target was named. */
 export type Kind = 'npm' | 'repo'
 
+const repoPattern = /^[\w.-]+\/[\w.-]+$/
+
 /**
  * How a target string names a repository.
  *
@@ -153,7 +155,14 @@ async function locate(
     }
 
   const { kind, name } = classify(value)
-  if (kind === 'repo') return { kind, ok: true, repo: name }
+  if (kind === 'repo') {
+    if (repoPattern.test(name)) return { kind, ok: true, repo: name }
+    return {
+      code: 'TARGET_UNKNOWN',
+      message: `\`${name}\` is not a repository. Name it as \`owner/name\`.`,
+      ok: false,
+    }
+  }
 
   const repo = await options.readRepo(name)
   if (repo) return { kind, ok: true, repo }

--- a/src/cli/commands/log.ts
+++ b/src/cli/commands/log.ts
@@ -74,7 +74,9 @@ export const log = Cli.create('log', {
       .string()
       .min(1)
       .optional()
-      .describe('Upstream package, `owner/repo`, or host. Omit for this repository.'),
+      .describe(
+        'Upstream npm package or GitHub repository as `owner/repo`. Omit for this repository.',
+      ),
   }),
   alias: { body: 'b', severity: 's', target: 't' },
   usage: [{}, { args: { title: true }, options: { body: true } }, { prefix: 'cat entry.md |' }],

--- a/src/cli/commands/publish.test.ts
+++ b/src/cli/commands/publish.test.ts
@@ -158,6 +158,27 @@ test('behavior: defers entries over the ceiling', async () => {
   expect(instance.issues.get(repo)).toHaveLength(2)
 })
 
+test('behavior: a refused entry does not consume the ceiling', async () => {
+  const cwd = await helpers.repo({ remote })
+  const instance = await github()
+  await Store.write(
+    { body, severity: 'minor', target: 'missing', title: 'Cannot resolve' },
+    { id: 'a', root: cwd },
+  )
+  await Store.write({ body, severity: 'minor', title: 'Can file' }, { id: 'b', root: cwd })
+
+  const result = await cli.data<Outcome>(['publish', '--cwd', cwd, '--max', '1'], env(instance.url))
+
+  expect(result.created).toEqual([{ id: 'b', issue: `${repo}#1` }])
+  expect(result.deferred).toEqual([
+    {
+      id: 'a',
+      reason:
+        '`missing` is not installed, or declares no GitHub repository. Name the repository instead, as `owner/name`.',
+    },
+  ])
+})
+
 describe('cross-repo', () => {
   const upstream = 'wevm/viem'
 

--- a/src/cli/commands/publish.ts
+++ b/src/cli/commands/publish.ts
@@ -75,11 +75,7 @@ export const publish = Cli.create('publish', {
     const pending = entries.value.filter((entry) => !entry.issue)
 
     const max = c.options.max ?? config.maxPerRun
-    for (const entry of pending.slice(max))
-      deferred.push({ id: entry.id, reason: `over the ceiling of ${max} per run` })
-    const publishable = pending.slice(0, max)
-
-    if (publishable.length === 0)
+    if (pending.length === 0)
       return c.ok({ commented: [], committed: false, created: [], deferred, unlabelled: [] })
 
     const ready = await publisher.prepare({
@@ -109,7 +105,8 @@ export const publish = Cli.create('publish', {
     type Group = { entries: Entry.Entry[]; labels?: readonly string[] | undefined }
     const groups = new Map<string, Group>()
 
-    for (const entry of publishable) {
+    let accepted = 0
+    for (const entry of pending) {
       const resolution = await attempt(Target.resolve(entry.target, resolvers))
       if (!resolution.ok) {
         deferred.push({ id: entry.id, reason: resolution.message })
@@ -119,6 +116,11 @@ export const publish = Cli.create('publish', {
         deferred.push({ id: entry.id, reason: resolution.value.message })
         continue
       }
+      if (accepted >= max) {
+        deferred.push({ id: entry.id, reason: `over the ceiling of ${max} per run` })
+        continue
+      }
+      accepted += 1
 
       const { labels, repo: destination } = resolution.value.target
       const group = groups.get(destination) ?? {

--- a/src/cli/commands/publish.ts
+++ b/src/cli/commands/publish.ts
@@ -168,7 +168,7 @@ export const publish = Cli.create('publish', {
       if (!(c.options.commit ?? config.commit) || c.options.dryRun || written.length === 0)
         return false
       await Git.add(written, { cwd: root })
-      return Git.commit('chore: link friction log to issues', { cwd: root })
+      return Git.commit('chore: link friction log to issues', { cwd: root, files: written })
     })()
 
     return c.ok(

--- a/src/cli/commands/sync.test.ts
+++ b/src/cli/commands/sync.test.ts
@@ -2,6 +2,7 @@ import * as cli from '../../../test/cli.js'
 import { github } from '../../../test/github.js'
 import * as helpers from '../../../test/helpers.js'
 import * as Github from '../../Github.js'
+import * as Mirrors from '../../Mirrors.js'
 import * as Store from '../../Store.js'
 
 const repo = 'wevm/demo'
@@ -80,7 +81,7 @@ test('behavior: closing takes the committed reproduction with it', async () => {
   // Gone from disk and from the index: a staged artifact left behind would show up here.
   expect(await Store.files('a', { root: cwd })).toEqual([])
   expect(await helpers.git(['status', '--porcelain'], cwd)).toBe('')
-  expect(await helpers.git(['ls-files', Store.dir], cwd)).toBe('')
+  expect(await helpers.git(['ls-files', Store.dir], cwd)).toBe(Mirrors.file)
 })
 
 test('behavior: deletes an entry that was never committed', async () => {
@@ -194,6 +195,7 @@ test('behavior: --dry-run changes nothing', async () => {
 
   expect(result).toMatchObject({ committed: false, removed: ['a'] })
   expect(await Store.list({ root: cwd })).toEqual(['a'])
+  expect(await Mirrors.resolve({ root: cwd })).toEqual(Mirrors.empty())
 })
 
 test('behavior: --no-commit leaves the change uncommitted', async () => {
@@ -249,6 +251,34 @@ describe('cross-repo', () => {
     expect(await Store.list({ root: cwd })).toEqual([])
   })
 
+  test('behavior: restores the final unlabelled upstream mirror after reopening', async () => {
+    const cwd = await helpers.repo({ remote })
+    await Store.write(
+      { body: 'Body.', issue: `${upstream}#1`, severity: 'minor', target: 'viem', title },
+      { id: 'a', root: cwd },
+    )
+    await helpers.commit('log friction', cwd)
+    const instance = await github({
+      [upstream]: [{ body: upstreamBody(), labels: [], state: 'closed', title }],
+    })
+
+    const closed = await cli.data<Outcome>(['sync', '--cwd', cwd], env(instance.url))
+    expect(closed.removed).toEqual(['a'])
+    expect((await Mirrors.resolve({ root: cwd })).mirrors).toEqual([
+      { issue: `${upstream}#1`, path: Store.toPath('a') },
+    ])
+
+    const issue = instance.issues.get(upstream)?.[0]
+    if (issue) issue.state = 'open'
+    const reopened = await cli.data<Outcome>(['sync', '--cwd', cwd], env(instance.url))
+    expect(reopened.updated).toEqual(['a'])
+    expect((await Store.get('a', { root: cwd })).issue).toBe(`${upstream}#1`)
+    expect(await Mirrors.resolve({ root: cwd })).toEqual(Mirrors.empty())
+
+    const third = await cli.data<Outcome>(['sync', '--cwd', cwd], env(instance.url))
+    expect(third).toMatchObject({ cleared: [], committed: false, removed: [], updated: [] })
+  })
+
   test('behavior: an open upstream issue leaves the entry alone', async () => {
     const { cwd, instance } = await reporting('open')
 
@@ -270,6 +300,25 @@ describe('cross-repo', () => {
 
     expect(result.cleared).toEqual(['a'])
     expect((await Store.get('a', { root: cwd })).issue).toBeUndefined()
+  })
+
+  test('behavior: forgets a remembered issue that no longer exists', async () => {
+    const cwd = await helpers.repo({ remote })
+    await helpers.writeFile('README.md', '# demo\n', cwd)
+    await Mirrors.write(
+      Mirrors.update(Mirrors.empty(), {
+        remember: [{ issue: `${upstream}#9`, path: Store.toPath('a') }],
+      }),
+      { root: cwd },
+    )
+    await helpers.commit('remember mirror', cwd)
+    const instance = await github()
+
+    const result = await cli.data<Outcome>(['sync', '--cwd', cwd], env(instance.url))
+
+    expect(result.committed).toBe(true)
+    expect(await Mirrors.resolve({ root: cwd })).toEqual(Mirrors.empty())
+    expect(await helpers.git(['status', '--porcelain'], cwd)).toBe('')
   })
 
   test('behavior: reconciles this repository and an upstream one in one pass', async () => {

--- a/src/cli/commands/sync.ts
+++ b/src/cli/commands/sync.ts
@@ -134,7 +134,10 @@ export const sync = Cli.create('sync', {
     const committed = await (async () => {
       if (!(c.options.commit ?? config.commit)) return false
       await Git.add(touched, { cwd: root })
-      return Git.commit('chore: sync friction log', { cwd: root })
+      return Git.commit('chore: sync friction log', {
+        cwd: root,
+        files: [...removed.map(Store.toDir), ...touched],
+      })
     })()
 
     return c.ok(

--- a/src/cli/commands/sync.ts
+++ b/src/cli/commands/sync.ts
@@ -1,6 +1,7 @@
 import { Cli, z } from 'incur'
 import * as Git from '../../Git.js'
 import * as Github from '../../Github.js'
+import * as Mirrors from '../../Mirrors.js'
 import * as Store from '../../Store.js'
 import * as Sync from '../../Sync.js'
 import { attempt } from '../internal/attempt.js'
@@ -48,6 +49,8 @@ export const sync = Cli.create('sync', {
 
     const entries = await attempt(Store.read({ root }))
     if (!entries.ok) return c.error({ code: entries.code, message: entries.message })
+    const mirrors = await attempt(Mirrors.resolve({ root }))
+    if (!mirrors.ok) return c.error({ code: mirrors.code, message: mirrors.message })
 
     const ready = await publisher.prepare({
       config,
@@ -73,16 +76,26 @@ export const sync = Cli.create('sync', {
         ...entries.value
           .map((entry) => (entry.issue ? Github.parseLink(entry.issue)?.repo : undefined))
           .filter((repo): repo is string => repo !== undefined),
+        ...mirrors.value.mirrors
+          .map((mirror) => Github.parseLink(mirror.issue)?.repo)
+          .filter((repo): repo is string => repo !== undefined),
       ]),
     ]
 
     const plans: Sync.Plan[] = []
+    const forget: Mirrors.Mirror[] = []
     for (const destination of destinations) {
+      const remembered = mirrors.value.mirrors.filter(
+        (mirror) => Github.parseLink(mirror.issue)?.repo === destination,
+      )
       const issues = await attempt(
         Sync.state({
           entries: entries.value,
           get: (issue) => Github.get(ready.client, { issue, repo: destination }),
           list: () => Github.list(ready.client, { label: ready.label, repo: destination }),
+          remembered: remembered
+            .map((mirror) => Github.parseLink(mirror.issue)?.issue)
+            .filter((issue): issue is number => issue !== undefined),
           repo: destination,
         }),
       )
@@ -100,10 +113,19 @@ export const sync = Cli.create('sync', {
           entries: entries.value,
           issues: issues.value,
           labels: config.labels,
+          mirrors: remembered,
           // The files are always here, whichever repository the issues are in.
           origin: ready.repo,
           repo: destination,
           severityLabels: config.severityLabels,
+        }),
+      )
+
+      const found = new Set(issues.value.map((issue) => issue.number))
+      forget.push(
+        ...remembered.filter((mirror) => {
+          const link = Github.parseLink(mirror.issue)
+          return Boolean(link && !found.has(link.issue))
         }),
       )
     }
@@ -118,7 +140,22 @@ export const sync = Cli.create('sync', {
     const removed = [...new Set(plan.remove)]
     const updated = plan.write.map((entry) => entry.id)
 
-    if (c.options.dryRun || Sync.empty(plan))
+    const byId = new Map(entries.value.map((entry) => [entry.id, entry]))
+    const remember: Mirrors.Mirror[] = []
+    for (const id of removed) {
+      const entry = byId.get(id)
+      if (entry?.issue) remember.push({ issue: entry.issue, path: Store.toPath(entry.id) })
+    }
+    forget.push(
+      ...plan.write
+        .filter((entry): entry is typeof entry & { issue: string } => Boolean(entry.issue))
+        .map((entry) => ({ issue: entry.issue, path: Store.toPath(entry.id) })),
+    )
+
+    const nextMirrors = Mirrors.update(mirrors.value, { forget, remember })
+    const mirrorsChanged = Mirrors.serialize(nextMirrors) !== Mirrors.serialize(mirrors.value)
+
+    if (c.options.dryRun || (Sync.empty(plan) && !mirrorsChanged))
       return c.ok({ cleared, committed: false, removed, updated })
 
     // Staged before unlinking, so tracked entries have their deletion recorded. The whole directory
@@ -129,8 +166,10 @@ export const sync = Cli.create('sync', {
 
     for (const entry of [...plan.write, ...plan.clearLink])
       await Store.write(entry, { id: entry.id, root })
+    if (mirrorsChanged) await Mirrors.write(nextMirrors, { root })
 
     const touched = [...plan.write, ...plan.clearLink].map((entry) => Store.toPath(entry.id))
+    if (mirrorsChanged) touched.push(Mirrors.file)
     const committed = await (async () => {
       if (!(c.options.commit ?? config.commit)) return false
       await Git.add(touched, { cwd: root })

--- a/src/cli/commands/targets.test.ts
+++ b/src/cli/commands/targets.test.ts
@@ -204,6 +204,29 @@ test('behavior: a repository that accepts nothing is not re-asked', async () => 
   expect(instance.requests.length).toBe(first)
 })
 
+test('behavior: a transient config failure is not cached as rejection', async () => {
+  const cwd = await helpers.repo()
+  await declare(cwd, { viem: '^2.0.0' })
+  await install(cwd, 'viem', { repository: 'https://github.com/wevm/viem' })
+
+  const errors: Record<string, number> = { 'wevm/viem': 503 }
+  const instance = await github(
+    {},
+    {
+      errors,
+      files: { 'wevm/viem': { [Config.file]: config(true) } },
+    },
+  )
+  const cache = await helpers.tmpdir()
+
+  const first = await cli.data<Listed>(['targets', '--cwd', cwd], env(instance.url, cache))
+  expect(first.targets).toEqual([])
+
+  delete errors['wevm/viem']
+  const second = await cli.data<Listed>(['targets', '--cwd', cwd], env(instance.url, cache))
+  expect(second.targets).toEqual([{ name: 'viem', repo: 'wevm/viem' }])
+})
+
 test('behavior: one repository behind several packages is asked about once', async () => {
   const cwd = await helpers.repo()
   await declare(cwd, { '@changesets/cli': '^2.0.0', '@changesets/config': '^3.0.0' })

--- a/src/cli/commands/targets.test.ts
+++ b/src/cli/commands/targets.test.ts
@@ -75,6 +75,24 @@ test('behavior: lists dependencies whose repositories accept reports', async () 
   `)
 })
 
+test('behavior: includes optional dependencies', async () => {
+  const cwd = await helpers.repo()
+  await helpers.writeFile(
+    'package.json',
+    JSON.stringify({ name: 'app', optionalDependencies: { viem: '^2.0.0' } }),
+    cwd,
+  )
+  await install(cwd, 'viem', { repository: 'https://github.com/wevm/viem' })
+
+  const instance = await github({}, { files: { 'wevm/viem': { [Config.file]: config(true) } } })
+  const result = await cli.data<Listed>(
+    ['targets', '--cwd', cwd],
+    env(instance.url, await helpers.tmpdir()),
+  )
+
+  expect(result.targets).toEqual([{ name: 'viem', repo: 'wevm/viem' }])
+})
+
 test('behavior: a dependency declaring no GitHub repository is skipped without a lookup', async () => {
   const cwd = await helpers.repo()
   await declare(cwd, { private: '^1.0.0' })

--- a/src/cli/commands/targets.test.ts
+++ b/src/cli/commands/targets.test.ts
@@ -28,8 +28,8 @@ async function declare(cwd: string, dependencies: Record<string, string>): Promi
 }
 
 /** A repository that has committed its consent, or opted out. */
-function config(enabled: boolean): string {
-  return JSON.stringify({ inbound: { enabled } })
+function config(enabled: boolean, allowFrom?: readonly string[]): string {
+  return JSON.stringify({ inbound: { enabled, ...(allowFrom ? { allowFrom } : {}) } })
 }
 
 function env(url: string, cache: string): Record<string, string> {
@@ -85,6 +85,29 @@ test('behavior: includes optional dependencies', async () => {
   await install(cwd, 'viem', { repository: 'https://github.com/wevm/viem' })
 
   const instance = await github({}, { files: { 'wevm/viem': { [Config.file]: config(true) } } })
+  const result = await cli.data<Listed>(
+    ['targets', '--cwd', cwd],
+    env(instance.url, await helpers.tmpdir()),
+  )
+
+  expect(result.targets).toEqual([{ name: 'viem', repo: 'wevm/viem' }])
+})
+
+test('behavior: applies each receiver allowFrom policy', async () => {
+  const cwd = await helpers.repo({ remote: 'https://github.com/acme/app' })
+  await declare(cwd, { ox: '^1.0.0', viem: '^2.0.0' })
+  await install(cwd, 'ox', { repository: 'https://github.com/wevm/ox' })
+  await install(cwd, 'viem', { repository: 'https://github.com/wevm/viem' })
+
+  const instance = await github(
+    {},
+    {
+      files: {
+        'wevm/ox': { [Config.file]: config(true, ['other/*']) },
+        'wevm/viem': { [Config.file]: config(true, ['acme/*']) },
+      },
+    },
+  )
   const result = await cli.data<Listed>(
     ['targets', '--cwd', cwd],
     env(instance.url, await helpers.tmpdir()),

--- a/src/cli/commands/targets.ts
+++ b/src/cli/commands/targets.ts
@@ -31,7 +31,7 @@ export const targets = Cli.create('targets', {
     ),
   }),
   async run(c) {
-    const { root } = await context.resolve({ cwd: c.options.cwd })
+    const { repo, root } = await context.resolve({ cwd: c.options.cwd })
 
     // Consent lives on the target repository, so this needs a client. Unauthenticated works, at 60
     // requests an hour, which the day-long cache is what keeps within reach.
@@ -45,7 +45,7 @@ export const targets = Cli.create('targets', {
     })
 
     const found = await attempt(
-      target.accepting({ client, root, store: cache.file(cache.dir(c.env)) }),
+      target.accepting({ client, root, self: repo, store: cache.file(cache.dir(c.env)) }),
     )
     if (!found.ok) return c.error({ code: found.code, message: found.message })
 

--- a/src/cli/internal/target.ts
+++ b/src/cli/internal/target.ts
@@ -63,9 +63,7 @@ export function reader(
     }
 
     const inbound = await (async () => {
-      const contents = await GithubModule.fetchFile(client, { path: Config.file, repo }).catch(
-        () => undefined,
-      )
+      const contents = await GithubModule.fetchFile(client, { path: Config.file, repo })
       if (!contents) return undefined
       try {
         return Config.from(JSON.parse(contents)).inbound

--- a/src/cli/internal/target.ts
+++ b/src/cli/internal/target.ts
@@ -119,6 +119,7 @@ export async function accepting(options: accepting.Options): Promise<readonly Ac
     ...new Set([
       ...Object.keys(own?.dependencies ?? {}),
       ...Object.keys(own?.devDependencies ?? {}),
+      ...Object.keys(own?.optionalDependencies ?? {}),
       ...Object.keys(own?.peerDependencies ?? {}),
     ]),
   ].sort()
@@ -165,6 +166,7 @@ type Dependencies = {
   dependencies?: Record<string, string> | undefined
   devDependencies?: Record<string, string> | undefined
   homepage?: string | undefined
+  optionalDependencies?: Record<string, string> | undefined
   peerDependencies?: Record<string, string> | undefined
   repository?: { url?: string | undefined } | string | undefined
 }

--- a/src/cli/internal/target.ts
+++ b/src/cli/internal/target.ts
@@ -108,7 +108,7 @@ export type Accepting = {
  * reports.
  */
 export async function accepting(options: accepting.Options): Promise<readonly Accepting[]> {
-  const { client, root, store } = options
+  const { client, root, self, store } = options
 
   const own = await fs
     .readFile(path.join(root, 'package.json'), 'utf8')
@@ -142,7 +142,8 @@ export async function accepting(options: accepting.Options): Promise<readonly Ac
     const batch = repos.slice(index, index + concurrency)
     const inbounds = await Promise.all(batch.map((repo) => read(repo).catch(() => undefined)))
     batch.forEach((repo, offset) => {
-      if (inbounds[offset]?.enabled) accepts.add(repo)
+      const inbound = inbounds[offset]
+      if (inbound && Config.allows(inbound, self)) accepts.add(repo)
     })
   }
 
@@ -156,6 +157,8 @@ export declare namespace accepting {
     client: Github.Client
     /** Repository root, holding `package.json` and `node_modules`. */
     root: string
+    /** This repository, as `owner/name`, for applying each receiver's `allowFrom` policy. */
+    self: string | undefined
     /** Where to keep config lookups. Absent reads fresh every time. */
     store?: Cache.Cache | undefined
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,9 @@ export * as Git from './Git.js'
 /** Issue rendering, the dedupe marker, and create-or-comment. Transport-agnostic. */
 export * as Github from './Github.js'
 
+/** Recovery records for entries removed when their mirrored issues close. */
+export * as Mirrors from './Mirrors.js'
+
 /** Reading and writing entries under `.agents/friction-log`. */
 export * as Store from './Store.js'
 

--- a/test/github.ts
+++ b/test/github.ts
@@ -222,6 +222,15 @@ export async function github(seed: Seed = {}, options: Options = {}): Promise<In
         return json(response, 200, found)
       }
 
+      if (one && request.method === 'PATCH') {
+        const repo = `${one[1]}/${one[2]}`
+        const found = (issues.get(repo) ?? []).find((issue) => issue.number === Number(one[3]))
+        if (!found) return json(response, 404, { message: 'Not Found' })
+        const payload = await readBody<{ state?: 'closed' | 'open' }>(request)
+        if (payload.state) found.state = payload.state
+        return json(response, 200, found)
+      }
+
       if (list && request.method === 'GET') {
         const repo = `${list[1]}/${list[2]}`
         const label = url.searchParams.get('labels')

--- a/test/github.ts
+++ b/test/github.ts
@@ -277,10 +277,12 @@ export async function github(seed: Seed = {}, options: Options = {}): Promise<In
       if (comment && request.method === 'GET') {
         const key = `${comment[1]}/${comment[2]}#${comment[3]}`
         const listed = comments.filter((entry) => entry.key === key)
+        const page = Number(url.searchParams.get('page') ?? '1')
+        const perPage = Number(url.searchParams.get('per_page') ?? '30')
         return json(
           response,
           200,
-          listed.map(({ body, id }) => ({ body, id })),
+          listed.slice((page - 1) * perPage, page * perPage).map(({ body, id }) => ({ body, id })),
         )
       }
 

--- a/test/github.ts
+++ b/test/github.ts
@@ -86,6 +86,8 @@ export type Options = {
    * The App has no `node_modules`, so it resolves a package to its repository through the registry.
    */
   packages?: Record<string, string> | undefined
+  /** Registry packages that respond with an error status. */
+  registryErrors?: Record<string, number> | undefined
   /**
    * Repositories the token has push access to. `undefined` means all of them.
    *
@@ -170,8 +172,9 @@ export async function github(seed: Seed = {}, options: Options = {}): Promise<In
       const comment = /^\/repos\/([^/]+)\/([^/]+)\/issues\/(\d+)\/comments$/.exec(url.pathname)
       const one = /^\/repos\/([^/]+)\/([^/]+)\/issues\/(\d+)$/.exec(url.pathname)
       const repository = /^\/repos\/([^/]+)\/([^/]+)$/.exec(url.pathname)
+      const contents = /^\/repos\/([^/]+)\/([^/]+)\/contents\/(.*)$/.exec(url.pathname)
 
-      const owned = list ?? comment ?? one ?? repository
+      const owned = list ?? comment ?? one ?? repository ?? contents
       const status = owned ? errors[`${owned[1]}/${owned[2]}`] : undefined
       if (status) return json(response, status, { message: 'Not Found' })
 
@@ -179,6 +182,8 @@ export async function github(seed: Seed = {}, options: Options = {}): Promise<In
       const registry = /^\/registry\/(.+)\/latest$/.exec(url.pathname)
       if (registry && request.method === 'GET') {
         const name = decodeURIComponent(registry[1] ?? '')
+        const status = options.registryErrors?.[name]
+        if (status) return json(response, status, { message: 'Registry error' })
         const declared = options.packages?.[name]
         if (declared === undefined) return json(response, 404, { message: 'Not Found' })
         return json(response, 200, { name, repository: `https://github.com/${declared}` })
@@ -281,7 +286,6 @@ export async function github(seed: Seed = {}, options: Options = {}): Promise<In
       }
 
       // `repos.getContent`, for reading entries and config without cloning.
-      const contents = /^\/repos\/([^/]+)\/([^/]+)\/contents\/(.*)$/.exec(url.pathname)
       if (contents && request.method === 'GET') {
         const name = `${contents[1]}/${contents[2]}`
         const path = decodeURIComponent(contents[3] ?? '')


### PR DESCRIPTION
Harden target authorization, dependency discovery, publishing, mirror recovery, and webhook delivery. This prevents malformed configuration, transient API failures, replayed events, and stale synchronization from losing or misrouting friction records.