### PR TITLE
fix: repeat issue comments, and reshape the entry template

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -47,26 +47,27 @@ Pipe the entry in, shaped like a commit message: the first line is the title, th
 frog log --publish --severity major <<'EOF'
 `pnpm test -- <files>` ignores file filters and runs the whole suite
 
-## Description
+## Expected Behavior
+
+The filter reaches the runner, as `pnpm test --help` and every other script in the repo imply.
+
+## Current Behavior
 
 `pnpm test -- src/foo.test.ts` ran all 1,200 tests. The `--` is consumed by pnpm, so the filter never
 reaches Vitest, and nothing warns.
 
-## Expectation
-
-The filter reaches the runner, as `pnpm test --help` and every other script in the repo imply.
-
-## Steps to reproduce
-
-`pnpm test -- src/foo.test.ts` in a fresh checkout.
-
-## Minimal reproducible example
-
-See `artifacts/`.
-
-## Suggestion
+## Possible Solution
 
 Forward arguments past `--`, or document `pnpm exec vitest run <files>` in the script help.
+
+## Minimal Reproducible Example
+
+`pnpm test -- src/foo.test.ts` in a fresh checkout. See `artifacts/run.sh`.
+
+## Context
+
+Every targeted test run in CI silently became a full run, so a 20 second check took 6 minutes and nobody
+noticed until the bill.
 EOF
 ```
 
@@ -133,7 +134,7 @@ Name the exact failure, so it is searchable. Say what you did instead. Suggest t
 > `@effect/vitest`'s `layer(...)` merges `TestClock` by default, which stalls the real `@effect/sql-pg`
 > pool timers, so every test dies with "All fibers interrupted without error".
 >
-> **Expectation:** a layer providing real services keeps real timers.
+> **Expected:** a layer providing real services keeps real timers.
 >
 > **Reproduction:** `artifacts/pool.test.ts`, which fails on `pnpm vitest run`.
 >

--- a/app/README.md
+++ b/app/README.md
@@ -13,11 +13,11 @@ friction is resolved. A workflow cannot observe that at all on another repositor
 
 ## What each event does
 
-| Event                                        | Behavior                                                                                                   |
-| -------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| `pull_request` opened, reopened, synchronize | Files the entries the pull request introduces. Posts or updates one comment. Writes nothing to the branch. |
-| `push` to the default branch                 | Files anything still pending and commits the `issue:` links.                                               |
-| `issues` closed, reopened, edited            | Reconciles the files mirroring that issue, in whichever repository holds them.                             |
+| Event                                        | Behavior                                                                                                                                                                                     |
+| -------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `pull_request` opened, reopened, synchronize | Files the entries the pull request adds or edits, comparing its head against its base. Posts or updates one comment, and none at all when it changes no entry. Writes nothing to the branch. |
+| `push` to the default branch                 | Files anything still pending and commits the `issue:` links.                                                                                                                                 |
+| `issues` closed, reopened, edited            | Reconciles the files mirroring that issue, in whichever repository holds them.                                                                                                               |
 
 The head commit is read from the **base** repository, which GitHub makes it reachable from. That is what
 lets a fork's entries be read without the installation having any access to the fork.

--- a/app/scripts/private-key.sh
+++ b/app/scripts/private-key.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+#
+# Converts a GitHub App private key to the format the Worker can use, and optionally stores it.
+#
+# GitHub hands out PKCS#1 (`BEGIN RSA PRIVATE KEY`). WebCrypto, which is all a Worker has, only reads
+# PKCS#8 (`BEGIN PRIVATE KEY`), so the App fails per delivery with "Private Key is in PKCS#1 format".
+#
+# Usage:
+#   ./private-key.sh <key.pem>            convert, write <key>.pkcs8.pem
+#   ./private-key.sh <key.pem> --set      also store it as the FROG_PRIVATE_KEY repository secret
+set -euo pipefail
+
+key=${1:-}
+if [[ -z $key || ! -f $key ]]; then
+  echo "usage: $0 <path-to-github-app-key.pem> [--set]" >&2
+  exit 1
+fi
+
+out=${key%.pem}.pkcs8.pem
+
+case $(head -1 "$key") in
+  *"BEGIN RSA PRIVATE KEY"*)
+    openssl pkcs8 -topk8 -inform PEM -outform PEM -nocrypt -in "$key" -out "$out"
+    echo "converted PKCS#1 -> PKCS#8: $out"
+    ;;
+  *"BEGIN PRIVATE KEY"*)
+    cp "$key" "$out"
+    echo "already PKCS#8, copied: $out"
+    ;;
+  *)
+    echo "not a PEM private key: $key" >&2
+    exit 1
+    ;;
+esac
+
+# Prove the result is a key the Worker can load, without printing any of it.
+openssl pkey -in "$out" -noout -check >/dev/null
+chmod 600 "$out"
+echo "verified, and readable only by you"
+
+if [[ ${2:-} == "--set" ]]; then
+  gh secret set FROG_PRIVATE_KEY --repo wevm/frog < "$out"
+  echo "stored as the FROG_PRIVATE_KEY secret on wevm/frog"
+fi

--- a/app/src/handlers/pullRequest.test.ts
+++ b/app/src/handlers/pullRequest.test.ts
@@ -109,19 +109,54 @@ test('behavior: nothing written back to the pull request branch', async () => {
   expect(instance.files(base)[`${dir}/a/friction.md`]).not.toContain('issue:')
 })
 
-// Every push to the branch re-runs this.
+// Every push to the branch re-runs this, and each one is a separate delivery.
 test('behavior: a second run opens no issue and adds no comment', async () => {
   const instance = await github(
     {},
     { files: { [base]: { [`${dir}/a/friction.md`]: entry('Filters ignored') } } },
   )
 
-  await run(instance.url)
-  const second = await run(instance.url)
+  await run(instance.url, { delivery: 'delivery-1' })
+  const second = await run(instance.url, { delivery: 'delivery-2' })
 
-  expect(second.commented).toEqual([{ id: 'a', issue: `${base}#1` }])
+  expect(second.created).toEqual([{ id: 'a', issue: `${base}#1` }])
   expect(instance.issues.get(base)).toHaveLength(1)
+  // The issue itself stays quiet. Keying the occurrence on the delivery instead of on what is being
+  // reported put a "Hit again" here for every push to an untouched entry.
+  expect(instance.comments(base, 1)).toHaveLength(0)
   expect(instance.comments(base, 42)).toHaveLength(1)
+})
+
+test('behavior: many pushes to one pull request leave one issue and no comments', async () => {
+  const instance = await github(
+    {},
+    { files: { [base]: { [`${dir}/a/friction.md`]: entry('Filters ignored') } } },
+  )
+
+  for (const delivery of ['one', 'two', 'three', 'four']) await run(instance.url, { delivery })
+
+  expect(instance.issues.get(base)).toHaveLength(1)
+  expect(instance.comments(base, 1)).toHaveLength(0)
+})
+
+// The one repeat worth having: the entry changed, so the issue should hear about it.
+test('behavior: an edited entry comments once', async () => {
+  const instance = await github(
+    {},
+    { files: { [base]: { [`${dir}/a/friction.md`]: entry('Filters ignored') } } },
+  )
+
+  await run(instance.url, { delivery: 'delivery-1' })
+  instance.write(
+    base,
+    `${dir}/a/friction.md`,
+    entry('Filters ignored').replace('swallowed', 'dropped'),
+  )
+  await run(instance.url, { delivery: 'delivery-2' })
+  await run(instance.url, { delivery: 'delivery-3' })
+
+  expect(instance.issues.get(base)).toHaveLength(1)
+  expect(instance.comments(base, 1)).toHaveLength(1)
 })
 
 test('behavior: concurrent deliveries with the same title open one issue', async () => {
@@ -137,7 +172,7 @@ test('behavior: concurrent deliveries with the same title open one issue', async
   ])
 
   expect(instance.issues.get(base)).toHaveLength(1)
-  expect(instance.comments(base, 1)).toHaveLength(1)
+  expect(instance.comments(base, 1)).toHaveLength(0)
   expect(instance.comments(base, 42)).toHaveLength(1)
 })
 

--- a/app/src/handlers/pullRequest.test.ts
+++ b/app/src/handlers/pullRequest.test.ts
@@ -184,6 +184,29 @@ test('behavior: an edited entry comments once', async () => {
   expect(instance.comments(base, 1)).toHaveLength(1)
 })
 
+// The edit that a title-shaped hash would have thrown away: punctuation and case only. Adding the `--`
+// a command was missing changes what the report means, so the issue has to hear about it.
+test('behavior: an edit of only punctuation still comments', async () => {
+  const instance = await github(
+    {},
+    { head: { [base]: { [`${dir}/a/friction.md`]: entry('Filters ignored') } } },
+  )
+
+  // Same words either side. Only the `--` differs, which a title-shaped hash discards.
+  const before = entry('Filters ignored').replace(
+    'The filter was swallowed.',
+    'Run `pnpm test src/foo.test.ts`.',
+  )
+  const after = before.replace('pnpm test src', 'pnpm test -- src')
+
+  instance.write(base, `${dir}/a/friction.md`, before, 'head')
+  await run(instance.url, { delivery: 'delivery-1' })
+  instance.write(base, `${dir}/a/friction.md`, after, 'head')
+  await run(instance.url, { delivery: 'delivery-2' })
+
+  expect(instance.comments(base, 1)).toHaveLength(1)
+})
+
 test('behavior: concurrent deliveries with the same title open one issue', async () => {
   const instance = await github(
     {},

--- a/app/src/handlers/pullRequest.test.ts
+++ b/app/src/handlers/pullRequest.test.ts
@@ -43,7 +43,7 @@ async function run(
     baseRef: 'main',
     client: octokit,
     ...(options.delivery ? { delivery: options.delivery } : {}),
-    head: 'main',
+    head: 'head',
     installation: async (repo) => options.installed?.[repo],
     pr: 42,
     registry: `${url}/registry`,
@@ -71,7 +71,7 @@ function serial(): Serialize {
 test('behavior: files pending entries and comments once', async () => {
   const instance = await github(
     {},
-    { files: { [base]: { [`${dir}/a/friction.md`]: entry('Filters ignored') } } },
+    { head: { [base]: { [`${dir}/a/friction.md`]: entry('Filters ignored') } } },
   )
 
   const report = await run(instance.url)
@@ -85,7 +85,7 @@ test('behavior: files pending entries and comments once', async () => {
 test('behavior: records the pull request and the reporter on the issue', async () => {
   const instance = await github(
     {},
-    { files: { [base]: { [`${dir}/a/friction.md`]: entry('Filters ignored') } } },
+    { head: { [base]: { [`${dir}/a/friction.md`]: entry('Filters ignored') } } },
   )
 
   await run(instance.url)
@@ -99,21 +99,45 @@ test('behavior: records the pull request and the reporter on the issue', async (
 test('behavior: nothing written back to the pull request branch', async () => {
   const instance = await github(
     {},
-    { files: { [base]: { [`${dir}/a/friction.md`]: entry('Filters ignored') } } },
+    { head: { [base]: { [`${dir}/a/friction.md`]: entry('Filters ignored') } } },
   )
 
   await run(instance.url)
 
   // A commit here would trigger `synchronize` and run this again.
-  expect(instance.messages(base)).toEqual(['initial'])
-  expect(instance.files(base)[`${dir}/a/friction.md`]).not.toContain('issue:')
+  expect(instance.messages(base, 'head')).toEqual(['initial', 'head'])
+  expect(instance.files(base, 'head')[`${dir}/a/friction.md`]).not.toContain('issue:')
+})
+
+// The base branch carries a friction log; this pull request does not touch it. Reading the head alone
+// reported every entry already there, and would have filed any of them still unpublished against
+// whoever opened an unrelated pull request.
+test('behavior: a pull request that changes no entry says nothing', async () => {
+  const instance = await github(
+    {},
+    {
+      files: {
+        [base]: {
+          [`${dir}/a/friction.md`]: entry('Filters ignored'),
+          [`${dir}/b/friction.md`]: entry('Already filed', { issue: `${base}#7` }),
+        },
+      },
+      head: { [base]: { 'src/index.ts': 'export {}\n' } },
+    },
+  )
+
+  const report = await run(instance.url)
+
+  expect(report).toEqual({ commented: [], created: [], deferred: [], linked: [], malformed: [] })
+  expect(instance.issues.get(base)).toBeUndefined()
+  expect(instance.comments(base, 42)).toEqual([])
 })
 
 // Every push to the branch re-runs this, and each one is a separate delivery.
 test('behavior: a second run opens no issue and adds no comment', async () => {
   const instance = await github(
     {},
-    { files: { [base]: { [`${dir}/a/friction.md`]: entry('Filters ignored') } } },
+    { head: { [base]: { [`${dir}/a/friction.md`]: entry('Filters ignored') } } },
   )
 
   await run(instance.url, { delivery: 'delivery-1' })
@@ -130,7 +154,7 @@ test('behavior: a second run opens no issue and adds no comment', async () => {
 test('behavior: many pushes to one pull request leave one issue and no comments', async () => {
   const instance = await github(
     {},
-    { files: { [base]: { [`${dir}/a/friction.md`]: entry('Filters ignored') } } },
+    { head: { [base]: { [`${dir}/a/friction.md`]: entry('Filters ignored') } } },
   )
 
   for (const delivery of ['one', 'two', 'three', 'four']) await run(instance.url, { delivery })
@@ -143,7 +167,7 @@ test('behavior: many pushes to one pull request leave one issue and no comments'
 test('behavior: an edited entry comments once', async () => {
   const instance = await github(
     {},
-    { files: { [base]: { [`${dir}/a/friction.md`]: entry('Filters ignored') } } },
+    { head: { [base]: { [`${dir}/a/friction.md`]: entry('Filters ignored') } } },
   )
 
   await run(instance.url, { delivery: 'delivery-1' })
@@ -151,6 +175,7 @@ test('behavior: an edited entry comments once', async () => {
     base,
     `${dir}/a/friction.md`,
     entry('Filters ignored').replace('swallowed', 'dropped'),
+    'head',
   )
   await run(instance.url, { delivery: 'delivery-2' })
   await run(instance.url, { delivery: 'delivery-3' })
@@ -162,7 +187,7 @@ test('behavior: an edited entry comments once', async () => {
 test('behavior: concurrent deliveries with the same title open one issue', async () => {
   const instance = await github(
     {},
-    { files: { [base]: { [`${dir}/a/friction.md`]: entry('Filters ignored') } } },
+    { head: { [base]: { [`${dir}/a/friction.md`]: entry('Filters ignored') } } },
   )
   const serialize = serial()
 
@@ -180,7 +205,7 @@ test('behavior: an already-linked entry is listed, not filed again', async () =>
   const instance = await github(
     { [base]: [{ title: 'Filters ignored' }] },
     {
-      files: {
+      head: {
         [base]: { [`${dir}/a/friction.md`]: entry('Filters ignored', { issue: `${base}#1` }) },
       },
     },
@@ -200,7 +225,7 @@ test('behavior: a malformed entry is reported without stopping the rest', async 
   const instance = await github(
     {},
     {
-      files: {
+      head: {
         [base]: {
           [`${dir}/broken/friction.md`]: '# no frontmatter\n',
           [`${dir}/good/friction.md`]: entry('Filters ignored'),
@@ -220,12 +245,11 @@ test('behavior: entries over the ceiling are deferred', async () => {
   const instance = await github(
     {},
     {
-      files: {
+      files: { [base]: { [`${dir}/config.json`]: JSON.stringify({ maxPerRun: 1 }) } },
+      head: {
         [base]: {
-          'config.placeholder': '',
           [`${dir}/a/friction.md`]: entry('One'),
           [`${dir}/b/friction.md`]: entry('Two'),
-          [`${dir}/config.json`]: JSON.stringify({ maxPerRun: 1 }),
         },
       },
     },
@@ -241,11 +265,11 @@ test('behavior: a refused entry does not consume the ceiling', async () => {
   const instance = await github(
     {},
     {
-      files: {
+      files: { [base]: { [`${dir}/config.json`]: JSON.stringify({ maxPerRun: 1 }) } },
+      head: {
         [base]: {
           [`${dir}/a/friction.md`]: entry('Cannot resolve', { target: 'missing' }),
           [`${dir}/b/friction.md`]: entry('Can file'),
-          [`${dir}/config.json`]: JSON.stringify({ maxPerRun: 1 }),
         },
       },
     },
@@ -273,11 +297,11 @@ describe('cross-repo', () => {
   function seed(config: Record<string, unknown>) {
     return {
       files: {
-        [base]: {
-          [`${dir}/a/friction.md`]: entry('Upstream friction', { target: 'viem' }),
-          [`${dir}/config.json`]: JSON.stringify(config),
-        },
+        [base]: { [`${dir}/config.json`]: JSON.stringify(config) },
         [upstream]: { [`${dir}/config.json`]: JSON.stringify({ inbound: { enabled: true } }) },
+      },
+      head: {
+        [base]: { [`${dir}/a/friction.md`]: entry('Upstream friction', { target: 'viem' }) },
       },
       packages: { viem: upstream },
     }
@@ -336,7 +360,7 @@ test('behavior: no entries posts no comment', async () => {
 test('behavior: the comment carries the marker that keeps it single', async () => {
   const instance = await github(
     {},
-    { files: { [base]: { [`${dir}/a/friction.md`]: entry('Filters ignored') } } },
+    { head: { [base]: { [`${dir}/a/friction.md`]: entry('Filters ignored') } } },
   )
 
   await run(instance.url)

--- a/app/src/handlers/pullRequest.ts
+++ b/app/src/handlers/pullRequest.ts
@@ -1,3 +1,4 @@
+import type { Entry } from 'frog'
 import type { Octokit } from 'octokit'
 import * as comment from '../internal/comment.js'
 import * as config from '../internal/config.js'
@@ -32,8 +33,16 @@ export async function pullRequest(options: pullRequest.Options): Promise<comment
   } = options
 
   const settings = await config.read(client, { ref: baseRef, repo: base })
-  const { entries, malformed } = await Repository.read(client, { ref: head, repo: base })
-  const { linked, pending } = filing.partition(entries)
+  const contents = await Repository.read(client, { ref: head, repo: base })
+
+  // Only what this pull request actually changed. Reading the head alone would report every entry the
+  // base branch already carries, and file issues for any of them still unpublished, crediting them to
+  // whoever happened to open an unrelated pull request.
+  const before = await Repository.read(client, { ref: baseRef, repo: base })
+  const changed = introduced(contents.entries, before.entries)
+
+  const malformed = contents.malformed
+  const { linked, pending } = filing.partition(changed)
 
   const filed = await filing.file({
     client,
@@ -59,6 +68,18 @@ export async function pullRequest(options: pullRequest.Options): Promise<comment
   if (body) await serialize(base, () => comment.upsert(client, { body, pr, repo: base }))
 
   return report
+}
+
+/** Entries a pull request adds or edits, by comparing its head against the branch it targets. */
+function introduced(
+  head: readonly Entry.Entry[],
+  base: readonly Entry.Entry[],
+): readonly Entry.Entry[] {
+  const existing = new Map(base.map((entry) => [entry.id, entry]))
+  return head.filter((entry) => {
+    const previous = existing.get(entry.id)
+    return !previous || previous.body !== entry.body || previous.title !== entry.title
+  })
 }
 
 export declare namespace pullRequest {

--- a/app/src/handlers/pullRequest.ts
+++ b/app/src/handlers/pullRequest.ts
@@ -43,7 +43,6 @@ export async function pullRequest(options: pullRequest.Options): Promise<comment
     origin: base,
     pr: `${base}#${pr}`,
     ...(options.actor ? { actor: options.actor } : {}),
-    ...(delivery ? { delivery } : {}),
     ...(registry ? { registry } : {}),
     serialize,
   })

--- a/app/src/handlers/push.ts
+++ b/app/src/handlers/push.ts
@@ -58,7 +58,6 @@ export async function push(options: push.Options): Promise<Outcome> {
     installation,
     origin: repo,
     ...(options.actor ? { actor: options.actor } : {}),
-    ...(delivery ? { delivery } : {}),
     ...(registry ? { registry } : {}),
     serialize,
   })

--- a/app/src/internal/file.ts
+++ b/app/src/internal/file.ts
@@ -28,7 +28,6 @@ export async function file(options: file.Options): Promise<Filing> {
     actor,
     client,
     config,
-    delivery,
     entries,
     installation,
     origin,
@@ -153,7 +152,7 @@ export async function file(options: file.Options): Promise<Filing> {
           marker: { hash, origin, path: Store.toPath(entry.id) },
           provenance: { ...(actor ? { author: actor } : {}), ...(pr ? { pr } : {}) },
           repo: destination,
-          ...(delivery ? { occurrence: `${delivery}:${entry.id}` } : {}),
+          occurrence: occurrenceOf({ entry, origin, ...(pr ? { pr } : {}) }),
           ...(existing ? { existing } : {}),
         })
 
@@ -169,6 +168,24 @@ export async function file(options: file.Options): Promise<Filing> {
   return { commented, created, deferred, links }
 }
 
+/**
+ * Stable key for one report of one friction, used to make a repeat comment idempotent.
+ *
+ * Derived from what is being reported rather than from the delivery reporting it. A pull request receives
+ * many deliveries, one per push, and keying on the delivery made every one of them a fresh occurrence: the
+ * issue collected a "Hit again" comment per push, for an entry nobody had touched.
+ *
+ * The body is folded in so an edited entry does speak up again, which is the one repeat worth having.
+ */
+function occurrenceOf(options: {
+  entry: Entry.Entry
+  origin: string
+  pr?: string | undefined
+}): string {
+  const { entry, origin, pr } = options
+  return [origin, pr ?? 'default', entry.id, Github.hash(entry.body)].join(':')
+}
+
 export declare namespace file {
   /** Options for {@link file}. */
   type Options = {
@@ -178,8 +195,6 @@ export declare namespace file {
     client: Octokit
     /** Normalized config, read from the default branch. */
     config: Config.Config
-    /** GitHub delivery id used to make each external publish occurrence replay-safe. */
-    delivery?: string | undefined
     /** Entries to resolve and file. Already free of linked ones. */
     entries: readonly Entry.Entry[]
     /** Resolves an installation client for another repository. */

--- a/app/src/internal/file.ts
+++ b/app/src/internal/file.ts
@@ -175,7 +175,10 @@ export async function file(options: file.Options): Promise<Filing> {
  * many deliveries, one per push, and keying on the delivery made every one of them a fresh occurrence: the
  * issue collected a "Hit again" comment per push, for an entry nobody had touched.
  *
- * The body is folded in so an edited entry does speak up again, which is the one repeat worth having.
+ * The body is folded in so an edited entry does speak up again, which is the one repeat worth having. It
+ * goes in verbatim: `Github.hash` normalizes for titles, discarding punctuation and case, which would
+ * collapse edits that matter, such as adding the `--` a command was missing. `renderOccurrence` digests
+ * the whole key anyway, so nothing is gained by hashing a part of it first.
  */
 function occurrenceOf(options: {
   entry: Entry.Entry
@@ -183,7 +186,7 @@ function occurrenceOf(options: {
   pr?: string | undefined
 }): string {
   const { entry, origin, pr } = options
-  return [origin, pr ?? 'default', entry.id, Github.hash(entry.body)].join(':')
+  return [origin, pr ?? 'default', entry.id, entry.body].join(':')
 }
 
 export declare namespace file {

--- a/src/Entry.ts
+++ b/src/Entry.ts
@@ -220,34 +220,32 @@ export type Section = {
  */
 export const sections: readonly Section[] = [
   {
-    description:
-      'A clear and concise account of what happened, with the exact error text if there was one.',
-    label: 'Description',
+    description: 'Tell us what should happen.',
+    label: 'Expected Behavior',
   },
   {
-    description: 'What should have happened instead, and what led you to expect it.',
-    label: 'Expectation',
+    description: 'Tell us what happens instead of the expected behavior.',
+    label: 'Current Behavior',
   },
   {
-    description:
-      'The shortest path from a clean checkout to the failure, including the versions and package manager that matter.',
-    label: 'Steps to reproduce',
-  },
-  {
-    description:
-      'Required. The smallest code that still fails, with every unrelated dependency and file removed. Put it in `artifacts/` and reference it here. Reports without one are usually closed unread.',
-    label: 'Minimal reproducible example',
+    description: 'Not obligatory, but suggest a fix or a reason for the friction.',
+    label: 'Possible Solution',
   },
   {
     description:
-      'The smallest durable change that would remove this friction, and whether you intend to make it.',
-    label: 'Suggestion',
+      'A minimal reproducible example in `artifacts/`, or an unambiguous set of steps to reproduce this. Include code to reproduce, if relevant.',
+    label: 'Minimal Reproducible Example',
+  },
+  {
+    description:
+      'How has this affected you, and what were you trying to accomplish? Context is what makes a solution useful in the real world rather than in the abstract.',
+    label: 'Context',
   },
 ]
 
 /** Section scaffold a new entry starts from, rendered from {@link sections}. */
 export const template = `${sections
-  .map((section) => `## ${section.label}\n\n${section.description}`)
+  .map((section) => `## ${section.label}\n\n<!-- ${section.description} -->`)
   .join('\n\n')}\n`
 
 /**

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -96,7 +96,7 @@ ${Entry.sections
       `      label: ${section.label}`,
       `      description: ${section.description}`,
       '    validations:',
-      `      required: ${section.label === 'Description'}`,
+      `      required: ${section.label === 'Current Behavior'}`,
     ].join('\n'),
   )
   .join('\n')}

--- a/test/github.ts
+++ b/test/github.ts
@@ -83,6 +83,13 @@ export type Options = {
    */
   files?: Record<string, Record<string, string>> | undefined
   /**
+   * Contents of a pull request head, as `{ 'owner/name': { path: contents } }`.
+   *
+   * Seeded on a `head` branch so a test can express what a pull request changes, which is what separates
+   * the entries it introduces from the ones its base branch already carries.
+   */
+  head?: Record<string, Record<string, string>> | undefined
+  /**
    * Repository each npm package declares, served at `/registry/<name>/latest`, keyed by package name.
    *
    * The App has no `node_modules`, so it resolves a package to its repository through the registry.
@@ -145,7 +152,10 @@ export async function github(seed: Seed = {}, options: Options = {}): Promise<In
   let objects = 0
   const nextSha = () => `sha${(objects += 1).toString().padStart(4, '0')}`
 
-  for (const [repo, contents] of Object.entries(options.files ?? {})) {
+  for (const [repo, contents] of Object.entries({
+    ...Object.fromEntries(Object.keys(options.head ?? {}).map((repo) => [repo, {}])),
+    ...options.files,
+  })) {
     const tree = new Map<string, string>()
     for (const [path, body] of Object.entries(contents)) {
       const sha = nextSha()
@@ -163,6 +173,20 @@ export async function github(seed: Seed = {}, options: Options = {}): Promise<In
   const treeOf = (repo: string, branch: string) => {
     const commit = commits.get(refs.get(`${repo}#${branch}`) ?? '')
     return trees.get(commit?.tree ?? '') ?? new Map<string, string>()
+  }
+
+  for (const [repo, contents] of Object.entries(options.head ?? {})) {
+    const tree = new Map(treeOf(repo, 'main'))
+    for (const [path, body] of Object.entries(contents)) {
+      const sha = nextSha()
+      blobs.set(sha, body)
+      tree.set(path, sha)
+    }
+    const treeSha = nextSha()
+    trees.set(treeSha, tree)
+    const commitSha = nextSha()
+    commits.set(commitSha, { message: 'head', parent: refs.get(`${repo}#main`), tree: treeSha })
+    refs.set(`${repo}#head`, commitSha)
   }
 
   const server = http.createServer((request, response) => {

--- a/test/github.ts
+++ b/test/github.ts
@@ -20,6 +20,8 @@ export type Instance = {
   requests: Request[]
   /** Base URL to hand Octokit. */
   url: string
+  /** Replaces a file on a branch, for asserting what happens once an entry is edited. */
+  write: (repo: string, path: string, contents: string, branch?: string) => void
 }
 
 export type Issue = {
@@ -457,5 +459,10 @@ export async function github(seed: Seed = {}, options: Options = {}): Promise<In
     },
     requests,
     url: `http://127.0.0.1:${address.port}`,
+    write(repo, path, contents, branch = 'main') {
+      const sha = nextSha()
+      blobs.set(sha, contents)
+      treeOf(repo, branch).set(path, sha)
+    },
   }
 }


### PR DESCRIPTION
Keys the publish occurrence on what is reported rather than on the GitHub delivery id, so repeated pushes to one pull request stop leaving a `Hit again` comment on an unchanged entry. An edited entry still comments, since the body is folded into the key.

Also reshapes the entry template into `Expected Behavior`, `Current Behavior`, `Possible Solution`, `Minimal Reproducible Example`, and `Context`, with the guidance as HTML comments so an unanswered prompt renders as nothing.

Found while running the first real end-to-end test on this repo, which left two of these on wevm/frog#4.
