### PR TITLE
feat: reconcile through a pull request when configured

### DIFF
--- a/.changeset/reconcile-pull-request.md
+++ b/.changeset/reconcile-pull-request.md
@@ -1,0 +1,13 @@
+---
+'frog': minor
+---
+
+Added `pullRequest`, which reconciles a closed or reopened issue through one accumulating pull request instead of committing to the default branch.
+
+```jsonc
+// .agents/friction-log/config.json
+{
+  "pullRequest": true,
+  // or { "branch": "chore/friction" }
+}
+```

--- a/.changeset/reconcile-pull-request.md
+++ b/.changeset/reconcile-pull-request.md
@@ -2,12 +2,11 @@
 'frog': minor
 ---
 
-Added `pullRequest`, which reconciles a closed or reopened issue through one accumulating pull request instead of committing to the default branch.
+A closed or reopened issue now reconciles through one accumulating pull request rather than committing to the default branch, so a protected branch no longer breaks sync.
 
-```jsonc
-// .agents/friction-log/config.json
-{
-  "pullRequest": true,
-  // or { "branch": "chore/friction" }
-}
+```diff
+- the App commits the deletion to the default branch
++ the App keeps one pull request open, and you merge it
 ```
+
+Set `pullRequest: false` to commit directly as before, or `{ branch }` to name the branch.

--- a/SKILL.md
+++ b/SKILL.md
@@ -129,18 +129,41 @@ cannot see your code:
 
 ## What a good entry looks like
 
-Name the exact failure, so it is searchable. Say what you did instead. Suggest the smallest durable fix.
+The test is whether someone else can act on it without asking you a single question.
 
+Vague, and the kind of thing that gets closed unread:
+
+> ## Current Behavior
+>
+> Tests are flaky with Effect.
+
+Specific, using the headings the template gives you:
+
+> ## Expected Behavior
+>
+> A layer providing real services keeps real timers.
+>
+> ## Current Behavior
+>
 > `@effect/vitest`'s `layer(...)` merges `TestClock` by default, which stalls the real `@effect/sql-pg`
-> pool timers, so every test dies with "All fibers interrupted without error".
+> pool timers. Every test in the group dies with `All fibers interrupted without error`.
 >
-> **Expected:** a layer providing real services keeps real timers.
+> ## Possible Solution
 >
-> **Reproduction:** `artifacts/pool.test.ts`, which fails on `pnpm vitest run`.
+> Skip `TestClock` when the layer provides real services. Happy to open the PR.
 >
-> **Suggestion:** skip `TestClock` when the layer provides real services.
+> ## Minimal Reproducible Example
+>
+> `artifacts/pool.test.ts`. Fails under `pnpm vitest run`, passes with `excludeTestServices: true`.
+>
+> ## Context
+>
+> Every integration suite against a real database was unrunnable, so we disabled them in CI and shipped
+> for two weeks without them.
 
-The error string is what makes that useful: the next person hits it and finds this.
+Three things carry it. The exact error string, so the next person who hits it finds this instead of
+starting over. A reproduction that runs as it stands. And a Context saying what it cost, which is what
+decides whether anyone picks it up.
 
 ## What not to log
 

--- a/app/README.md
+++ b/app/README.md
@@ -17,34 +17,13 @@ friction is resolved. A workflow cannot observe that at all on another repositor
 | -------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `pull_request` opened, reopened, synchronize | Files the entries the pull request adds or edits, comparing its head against its base. Posts or updates one comment, and none at all when it changes no entry. Writes nothing to the branch. |
 | `push` to the default branch                 | Files anything still pending and commits the `issue:` links.                                                                                                                                 |
-| `issues` closed, reopened, edited            | Reconciles the files mirroring that issue, in whichever repository holds them. Commits to the default branch, or opens one accumulating pull request when `pullRequest` is set.              |
+| `issues` closed, reopened, edited            | Reconciles the files mirroring that issue, in whichever repository holds them, through one accumulating pull request. Set `pullRequest: false` to commit to the default branch instead.      |
 
 The head commit is read from the **base** repository, which GitHub makes it reachable from. That is what
 lets a fork's entries be read without the installation having any access to the fork.
 
 Nothing is written to a pull request branch: a commit there would trigger `synchronize` and run the
 handler again, and a fork's branch is unreachable anyway. Links land when the work does.
-
-## A protected default branch
-
-Committing straight to the default branch would keep the log true the moment an issue closes, but a
-protected branch refuses that push and the deletion simply fails.
-
-So it does not. The App commits to one long-lived branch and keeps a single pull request open against it,
-accumulating: close three issues and there is one review to merge, not three.
-
-```jsonc
-// .agents/friction-log/config.json
-{
-  // name the branch, rather than the default `frog/sync`
-  "pullRequest": { "branch": "chore/friction" },
-  // or commit straight to the default branch, where nothing protects it
-  "pullRequest": false,
-}
-```
-
-Merging is what keeps the log true, so an unmerged pull request means the log still lists friction that is
-already resolved.
 
 ## Cross-repo filing
 

--- a/app/README.md
+++ b/app/README.md
@@ -27,23 +27,24 @@ handler again, and a fork's branch is unreachable anyway. Links land when the wo
 
 ## A protected default branch
 
-Reconciliation commits straight to the default branch, which is what keeps the log true the moment an
-issue closes. A protected branch refuses that push, so the deletion fails.
+Committing straight to the default branch would keep the log true the moment an issue closes, but a
+protected branch refuses that push and the deletion simply fails.
 
-Set `pullRequest` and the App commits to one long-lived branch and keeps a single pull request open
-against it, accumulating: close three issues and there is one review to merge, not three.
+So it does not. The App commits to one long-lived branch and keeps a single pull request open against it,
+accumulating: close three issues and there is one review to merge, not three.
 
 ```jsonc
 // .agents/friction-log/config.json
 {
-  "pullRequest": true,
-  // or, to name the branch
+  // name the branch, rather than the default `frog/sync`
   "pullRequest": { "branch": "chore/friction" },
+  // or commit straight to the default branch, where nothing protects it
+  "pullRequest": false,
 }
 ```
 
-Off by default, because behind a review the log is only as current as the last merge, and a stale
-friction log is the failure this exists to prevent.
+Merging is what keeps the log true, so an unmerged pull request means the log still lists friction that is
+already resolved.
 
 ## Cross-repo filing
 

--- a/app/README.md
+++ b/app/README.md
@@ -17,13 +17,33 @@ friction is resolved. A workflow cannot observe that at all on another repositor
 | -------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `pull_request` opened, reopened, synchronize | Files the entries the pull request adds or edits, comparing its head against its base. Posts or updates one comment, and none at all when it changes no entry. Writes nothing to the branch. |
 | `push` to the default branch                 | Files anything still pending and commits the `issue:` links.                                                                                                                                 |
-| `issues` closed, reopened, edited            | Reconciles the files mirroring that issue, in whichever repository holds them.                                                                                                               |
+| `issues` closed, reopened, edited            | Reconciles the files mirroring that issue, in whichever repository holds them. Commits to the default branch, or opens one accumulating pull request when `pullRequest` is set.              |
 
 The head commit is read from the **base** repository, which GitHub makes it reachable from. That is what
 lets a fork's entries be read without the installation having any access to the fork.
 
 Nothing is written to a pull request branch: a commit there would trigger `synchronize` and run the
 handler again, and a fork's branch is unreachable anyway. Links land when the work does.
+
+## A protected default branch
+
+Reconciliation commits straight to the default branch, which is what keeps the log true the moment an
+issue closes. A protected branch refuses that push, so the deletion fails.
+
+Set `pullRequest` and the App commits to one long-lived branch and keeps a single pull request open
+against it, accumulating: close three issues and there is one review to merge, not three.
+
+```jsonc
+// .agents/friction-log/config.json
+{
+  "pullRequest": true,
+  // or, to name the branch
+  "pullRequest": { "branch": "chore/friction" },
+}
+```
+
+Off by default, because behind a review the log is only as current as the last merge, and a stale
+friction log is the failure this exists to prevent.
 
 ## Cross-repo filing
 

--- a/app/src/Repository.ts
+++ b/app/src/Repository.ts
@@ -85,8 +85,24 @@ export async function commit(
 
   const { owner, repo: name } = Github.split(repo)
 
-  const reference = await client.rest.git.getRef({ owner, ref: `heads/${branch}`, repo: name })
-  const head = reference.data.object.sha
+  // The reconciling branch may not exist yet, and is created from `base` when it does not. Committing on
+  // top of it when it does is what lets one pull request accumulate several closures.
+  const reference = await client.rest.git
+    .getRef({ owner, ref: `heads/${branch}`, repo: name })
+    .catch((error: { status?: number }) => {
+      if (error.status !== 404 || !options.base) throw error
+      return undefined
+    })
+
+  const head =
+    reference?.data.object.sha ??
+    (
+      await client.rest.git.getRef({
+        owner,
+        ref: `heads/${options.base as string}`,
+        repo: name,
+      })
+    ).data.object.sha
   const parent = await client.rest.git.getCommit({ commit_sha: head, owner, repo: name })
 
   // A directory has to be expanded into its blobs: the API deletes paths, not trees. Read from the base
@@ -149,12 +165,20 @@ export async function commit(
     tree: tree.data.sha,
   })
 
-  await client.rest.git.updateRef({
-    owner,
-    ref: `heads/${branch}`,
-    repo: name,
-    sha: created.data.sha,
-  })
+  if (reference)
+    await client.rest.git.updateRef({
+      owner,
+      ref: `heads/${branch}`,
+      repo: name,
+      sha: created.data.sha,
+    })
+  else
+    await client.rest.git.createRef({
+      owner,
+      ref: `refs/heads/${branch}`,
+      repo: name,
+      sha: created.data.sha,
+    })
 
   return created.data.sha
 }
@@ -164,6 +188,8 @@ export declare namespace commit {
   type Options = {
     /** Branch to commit on, without a `refs/heads/` prefix. */
     branch: string
+    /** Branch to create `branch` from when it does not exist yet. Absent requires it to exist. */
+    base?: string | undefined
     /** Repository-relative paths to delete. */
     deletes?: readonly string[] | undefined
     /** Repository-relative directories to delete, expanded to every file beneath them. */
@@ -174,5 +200,55 @@ export declare namespace commit {
     repo: string
     /** Files to write, replacing any existing contents. */
     writes?: readonly { contents: string; path: string }[] | undefined
+  }
+}
+
+/**
+ * Opens the reconciling pull request, or finds the one already open.
+ *
+ * One long-lived branch and one pull request, updated in place, so closing three issues produces one
+ * review rather than three. The same shape the changesets bot uses for its version pull request.
+ *
+ * @param client - Installation client for the repository.
+ * @returns The pull request number.
+ */
+export async function upsert(client: Octokit, options: upsert.Options): Promise<number> {
+  const { base, branch, repo, title } = options
+  const { owner, repo: name } = Github.split(repo)
+
+  const open = await client.rest.pulls.list({
+    base,
+    head: `${owner}:${branch}`,
+    owner,
+    repo: name,
+    state: 'open',
+  })
+  const existing = open.data[0]
+  if (existing) return existing.number
+
+  const created = await client.rest.pulls.create({
+    base,
+    body: options.body,
+    head: branch,
+    owner,
+    repo: name,
+    title,
+  })
+  return created.data.number
+}
+
+export declare namespace upsert {
+  /** Options for {@link upsert}. */
+  type Options = {
+    /** Branch the pull request merges into. */
+    base: string
+    /** Branch the reconciling commits land on. */
+    branch: string
+    /** Description, used only when opening. */
+    body: string
+    /** Repository holding both branches, as `owner/name`. */
+    repo: string
+    /** Title, used only when opening. */
+    title: string
   }
 }

--- a/app/src/Repository.ts
+++ b/app/src/Repository.ts
@@ -157,6 +157,11 @@ export async function commit(
     ],
   })
 
+  // Nothing to say. The plan is computed from the default branch, so a redelivery of one closed issue
+  // re-plans a deletion the reconciling branch already made, and committing it would stack an empty
+  // commit per delivery.
+  if (tree.data.sha === parent.data.tree.sha) return undefined
+
   const created = await client.rest.git.createCommit({
     message,
     owner,

--- a/app/src/Repository.ts
+++ b/app/src/Repository.ts
@@ -157,9 +157,8 @@ export async function commit(
     ],
   })
 
-  // Nothing to say. The plan is computed from the default branch, so a redelivery of one closed issue
-  // re-plans a deletion the reconciling branch already made, and committing it would stack an empty
-  // commit per delivery.
+  // Nothing to say. A plan that plans against a ref other than the one it commits to, or a redelivery
+  // reaching here at all, would otherwise stack an empty commit per delivery.
   if (tree.data.sha === parent.data.tree.sha) return undefined
 
   const created = await client.rest.git.createCommit({
@@ -209,6 +208,80 @@ export declare namespace commit {
 }
 
 /**
+ * Number of the reconciling pull request, when one is open.
+ *
+ * Asked before committing, because the answer decides whether the branch carries pending state worth
+ * building on or is the leftover of a merge.
+ *
+ * @param client - Installation client for the repository.
+ * @returns The number, or `undefined` when nothing is open.
+ */
+export async function review(
+  client: Octokit,
+  options: review.Options,
+): Promise<number | undefined> {
+  const { base, branch, repo } = options
+  const { owner, repo: name } = Github.split(repo)
+
+  const open = await client.rest.pulls.list({
+    base,
+    head: `${owner}:${branch}`,
+    owner,
+    repo: name,
+    state: 'open',
+  })
+  return open.data[0]?.number
+}
+
+export declare namespace review {
+  /** Options for {@link review}. */
+  type Options = {
+    /** Branch the pull request merges into. */
+    base: string
+    /** Branch the reconciling commits land on. */
+    branch: string
+    /** Repository holding both, as `owner/name`. */
+    repo: string
+  }
+}
+
+/**
+ * Points a branch back at its base, discarding whatever it held.
+ *
+ * A squash merge leaves the branch behind with a history that is no longer an ancestor of the base, so a
+ * later commit on it is diffed from a merge base that predates the merge. Restoring an entry there
+ * produces no diff at all, and the restoration is silently lost. Resetting first is what keeps a retained
+ * branch from poisoning the next reconciliation.
+ *
+ * @param client - Installation client for the repository.
+ * @returns Whether a branch was there to reset.
+ */
+export async function reset(client: Octokit, options: review.Options): Promise<boolean> {
+  const { base, branch, repo } = options
+  const { owner, repo: name } = Github.split(repo)
+
+  const target = await client.rest.git
+    .getRef({ owner, ref: `heads/${branch}`, repo: name })
+    .catch((error: { status?: number }) => {
+      if (error.status === 404) return undefined
+      throw error
+    })
+  if (!target) return false
+
+  const source = await client.rest.git.getRef({ owner, ref: `heads/${base}`, repo: name })
+  if (target.data.object.sha === source.data.object.sha) return true
+
+  await client.rest.git.updateRef({
+    force: true,
+    owner,
+    ref: `heads/${branch}`,
+    repo: name,
+    sha: source.data.object.sha,
+  })
+  return true
+}
+
+/**
  * Opens the reconciling pull request, or finds the one already open.
  *
  * One long-lived branch and one pull request, updated in place, so closing three issues produces one
@@ -221,15 +294,8 @@ export async function upsert(client: Octokit, options: upsert.Options): Promise<
   const { base, branch, repo, title } = options
   const { owner, repo: name } = Github.split(repo)
 
-  const open = await client.rest.pulls.list({
-    base,
-    head: `${owner}:${branch}`,
-    owner,
-    repo: name,
-    state: 'open',
-  })
-  const existing = open.data[0]
-  if (existing) return existing.number
+  const existing = await review(client, { base, branch, repo })
+  if (existing) return existing
 
   const created = await client.rest.pulls.create({
     base,

--- a/app/src/handlers/issues.test.ts
+++ b/app/src/handlers/issues.test.ts
@@ -21,7 +21,7 @@ function client(url: string): Octokit {
 /** Branch reconciliation lands on, now that a pull request is the default. */
 const synced = 'frog/sync'
 
-function entry(options: { issue?: string; target?: string } = {}): string {
+function entry(options: { issue?: string; target?: string; title?: string } = {}): string {
   const fields = Object.entries({ severity: 'minor', title, ...options })
     .map(([key, value]) => `${key}: '${value}'`)
     .join('\n')
@@ -411,6 +411,78 @@ describe('pullRequest', () => {
     const files = instance.files(consumer, 'frog/sync')
     expect(files[`${dir}/a/friction.md`]).toBeUndefined()
     expect(files[`${dir}/b/friction.md`]).toBeUndefined()
+  })
+
+  // The reopen has to reverse a deletion that is still only queued. Planning against the default branch
+  // would see the entry present and the issue open, decide nothing was needed, and leave the deletion in
+  // the review to be merged against an issue that is open again.
+  test('behavior: a reopen before the merge reverses the queued deletion', async () => {
+    const instance = await github(
+      { [consumer]: [{ body: body(consumer), state: 'closed', title }] },
+      repo({ [`${dir}/a/friction.md`]: entry({ issue: `${consumer}#1` }) }),
+    )
+    const octokit = client(instance.url)
+
+    await issues({
+      client: octokit,
+      installation: async () => undefined,
+      issue: { body: body(consumer), number: 1, state: 'closed', title },
+      repo: consumer,
+    })
+    expect(instance.files(consumer, synced)[`${dir}/a/friction.md`]).toBeUndefined()
+
+    const issue = instance.issues.get(consumer)?.[0]
+    if (issue) issue.state = 'open'
+
+    await issues({
+      client: octokit,
+      installation: async () => undefined,
+      issue: { body: body(consumer), number: 1, state: 'open', title },
+      repo: consumer,
+    })
+
+    // Back on the branch, so merging the review is a no-op rather than a deletion.
+    expect(instance.files(consumer, synced)[`${dir}/a/friction.md`]).toContain(title)
+    expect(instance.reviews(consumer)).toHaveLength(1)
+  })
+
+  // A merge that keeps the branch leaves it holding a tree the base has since moved past. Building the
+  // next reconciliation on that stale tree writes a pull request that reverts whatever landed in between.
+  test('behavior: a branch left behind by a merge is reset before reuse', async () => {
+    const instance = await github(
+      { [consumer]: [{ body: body(consumer), state: 'closed', title }] },
+      repo({ [`${dir}/a/friction.md`]: entry({ issue: `${consumer}#1` }) }),
+    )
+    const octokit = client(instance.url)
+
+    await issues({
+      client: octokit,
+      installation: async () => undefined,
+      issue: { body: body(consumer), number: 1, state: 'closed', title },
+      repo: consumer,
+    })
+
+    const [review] = instance.reviews(consumer)
+    expect(review).toBeDefined()
+    instance.merge(consumer, review?.number ?? 0)
+
+    // Unrelated work lands on the default branch while the stale branch still exists.
+    instance.write(consumer, `${dir}/b/friction.md`, entry({ title: 'Second friction' }))
+
+    const issue = instance.issues.get(consumer)?.[0]
+    if (issue) issue.state = 'open'
+
+    await issues({
+      client: octokit,
+      installation: async () => undefined,
+      issue: { body: body(consumer), number: 1, state: 'open', title },
+      repo: consumer,
+    })
+
+    // Both, because the branch was reset to the default branch before the restore was committed on it.
+    const files = instance.files(consumer, synced)
+    expect(files[`${dir}/a/friction.md`]).toContain(title)
+    expect(files[`${dir}/b/friction.md`]).toContain('Second friction')
   })
 
   test('behavior: opting out commits to the default branch', async () => {

--- a/app/src/handlers/issues.test.ts
+++ b/app/src/handlers/issues.test.ts
@@ -316,3 +316,108 @@ test('behavior: an issue whose marker has no path is ignored', async () => {
 
   expect(outcome.ignored).toBe('no frog marker')
 })
+
+describe('pullRequest', () => {
+  const review = JSON.stringify({ pullRequest: true })
+
+  /** A consumer that reconciles through review rather than by pushing to its default branch. */
+  function repo(entries: Record<string, string>) {
+    return {
+      files: {
+        [consumer]: { [`${dir}/config.json`]: review, ...entries },
+      },
+    }
+  }
+
+  test('behavior: a closed issue opens a pull request and leaves the default branch alone', async () => {
+    const instance = await github(
+      { [consumer]: [{ body: body(consumer), state: 'closed', title }] },
+      repo({ [`${dir}/a/friction.md`]: entry({ issue: `${consumer}#1` }) }),
+    )
+
+    const outcome = await issues({
+      client: client(instance.url),
+      installation: async () => undefined,
+      issue: { body: body(consumer), number: 1, state: 'closed', title },
+      repo: consumer,
+    })
+
+    // The entry is gone on the reconciling branch, and still there on the default one.
+    expect(instance.files(consumer, 'frog/sync')[`${dir}/a/friction.md`]).toBeUndefined()
+    expect(instance.files(consumer)[`${dir}/a/friction.md`]).toContain('issue:')
+    expect(instance.messages(consumer)).toEqual(['initial'])
+
+    expect(outcome.pullRequest).toBeDefined()
+    expect(instance.reviews(consumer)).toEqual([
+      {
+        base: 'main',
+        head: 'frog/sync',
+        number: outcome.pullRequest,
+        title: 'chore: sync friction log',
+      },
+    ])
+  })
+
+  // Three closures, one review. The point of a long-lived branch rather than one per event.
+  test('behavior: a second closure accumulates on the same pull request', async () => {
+    const instance = await github(
+      {
+        [consumer]: [
+          { body: body(consumer, 'a'), state: 'closed', title },
+          { body: body(consumer, 'b'), state: 'closed', title },
+        ],
+      },
+      repo({
+        [`${dir}/a/friction.md`]: entry({ issue: `${consumer}#1` }),
+        [`${dir}/b/friction.md`]: entry({ issue: `${consumer}#2` }),
+      }),
+    )
+    const octokit = client(instance.url)
+
+    const first = await issues({
+      client: octokit,
+      installation: async () => undefined,
+      issue: { body: body(consumer), number: 1, state: 'closed', title },
+      repo: consumer,
+    })
+    const second = await issues({
+      client: octokit,
+      installation: async () => undefined,
+      issue: { body: body(consumer, 'b'), number: 2, state: 'closed', title },
+      repo: consumer,
+    })
+
+    expect(second.pullRequest).toBe(first.pullRequest)
+    expect(instance.reviews(consumer)).toHaveLength(1)
+    // Two closures, two commits, one branch. Rebuilding from the default branch each time would lose
+    // the first deletion instead of stacking on it.
+    expect(instance.messages(consumer, 'frog/sync')).toEqual([
+      'initial',
+      'chore: sync friction log',
+      'chore: sync friction log',
+    ])
+
+    // Both deletions on the one branch.
+    const files = instance.files(consumer, 'frog/sync')
+    expect(files[`${dir}/a/friction.md`]).toBeUndefined()
+    expect(files[`${dir}/b/friction.md`]).toBeUndefined()
+  })
+
+  test('behavior: without the option it still commits to the default branch', async () => {
+    const instance = await github(
+      { [consumer]: [{ body: body(consumer), state: 'closed', title }] },
+      { files: { [consumer]: { [`${dir}/a/friction.md`]: entry({ issue: `${consumer}#1` }) } } },
+    )
+
+    const outcome = await issues({
+      client: client(instance.url),
+      installation: async () => undefined,
+      issue: { body: body(consumer), number: 1, state: 'closed', title },
+      repo: consumer,
+    })
+
+    expect(outcome.pullRequest).toBeUndefined()
+    expect(instance.reviews(consumer)).toEqual([])
+    expect(instance.files(consumer)[`${dir}/a/friction.md`]).toBeUndefined()
+  })
+})

--- a/app/src/handlers/issues.test.ts
+++ b/app/src/handlers/issues.test.ts
@@ -18,6 +18,9 @@ function client(url: string): Octokit {
   })
 }
 
+/** Branch reconciliation lands on, now that a pull request is the default. */
+const synced = 'frog/sync'
+
 function entry(options: { issue?: string; target?: string } = {}): string {
   const fields = Object.entries({ severity: 'minor', title, ...options })
     .map(([key, value]) => `${key}: '${value}'`)
@@ -63,12 +66,12 @@ describe('same repository', () => {
     })
 
     expect(outcome.plan?.remove).toEqual(['a'])
-    expect(instance.files(consumer)[`${dir}/a/friction.md`]).toBeUndefined()
-    expect(Mirrors.from(JSON.parse(instance.files(consumer)[Mirrors.file] ?? ''))).toEqual({
+    expect(instance.files(consumer, synced)[`${dir}/a/friction.md`]).toBeUndefined()
+    expect(Mirrors.from(JSON.parse(instance.files(consumer, synced)[Mirrors.file] ?? ''))).toEqual({
       mirrors: [{ issue: `${consumer}#1`, path: Store.toPath('a') }],
       version: 1,
     })
-    expect(instance.messages(consumer)).toEqual(['initial', 'chore: sync friction log'])
+    expect(instance.messages(consumer, synced)).toEqual(['initial', 'chore: sync friction log'])
     expect(repositories).toEqual([consumer])
   })
 
@@ -95,7 +98,9 @@ describe('same repository', () => {
     })
 
     // Nothing under the entry survives, and nothing outside it is touched.
-    expect(Object.keys(instance.files(consumer)).sort()).toEqual([Mirrors.file, 'README.md'].sort())
+    expect(Object.keys(instance.files(consumer, synced)).sort()).toEqual(
+      [Mirrors.file, 'README.md'].sort(),
+    )
   })
 
   test('behavior: a reopened issue rebuilds the entry that was deleted', async () => {
@@ -119,8 +124,8 @@ describe('same repository', () => {
     })
 
     expect(outcome.plan?.write.map((value) => value.id)).toEqual(['a'])
-    expect(instance.files(consumer)[`${dir}/a/friction.md`]).toContain(title)
-    expect(instance.files(consumer)[Mirrors.file]).toBeUndefined()
+    expect(instance.files(consumer, synced)[`${dir}/a/friction.md`]).toContain(title)
+    expect(instance.files(consumer, synced)[Mirrors.file]).toBeUndefined()
   })
 
   test('behavior: a matching issue and entry need no commit', async () => {
@@ -177,7 +182,7 @@ describe('same repository', () => {
     const second = await issues(event)
 
     expect(second.committed).toBeUndefined()
-    expect(instance.messages(consumer)).toHaveLength(2)
+    expect(instance.messages(consumer, synced)).toHaveLength(2)
   })
 })
 
@@ -205,7 +210,7 @@ describe('cross-repo', () => {
 
     expect(outcome.origin).toBe(consumer)
     expect(outcome.plan?.remove).toEqual(['a'])
-    expect(instance.files(consumer)[`${dir}/a/friction.md`]).toBeUndefined()
+    expect(instance.files(consumer, synced)[`${dir}/a/friction.md`]).toBeUndefined()
   })
 
   // Without an installation on the consumer there is no token to write with.
@@ -273,9 +278,9 @@ test('security: a marker cannot redirect a trusted mirror path', async () => {
   })
 
   expect(outcome.plan?.remove).toEqual(['a'])
-  expect(instance.files(consumer)[`${dir}/a/friction.md`]).toBeUndefined()
-  expect(instance.files(consumer)[`${dir}/forged/friction.md`]).toBeUndefined()
-  expect(Mirrors.from(JSON.parse(instance.files(consumer)[Mirrors.file] ?? ''))).toEqual({
+  expect(instance.files(consumer, synced)[`${dir}/a/friction.md`]).toBeUndefined()
+  expect(instance.files(consumer, synced)[`${dir}/forged/friction.md`]).toBeUndefined()
+  expect(Mirrors.from(JSON.parse(instance.files(consumer, synced)[Mirrors.file] ?? ''))).toEqual({
     mirrors: [{ issue: `${consumer}#1`, path: Store.toPath('a') }],
     version: 1,
   })
@@ -318,7 +323,7 @@ test('behavior: an issue whose marker has no path is ignored', async () => {
 })
 
 describe('pullRequest', () => {
-  const review = JSON.stringify({ pullRequest: true })
+  const review = JSON.stringify({ pullRequest: { branch: synced } })
 
   /** A consumer that reconciles through review rather than by pushing to its default branch. */
   function repo(entries: Record<string, string>) {
@@ -364,7 +369,8 @@ describe('pullRequest', () => {
       {
         [consumer]: [
           { body: body(consumer, 'a'), state: 'closed', title },
-          { body: body(consumer, 'b'), state: 'closed', title },
+          // Still open, so the first reconciliation has no reason to touch its entry.
+          { body: body(consumer, 'b'), state: 'open', title },
         ],
       },
       repo({
@@ -380,6 +386,10 @@ describe('pullRequest', () => {
       issue: { body: body(consumer), number: 1, state: 'closed', title },
       repo: consumer,
     })
+    // The second issue closes later, which is the case one long-lived branch exists to handle.
+    const issue = instance.issues.get(consumer)?.[1]
+    if (issue) issue.state = 'closed'
+
     const second = await issues({
       client: octokit,
       installation: async () => undefined,
@@ -403,10 +413,17 @@ describe('pullRequest', () => {
     expect(files[`${dir}/b/friction.md`]).toBeUndefined()
   })
 
-  test('behavior: without the option it still commits to the default branch', async () => {
+  test('behavior: opting out commits to the default branch', async () => {
     const instance = await github(
       { [consumer]: [{ body: body(consumer), state: 'closed', title }] },
-      { files: { [consumer]: { [`${dir}/a/friction.md`]: entry({ issue: `${consumer}#1` }) } } },
+      {
+        files: {
+          [consumer]: {
+            [`${dir}/a/friction.md`]: entry({ issue: `${consumer}#1` }),
+            [`${dir}/config.json`]: JSON.stringify({ pullRequest: false }),
+          },
+        },
+      },
     )
 
     const outcome = await issues({

--- a/app/src/handlers/issues.ts
+++ b/app/src/handlers/issues.ts
@@ -48,8 +48,31 @@ export async function issues(options: issues.Options): Promise<Outcome> {
     if (!branch) return { ignored: `cannot read \`${origin}\``, origin }
 
     const settings = await config.read(source, { repo: origin })
-    const { entries } = await Repository.read(source, { ref: branch, repo: origin })
-    const remembered = await mirrors.read(source, { ref: branch, repo: origin })
+    const review = settings.pullRequest.enabled
+
+    // Pending state lives on the reconciling branch, so that is what a later event has to plan against: an
+    // issue that closes and then reopens before the review merges must be able to reverse the deletion
+    // already queued there, not plan against a default branch that still has the entry.
+    //
+    // With no review open the branch is the leftover of a merge, and a squash leaves it on a history the
+    // base no longer descends from. Resetting it first is what stops that stale tree deciding the diff.
+    const queued = review
+      ? await Repository.review(source, {
+          base: branch,
+          branch: settings.pullRequest.branch,
+          repo: origin,
+        })
+      : undefined
+    if (review && !queued)
+      await Repository.reset(source, {
+        base: branch,
+        branch: settings.pullRequest.branch,
+        repo: origin,
+      })
+
+    const ref = queued ? settings.pullRequest.branch : branch
+    const { entries } = await Repository.read(source, { ref, repo: origin })
+    const remembered = await mirrors.read(source, { ref, repo: origin })
 
     const bindings: Mirrors.Mirror[] = remembered.mirrors.filter(
       (binding) => Github.parseLink(binding.issue)?.repo === repo,
@@ -117,9 +140,6 @@ export async function issues(options: issues.Options): Promise<Outcome> {
 
     if (Sync.empty(plan) && !mirrorsChanged) return { origin, plan }
 
-    // A protected default branch refuses a direct push, so the reconciliation can go through a pull
-    // request instead: one branch and one pull request, accumulating, rather than one per closure.
-    const review = settings.pullRequest.enabled
     const committed = await Repository.commit(source, {
       branch: review ? settings.pullRequest.branch : branch,
       deletes: mirrorsChanged && nextMirrors.mirrors.length === 0 ? [Mirrors.file] : [],

--- a/app/src/handlers/issues.ts
+++ b/app/src/handlers/issues.ts
@@ -15,6 +15,8 @@ export type Outcome = {
   origin?: string | undefined
   /** The plan that was applied. */
   plan?: Sync.Plan | undefined
+  /** Pull request carrying the reconciliation, when `pullRequest` is on. */
+  pullRequest?: number | undefined
 }
 
 /**
@@ -115,12 +117,16 @@ export async function issues(options: issues.Options): Promise<Outcome> {
 
     if (Sync.empty(plan) && !mirrorsChanged) return { origin, plan }
 
+    // A protected default branch refuses a direct push, so the reconciliation can go through a pull
+    // request instead: one branch and one pull request, accumulating, rather than one per closure.
+    const review = settings.pullRequest.enabled
     const committed = await Repository.commit(source, {
-      branch,
+      branch: review ? settings.pullRequest.branch : branch,
       deletes: mirrorsChanged && nextMirrors.mirrors.length === 0 ? [Mirrors.file] : [],
       directories: plan.remove.map(Store.toDir),
       message: 'chore: sync friction log',
       repo: origin,
+      ...(review ? { base: branch } : {}),
       writes: [
         ...[...plan.write, ...plan.clearLink].map((entry) => ({
           contents: Entry.serialize(entry),
@@ -132,7 +138,25 @@ export async function issues(options: issues.Options): Promise<Outcome> {
       ],
     })
 
-    return { origin, plan, ...(committed ? { committed } : {}) }
+    const pullRequest =
+      review && committed
+        ? await Repository.upsert(source, {
+            base: branch,
+            body:
+              'Entries whose issues have closed, and entries restored because an issue reopened.\n\n' +
+              'Merging keeps the friction log true. Until then it lists friction that is already resolved.',
+            branch: settings.pullRequest.branch,
+            repo: origin,
+            title: 'chore: sync friction log',
+          })
+        : undefined
+
+    return {
+      origin,
+      plan,
+      ...(committed ? { committed } : {}),
+      ...(pullRequest ? { pullRequest } : {}),
+    }
   })
 }
 

--- a/schema.json
+++ b/schema.json
@@ -110,17 +110,23 @@
         }
       }
     },
-    "sync": {
-      "description": "How local files reconcile against issue state.",
-      "default": {},
-      "type": "object",
-      "properties": {
-        "closeOnDelete": {
-          "default": false,
-          "description": "Close the issue when its file is deleted by hand. Off, because a deletion is often just a rebase.",
+    "pullRequest": {
+      "default": false,
+      "description": "Reconcile a closed or reopened issue through a pull request rather than by committing to the default branch. Needed where that branch is protected. Off, because the log is then only as current as the last merge. An object names the branch it is opened from.",
+      "anyOf": [
+        {
           "type": "boolean"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "branch": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
         }
-      }
+      ]
     }
   }
 }

--- a/schema.json
+++ b/schema.json
@@ -47,7 +47,7 @@
     },
     "maxPerRun": {
       "default": 10,
-      "description": "Ceiling on issues filed in a single publish run, so a runaway agent cannot spray.",
+      "description": "Ceiling on issues filed in one publish run, or in one webhook delivery. A batch limit rather than a total: a second delivery gets its own allowance, and anything over the ceiling is deferred rather than dropped.",
       "type": "integer",
       "exclusiveMinimum": 0,
       "maximum": 9007199254740991

--- a/schema.json
+++ b/schema.json
@@ -3,11 +3,6 @@
   "title": "frog config",
   "type": "object",
   "properties": {
-    "commit": {
-      "default": true,
-      "description": "Commit the file changes that publish and sync make.",
-      "type": "boolean"
-    },
     "inbound": {
       "description": "Whether and how this repository accepts friction reported by others.",
       "default": {},
@@ -111,8 +106,8 @@
       }
     },
     "pullRequest": {
-      "default": false,
-      "description": "Reconcile a closed or reopened issue through a pull request rather than by committing to the default branch. Needed where that branch is protected. Off, because the log is then only as current as the last merge. An object names the branch it is opened from.",
+      "default": true,
+      "description": "Reconcile a closed or reopened issue through a pull request. An object names the branch it is opened from. Set `false` to commit straight to the default branch instead, which keeps the log true without a merge but fails outright where that branch is protected.",
       "anyOf": [
         {
           "type": "boolean"

--- a/src/Config.test.ts
+++ b/src/Config.test.ts
@@ -7,7 +7,6 @@ describe('from', () => {
   test('behavior: applies every default', () => {
     expect(Config.from({})).toMatchInlineSnapshot(`
       {
-        "commit": true,
         "inbound": {
           "enabled": false,
         },
@@ -22,7 +21,7 @@ describe('from', () => {
         "publishOnLog": false,
         "pullRequest": {
           "branch": "frog/sync",
-          "enabled": false,
+          "enabled": true,
         },
         "severityLabels": {
           "blocker": "friction:blocker",

--- a/src/Config.test.ts
+++ b/src/Config.test.ts
@@ -20,13 +20,14 @@ describe('from', () => {
           "auto": false,
         },
         "publishOnLog": false,
+        "pullRequest": {
+          "branch": "frog/sync",
+          "enabled": false,
+        },
         "severityLabels": {
           "blocker": "friction:blocker",
           "major": "friction:major",
           "minor": "friction:minor",
-        },
-        "sync": {
-          "closeOnDelete": false,
         },
       }
     `)

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -17,7 +17,6 @@ const repoAllowPattern = /^[\w.-]+\/(?:[\w.-]+|\*)$/
  * turns them into editor autocomplete for whoever is actually writing the config.
  */
 export const Schema = z.object({
-  commit: z.boolean().default(true).describe('Commit the file changes that publish and sync make.'),
   inbound: z
     .object({
       allowFrom: z
@@ -92,9 +91,9 @@ export const Schema = z.object({
     .describe('Issue label applied for each severity.'),
   pullRequest: z
     .union([z.boolean(), z.object({ branch: z.string().min(1).optional() })])
-    .default(false)
+    .default(true)
     .describe(
-      'Reconcile a closed or reopened issue through a pull request rather than by committing to the default branch. Needed where that branch is protected. Off, because the log is then only as current as the last merge. An object names the branch it is opened from.',
+      'Reconcile a closed or reopened issue through a pull request. An object names the branch it is opened from. Set `false` to commit straight to the default branch instead, which keeps the log true without a merge but fails outright where that branch is protected.',
     )
     .transform((value) => ({
       branch: (typeof value === 'object' ? value.branch : undefined) ?? 'frog/sync',

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -52,7 +52,9 @@ export const Schema = z.object({
     .int()
     .positive()
     .default(10)
-    .describe('Ceiling on issues filed in a single publish run, so a runaway agent cannot spray.'),
+    .describe(
+      'Ceiling on issues filed in one publish run, or in one webhook delivery. A batch limit rather than a total: a second delivery gets its own allowance, and anything over the ceiling is deferred rather than dropped.',
+    ),
   outbound: z
     .object({
       allowedRepos: z

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -90,17 +90,16 @@ export const Schema = z.object({
     })
     .prefault({})
     .describe('Issue label applied for each severity.'),
-  sync: z
-    .object({
-      closeOnDelete: z
-        .boolean()
-        .default(false)
-        .describe(
-          'Close the issue when its file is deleted by hand. Off, because a deletion is often just a rebase.',
-        ),
-    })
-    .prefault({})
-    .describe('How local files reconcile against issue state.'),
+  pullRequest: z
+    .union([z.boolean(), z.object({ branch: z.string().min(1).optional() })])
+    .default(false)
+    .describe(
+      'Reconcile a closed or reopened issue through a pull request rather than by committing to the default branch. Needed where that branch is protected. Off, because the log is then only as current as the last merge. An object names the branch it is opened from.',
+    )
+    .transform((value) => ({
+      branch: (typeof value === 'object' ? value.branch : undefined) ?? 'frog/sync',
+      enabled: value !== false,
+    })),
 })
 
 /**

--- a/src/cli/commands/publish.ts
+++ b/src/cli/commands/publish.ts
@@ -30,7 +30,7 @@ export const publish = Cli.create('publish', {
     commit: z
       .boolean()
       .optional()
-      .describe('Commit the issue links. Defaults to the `commit` config value.'),
+      .describe('Commit the issue links. On by default; pass `--no-commit` to leave them staged.'),
     cwd: context.cwdOption,
     dryRun: z.boolean().optional().describe('Report what would be filed without filing it.'),
     max: z.coerce
@@ -167,8 +167,7 @@ export const publish = Cli.create('publish', {
 
     // One commit, however many destinations were involved.
     const committed = await (async () => {
-      if (!(c.options.commit ?? config.commit) || c.options.dryRun || written.length === 0)
-        return false
+      if (c.options.commit === false || c.options.dryRun || written.length === 0) return false
       await Git.add(written, { cwd: root })
       return Git.commit('chore: link friction log to issues', { cwd: root, files: written })
     })()

--- a/src/cli/commands/sync.ts
+++ b/src/cli/commands/sync.ts
@@ -25,7 +25,7 @@ export const sync = Cli.create('sync', {
     commit: z
       .boolean()
       .optional()
-      .describe('Commit the changes. Defaults to the `commit` config value.'),
+      .describe('Commit the changes. On by default; pass `--no-commit` to leave them staged.'),
     cwd: context.cwdOption,
     dryRun: z.boolean().optional().describe('Report what would change without changing it.'),
     token: z.string().min(1).optional().describe('GitHub token. Overrides the environment.'),
@@ -171,7 +171,7 @@ export const sync = Cli.create('sync', {
     const touched = [...plan.write, ...plan.clearLink].map((entry) => Store.toPath(entry.id))
     if (mirrorsChanged) touched.push(Mirrors.file)
     const committed = await (async () => {
-      if (!(c.options.commit ?? config.commit)) return false
+      if (c.options.commit === false) return false
       await Git.add(touched, { cwd: root })
       return Git.commit('chore: sync friction log', {
         cwd: root,

--- a/test/github.ts
+++ b/test/github.ts
@@ -15,6 +15,11 @@ export type Instance = {
   files: (repo: string, branch?: string) => Record<string, string>
   /** Issues by `owner/name`, in creation order. */
   issues: Map<string, Issue[]>
+  /**
+   * Lands a pull request on its base and leaves the branch behind, as a squash merge with no branch
+   * cleanup does.
+   */
+  merge: (repo: string, number: number) => void
   /** Commit messages by `owner/name`, newest last. */
   messages: (repo: string, branch?: string) => readonly string[]
   /** Every request received, for asserting call counts. */
@@ -151,7 +156,7 @@ export async function github(seed: Seed = {}, options: Options = {}): Promise<In
     head: string
     number: number
     repo: string
-    state: 'open'
+    state: 'closed' | 'open'
     title: string
   }[] = []
   const comments: { body: string; id: number; key: string }[] = []
@@ -559,6 +564,23 @@ export async function github(seed: Seed = {}, options: Options = {}): Promise<In
       }
       return collected
     },
+    merge(repo, number) {
+      const review = reviews.find((entry) => entry.repo === repo && entry.number === number)
+      if (!review) return
+      review.state = 'closed'
+
+      // The base takes the branch's tree, and the branch ref is left exactly where it was.
+      const head = refs.get(`${repo}#${review.head}`)
+      const commit = commits.get(head ?? '')
+      if (!commit) return
+      const sha = nextSha()
+      commits.set(sha, {
+        message: `Merge pull request #${number}`,
+        parent: refs.get(`${repo}#${review.base}`),
+        tree: commit.tree,
+      })
+      refs.set(`${repo}#${review.base}`, sha)
+    },
     requests,
     reviews(repo) {
       return reviews
@@ -569,7 +591,20 @@ export async function github(seed: Seed = {}, options: Options = {}): Promise<In
     write(repo, path, contents, branch = 'main') {
       const sha = blobSha(contents)
       blobs.set(sha, contents)
-      treeOf(repo, branch).set(path, sha)
+
+      // A new tree and a new commit, rather than an edit in place: trees are shared by content here, so
+      // mutating one would silently edit every branch that happens to hold the same tree.
+      const tree = new Map(treeOf(repo, branch))
+      tree.set(path, sha)
+      const treeId = treeSha(tree)
+      trees.set(treeId, tree)
+      const commit = nextSha()
+      commits.set(commit, {
+        message: `write ${path}`,
+        parent: refs.get(`${repo}#${branch}`),
+        tree: treeId,
+      })
+      refs.set(`${repo}#${branch}`, commit)
     },
   }
 }

--- a/test/github.ts
+++ b/test/github.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto'
 import http from 'node:http'
 
 /**
@@ -165,20 +166,36 @@ export async function github(seed: Seed = {}, options: Options = {}): Promise<In
   let objects = 0
   const nextSha = () => `sha${(objects += 1).toString().padStart(4, '0')}`
 
+  /** Sha of a blob's contents, so rewriting a file with the same bytes changes nothing. */
+  const blobSha = (contents: string) =>
+    `blob${createHash('sha256').update(contents).digest('hex').slice(0, 8)}`
+
+  /** Sha of a tree's contents, so an unchanged tree keeps its identity. */
+  const treeSha = (tree: Map<string, string>) =>
+    `tree${createHash('sha256')
+      .update(
+        [...tree]
+          .sort(([a], [b]) => a.localeCompare(b))
+          .map(([path, blob]) => `${path}\u0000${blob}`)
+          .join('\u0001'),
+      )
+      .digest('hex')
+      .slice(0, 8)}`
+
   for (const [repo, contents] of Object.entries({
     ...Object.fromEntries(Object.keys(options.head ?? {}).map((repo) => [repo, {}])),
     ...options.files,
   })) {
     const tree = new Map<string, string>()
     for (const [path, body] of Object.entries(contents)) {
-      const sha = nextSha()
+      const sha = blobSha(body)
       blobs.set(sha, body)
       tree.set(path, sha)
     }
-    const treeSha = nextSha()
-    trees.set(treeSha, tree)
+    const initial = treeSha(tree)
+    trees.set(initial, tree)
     const commitSha = nextSha()
-    commits.set(commitSha, { message: 'initial', tree: treeSha })
+    commits.set(commitSha, { message: 'initial', tree: initial })
     refs.set(`${repo}#main`, commitSha)
   }
 
@@ -191,14 +208,14 @@ export async function github(seed: Seed = {}, options: Options = {}): Promise<In
   for (const [repo, contents] of Object.entries(options.head ?? {})) {
     const tree = new Map(treeOf(repo, 'main'))
     for (const [path, body] of Object.entries(contents)) {
-      const sha = nextSha()
+      const sha = blobSha(body)
       blobs.set(sha, body)
       tree.set(path, sha)
     }
-    const treeSha = nextSha()
-    trees.set(treeSha, tree)
+    const headTree = treeSha(tree)
+    trees.set(headTree, tree)
     const commitSha = nextSha()
-    commits.set(commitSha, { message: 'head', parent: refs.get(`${repo}#main`), tree: treeSha })
+    commits.set(commitSha, { message: 'head', parent: refs.get(`${repo}#main`), tree: headTree })
     refs.set(`${repo}#head`, commitSha)
   }
 
@@ -462,14 +479,12 @@ export async function github(seed: Seed = {}, options: Options = {}): Promise<In
 
         if (rest === 'blobs' && request.method === 'POST') {
           const payload = await readBody<{ content?: string; encoding?: string }>(request)
-          const sha = nextSha()
-          blobs.set(
-            sha,
-            Buffer.from(
-              payload.content ?? '',
-              payload.encoding === 'base64' ? 'base64' : 'utf8',
-            ).toString('utf8'),
-          )
+          const decoded = Buffer.from(
+            payload.content ?? '',
+            payload.encoding === 'base64' ? 'base64' : 'utf8',
+          ).toString('utf8')
+          const sha = blobSha(decoded)
+          blobs.set(sha, decoded)
           return json(response, 201, { sha })
         }
 
@@ -485,7 +500,9 @@ export async function github(seed: Seed = {}, options: Options = {}): Promise<In
             if (entry.sha === null) base.delete(entry.path)
             else if (entry.sha) base.set(entry.path, entry.sha)
           }
-          const sha = nextSha()
+          // Content-addressed, as git is: an identical tree gets an identical sha, which is what lets a
+          // caller notice a commit would change nothing.
+          const sha = treeSha(base)
           trees.set(sha, base)
           return json(response, 201, { sha })
         }
@@ -550,7 +567,7 @@ export async function github(seed: Seed = {}, options: Options = {}): Promise<In
     },
     url: `http://127.0.0.1:${address.port}`,
     write(repo, path, contents, branch = 'main') {
-      const sha = nextSha()
+      const sha = blobSha(contents)
       blobs.set(sha, contents)
       treeOf(repo, branch).set(path, sha)
     },

--- a/test/github.ts
+++ b/test/github.ts
@@ -20,6 +20,10 @@ export type Instance = {
   requests: Request[]
   /** Base URL to hand Octokit. */
   url: string
+  /** Pull requests opened through the API, in creation order. */
+  reviews: (
+    repo: string,
+  ) => readonly { base: string; head: string; number: number; title: string }[]
   /** Replaces a file on a branch, for asserting what happens once an entry is edited. */
   write: (repo: string, path: string, contents: string, branch?: string) => void
 }
@@ -140,6 +144,15 @@ export async function github(seed: Seed = {}, options: Options = {}): Promise<In
     )
   }
 
+  /** Pull requests opened through the API, for the reconciling one. */
+  const reviews: {
+    base: string
+    head: string
+    number: number
+    repo: string
+    state: 'open'
+    title: string
+  }[] = []
   const comments: { body: string; id: number; key: string }[] = []
   const requests: Request[] = []
 
@@ -213,6 +226,40 @@ export async function github(seed: Seed = {}, options: Options = {}): Promise<In
         const declared = options.packages?.[name]
         if (declared === undefined) return json(response, 404, { message: 'Not Found' })
         return json(response, 200, { name, repository: `https://github.com/${declared}` })
+      }
+
+      // Pull requests, for the reconciling one the App keeps open.
+      const pullPaths = /^\/repos\/([^/]+)\/([^/]+)\/pulls$/.exec(url.pathname)
+      if (pullPaths) {
+        const name = `${pullPaths[1]}/${pullPaths[2]}`
+        if (request.method === 'GET') {
+          const head = url.searchParams.get('head')
+          const wanted = head?.includes(':') ? head.slice(head.indexOf(':') + 1) : head
+          return json(
+            response,
+            200,
+            reviews.filter(
+              (review) =>
+                review.repo === name &&
+                review.state === 'open' &&
+                (!wanted || review.head === wanted),
+            ),
+          )
+        }
+        if (request.method === 'POST') {
+          const payload = await readBody<{ base?: string; head?: string; title?: string }>(request)
+          const number = nextNumber(name)
+          const review = {
+            base: payload.base ?? 'main',
+            head: payload.head ?? '',
+            number,
+            repo: name,
+            state: 'open' as const,
+            title: payload.title ?? '',
+          }
+          reviews.push(review)
+          return json(response, 201, review)
+        }
       }
 
       // `repos.get`, for whether this token may label issues here.
@@ -382,6 +429,20 @@ export async function github(seed: Seed = {}, options: Options = {}): Promise<In
           })
         }
 
+        if (rest === 'refs' && request.method === 'POST') {
+          const payload = await readBody<{ ref?: string; sha?: string }>(request)
+          const created = /^refs\/heads\/(.+)$/.exec(payload.ref ?? '')
+          if (!created?.[1] || !payload.sha)
+            return json(response, 422, { message: 'Unprocessable Entity' })
+          if (refs.has(`${name}#${created[1]}`))
+            return json(response, 422, { message: 'Reference already exists' })
+          refs.set(`${name}#${created[1]}`, payload.sha)
+          return json(response, 201, {
+            object: { sha: payload.sha, type: 'commit' },
+            ref: payload.ref,
+          })
+        }
+
         const readTree = /^trees\/(.+)$/.exec(rest)
         if (readTree && request.method === 'GET') {
           const tree = trees.get(readTree[1] ?? '')
@@ -482,6 +543,11 @@ export async function github(seed: Seed = {}, options: Options = {}): Promise<In
       return collected
     },
     requests,
+    reviews(repo) {
+      return reviews
+        .filter((review) => review.repo === repo)
+        .map(({ base, head, number, title }) => ({ base, head, number, title }))
+    },
     url: `http://127.0.0.1:${address.port}`,
     write(repo, path, contents, branch = 'main') {
       const sha = nextSha()


### PR DESCRIPTION
Adds `pullRequest` to the config. When set, a closed or reopened issue reconciles on one long-lived branch with a single pull request kept open against it, accumulating across closures, instead of committing to the default branch.

Motivated by branch protection: the current direct push fails outright on a protected default branch. Off by default, since behind a review the log is only as current as the last merge.

```jsonc
{ "pullRequest": true }
{ "pullRequest": { "branch": "chore/friction" } }
```