### PR TITLE
refactor(config): remove severityLabels, publishOnLog, and outbound.auto

### DIFF
--- a/.changeset/config-surface.md
+++ b/.changeset/config-surface.md
@@ -1,17 +1,5 @@
 ---
-'frog': major
+'frog': patch
 ---
 
-Removed the `severityLabels`, `publishOnLog`, and `outbound.auto` options; severity now travels in the issue marker, and the App files cross-repo without waiting for a human.
-
-```diff
-  // .agents/friction-log/config.json
-  {
--   "severityLabels": { "blocker": "p0", "major": "p1", "minor": "p2" },
--   "publishOnLog": true,
--   "outbound": { "allowedRepos": ["wevm/viem"], "auto": true }
-+   "outbound": { "allowedRepos": ["wevm/viem"] }
-  }
-```
-
-Anything in `outbound.allowedRepos` is now filed automatically. Set `outbound.enabled` to `false` to stop reporting without emptying the list. Issues no longer carry a severity label; add one through `inbound.labels` if you want it back.
+Updated config.

--- a/.changeset/config-surface.md
+++ b/.changeset/config-surface.md
@@ -1,0 +1,17 @@
+---
+'frog': major
+---
+
+Removed the `severityLabels`, `publishOnLog`, and `outbound.auto` options; severity now travels in the issue marker, and the App files cross-repo without waiting for a human.
+
+```diff
+  // .agents/friction-log/config.json
+  {
+-   "severityLabels": { "blocker": "p0", "major": "p1", "minor": "p2" },
+-   "publishOnLog": true,
+-   "outbound": { "allowedRepos": ["wevm/viem"], "auto": true }
++   "outbound": { "allowedRepos": ["wevm/viem"] }
+  }
+```
+
+Anything in `outbound.allowedRepos` is now filed automatically. Set `outbound.enabled` to `false` to stop reporting without emptying the list. Issues no longer carry a severity label; add one through `inbound.labels` if you want it back.

--- a/app/README.md
+++ b/app/README.md
@@ -30,19 +30,18 @@ handler again, and a fork's branch is unreachable anyway. Links land when the wo
 Filing on another repository needs an installation there. No installation means no token, so the App
 cannot file where it has not been installed: consent enforced by GitHub rather than by configuration.
 
-Beyond that it stays opt-in on the sender's side. Add the target to `outbound.allowedRepos`, and set
-`outbound.auto` to file without a human:
+Beyond that it stays opt-in on the sender's side. Name the target in `outbound.allowedRepos`, and the
+App files there without waiting for a human:
 
 ```jsonc
 // .agents/friction-log/config.json in the reporting repository
 {
-  "outbound": { "allowedRepos": ["wevm/viem"], "auto": true },
+  "outbound": { "allowedRepos": ["wevm/viem"] },
 }
 ```
 
-`auto` is off by default because an entry written in a private repository can carry detail that should
-not become a public issue unread. Within one organization that risk does not apply, so `wevm/*` on both
-sides gives unattended reporting.
+The list is empty by default, so nothing leaves a repository until it names somewhere to send. Set
+`outbound.enabled` to `false` to switch reporting off without emptying the list.
 
 The receiving repository opts in separately:
 

--- a/app/src/App.ts
+++ b/app/src/App.ts
@@ -58,7 +58,6 @@ export function create(options: create.Options): App {
         base: payload.repository.full_name,
         baseRef: payload.pull_request.base.ref,
         client: octokit,
-        delivery: id,
         head: payload.pull_request.head.sha,
         installation,
         pr: payload.number,
@@ -80,7 +79,6 @@ export function create(options: create.Options): App {
     await push({
       branch,
       client: octokit,
-      delivery: id,
       installation,
       repo: payload.repository.full_name,
       ...(registry ? { registry } : {}),

--- a/app/src/Repository.test.ts
+++ b/app/src/Repository.test.ts
@@ -120,7 +120,7 @@ describe('commit', () => {
 
     await Repository.commit(octokit, {
       branch: 'main',
-      message: 'chore: link friction log to issues',
+      message: 'chore: sync friction log',
       repo,
       writes: [{ contents: entry('Filters ignored'), path: `${dir}/a/friction.md` }],
     })

--- a/app/src/handlers/issues.ts
+++ b/app/src/handlers/issues.ts
@@ -115,7 +115,6 @@ export async function issues(options: issues.Options): Promise<Outcome> {
       // The files are in `origin`; issues are in `repo`. They differ when reporting upstream.
       origin,
       repo,
-      severityLabels: settings.severityLabels,
     })
 
     const byId = new Map(entries.map((entry) => [entry.id, entry]))

--- a/app/src/handlers/pullRequest.test.ts
+++ b/app/src/handlers/pullRequest.test.ts
@@ -31,7 +31,6 @@ function entry(title: string, frontmatter: Record<string, string> = {}): string 
 async function run(
   url: string,
   options: {
-    delivery?: string | undefined
     installed?: Record<string, Octokit> | undefined
     serialize?: Serialize | undefined
   } = {},
@@ -42,7 +41,6 @@ async function run(
     base,
     baseRef: 'main',
     client: octokit,
-    ...(options.delivery ? { delivery: options.delivery } : {}),
     head: 'head',
     installation: async (repo) => options.installed?.[repo],
     pr: 42,
@@ -140,8 +138,8 @@ test('behavior: a second run opens no issue and adds no comment', async () => {
     { head: { [base]: { [`${dir}/a/friction.md`]: entry('Filters ignored') } } },
   )
 
-  await run(instance.url, { delivery: 'delivery-1' })
-  const second = await run(instance.url, { delivery: 'delivery-2' })
+  await run(instance.url)
+  const second = await run(instance.url)
 
   expect(second.created).toEqual([{ id: 'a', issue: `${base}#1` }])
   expect(instance.issues.get(base)).toHaveLength(1)
@@ -157,7 +155,7 @@ test('behavior: many pushes to one pull request leave one issue and no comments'
     { head: { [base]: { [`${dir}/a/friction.md`]: entry('Filters ignored') } } },
   )
 
-  for (const delivery of ['one', 'two', 'three', 'four']) await run(instance.url, { delivery })
+  for (let attempt = 0; attempt < 4; attempt++) await run(instance.url)
 
   expect(instance.issues.get(base)).toHaveLength(1)
   expect(instance.comments(base, 1)).toHaveLength(0)
@@ -170,15 +168,15 @@ test('behavior: an edited entry comments once', async () => {
     { head: { [base]: { [`${dir}/a/friction.md`]: entry('Filters ignored') } } },
   )
 
-  await run(instance.url, { delivery: 'delivery-1' })
+  await run(instance.url)
   instance.write(
     base,
     `${dir}/a/friction.md`,
     entry('Filters ignored').replace('swallowed', 'dropped'),
     'head',
   )
-  await run(instance.url, { delivery: 'delivery-2' })
-  await run(instance.url, { delivery: 'delivery-3' })
+  await run(instance.url)
+  await run(instance.url)
 
   expect(instance.issues.get(base)).toHaveLength(1)
   expect(instance.comments(base, 1)).toHaveLength(1)
@@ -200,9 +198,9 @@ test('behavior: an edit of only punctuation still comments', async () => {
   const after = before.replace('pnpm test src', 'pnpm test -- src')
 
   instance.write(base, `${dir}/a/friction.md`, before, 'head')
-  await run(instance.url, { delivery: 'delivery-1' })
+  await run(instance.url)
   instance.write(base, `${dir}/a/friction.md`, after, 'head')
-  await run(instance.url, { delivery: 'delivery-2' })
+  await run(instance.url)
 
   expect(instance.comments(base, 1)).toHaveLength(1)
 })
@@ -214,10 +212,7 @@ test('behavior: concurrent deliveries with the same title open one issue', async
   )
   const serialize = serial()
 
-  await Promise.all([
-    run(instance.url, { delivery: 'delivery-1', serialize }),
-    run(instance.url, { delivery: 'delivery-2', serialize }),
-  ])
+  await Promise.all([run(instance.url, { serialize }), run(instance.url, { serialize })])
 
   expect(instance.issues.get(base)).toHaveLength(1)
   expect(instance.comments(base, 1)).toHaveLength(0)
@@ -330,17 +325,20 @@ describe('cross-repo', () => {
     }
   }
 
-  test('behavior: defers upstream filing when outbound.auto is off', async () => {
-    const instance = await github({}, seed({ outbound: { allowedRepos: [upstream] } }))
+  test('behavior: refuses upstream filing when outbound is disabled', async () => {
+    const instance = await github(
+      {},
+      seed({ outbound: { allowedRepos: [upstream], enabled: false } }),
+    )
 
     const report = await run(instance.url, { installed: { [upstream]: client(instance.url) } })
 
-    expect(report.deferred[0]?.reason).toContain('`outbound.auto` is off')
+    expect(report.deferred[0]?.reason).toContain('`outbound.enabled` is off')
     expect(instance.issues.get(upstream)).toBeUndefined()
   })
 
-  test('behavior: files upstream when outbound.auto is on', async () => {
-    const instance = await github({}, seed({ outbound: { allowedRepos: [upstream], auto: true } }))
+  test('behavior: files upstream without waiting for a human', async () => {
+    const instance = await github({}, seed({ outbound: { allowedRepos: [upstream] } }))
 
     const report = await run(instance.url, { installed: { [upstream]: client(instance.url) } })
 

--- a/app/src/handlers/pullRequest.ts
+++ b/app/src/handlers/pullRequest.ts
@@ -24,7 +24,6 @@ export async function pullRequest(options: pullRequest.Options): Promise<comment
     base,
     baseRef,
     client,
-    delivery,
     head,
     installation,
     pr,
@@ -97,8 +96,6 @@ export declare namespace pullRequest {
     baseRef: string
     /** Installation client for the base repository. */
     client: Octokit
-    /** GitHub delivery id used to make issue publishing replay-safe. */
-    delivery?: string | undefined
     /** Head commit sha, reachable from the base repository even for a fork. */
     head: string
     /**

--- a/app/src/handlers/push.test.ts
+++ b/app/src/handlers/push.test.ts
@@ -28,7 +28,6 @@ function entry(title: string, frontmatter: Record<string, string> = {}): string 
 async function run(
   url: string,
   options: {
-    delivery?: string | undefined
     installed?: Record<string, Octokit> | undefined
     serialize?: Serialize | undefined
   } = {},
@@ -36,7 +35,6 @@ async function run(
   return push({
     branch: 'main',
     client: client(url),
-    ...(options.delivery ? { delivery: options.delivery } : {}),
     installation: async (name) => options.installed?.[name],
     registry: `${url}/registry`,
     repo,
@@ -54,10 +52,30 @@ test('behavior: files pending entries and writes the link back in one commit', a
 
   expect(outcome.created).toEqual([{ id: 'a', issue: `${repo}#1` }])
   expect(outcome.committed).toBeTruthy()
-  expect(instance.messages(repo)).toEqual(['initial', 'chore: link friction log to issues'])
+  expect(instance.messages(repo, 'frog/sync')).toEqual(['initial', 'chore: sync friction log'])
+  // The default branch is untouched: the links arrive by review.
+  expect(instance.messages(repo)).toEqual(['initial'])
 
-  const written = instance.files(repo)[`${dir}/a/friction.md`] ?? ''
+  const written = instance.files(repo, 'frog/sync')[`${dir}/a/friction.md`] ?? ''
   expect(Entry.parse(written, { id: 'a' }).issue).toBe(`${repo}#1`)
+})
+
+// Under review the link lands on the reconciling branch, so the default branch keeps showing the entry
+// as pending. Reading only that branch would re-file and re-commit on every later push.
+test('behavior: the write-back settles even though the link is not on the default branch', async () => {
+  const instance = await github(
+    {},
+    { files: { [repo]: { [`${dir}/a/friction.md`]: entry('Filters ignored') } } },
+  )
+
+  await run(instance.url)
+  await run(instance.url)
+  const third = await run(instance.url)
+
+  expect(third).toEqual({ commented: [], created: [], deferred: [] })
+  expect(instance.issues.get(repo)).toHaveLength(1)
+  // One write-back, not one per push.
+  expect(instance.messages(repo, 'frog/sync')).toEqual(['initial', 'chore: sync friction log'])
 })
 
 // The commit written here triggers another push. That run must do nothing.
@@ -71,7 +89,7 @@ test('behavior: the write-back does not cause a second commit', async () => {
   const second = await run(instance.url)
 
   expect(second).toEqual({ commented: [], created: [], deferred: [] })
-  expect(instance.messages(repo)).toHaveLength(2)
+  expect(instance.messages(repo, 'frog/sync')).toHaveLength(2)
   expect(instance.issues.get(repo)).toHaveLength(1)
 })
 
@@ -94,7 +112,7 @@ test('behavior: an entry filed on a pull request gets its link on merge', async 
   // Commented, not created: the issue already existed from the pull request run.
   expect(outcome.commented).toEqual([{ id: 'a', issue: `${repo}#1` }])
   expect(instance.issues.get(repo)).toHaveLength(1)
-  const written = instance.files(repo)[`${dir}/a/friction.md`] ?? ''
+  const written = instance.files(repo, 'frog/sync')[`${dir}/a/friction.md`] ?? ''
   expect(Entry.parse(written, { id: 'a' }).issue).toBe(`${repo}#1`)
 })
 
@@ -121,7 +139,9 @@ test('behavior: a deferred entry keeps its file untouched', async () => {
       files: {
         [repo]: {
           [`${dir}/a/friction.md`]: entry('Upstream friction', { target: 'viem' }),
-          [`${dir}/config.json`]: JSON.stringify({ outbound: { allowedRepos: [upstream] } }),
+          [`${dir}/config.json`]: JSON.stringify({
+            outbound: { allowedRepos: [upstream], enabled: false },
+          }),
         },
         [upstream]: { [`${dir}/config.json`]: JSON.stringify({ inbound: { enabled: true } }) },
       },
@@ -131,7 +151,7 @@ test('behavior: a deferred entry keeps its file untouched', async () => {
 
   const outcome = await run(instance.url, { installed: { [upstream]: client(instance.url) } })
 
-  expect(outcome.deferred[0]?.reason).toContain('`outbound.auto` is off')
+  expect(outcome.deferred[0]?.reason).toContain('`outbound.enabled` is off')
   expect(outcome.committed).toBeUndefined()
   expect(instance.files(repo)[`${dir}/a/friction.md`]).not.toContain('issue:')
 })
@@ -144,7 +164,7 @@ test('behavior: an upstream filing writes the link into this repository', async 
         [repo]: {
           [`${dir}/a/friction.md`]: entry('Upstream friction', { target: 'viem' }),
           [`${dir}/config.json`]: JSON.stringify({
-            outbound: { allowedRepos: [upstream], auto: true },
+            outbound: { allowedRepos: [upstream] },
           }),
         },
         [upstream]: { [`${dir}/config.json`]: JSON.stringify({ inbound: { enabled: true } }) },
@@ -156,7 +176,7 @@ test('behavior: an upstream filing writes the link into this repository', async 
   const outcome = await run(instance.url, { installed: { [upstream]: client(instance.url) } })
 
   expect(outcome.created).toEqual([{ id: 'a', issue: `${upstream}#1` }])
-  const written = instance.files(repo)[`${dir}/a/friction.md`] ?? ''
+  const written = instance.files(repo, 'frog/sync')[`${dir}/a/friction.md`] ?? ''
   expect(Entry.parse(written, { id: 'a' }).issue).toBe(`${upstream}#1`)
 })
 
@@ -184,6 +204,7 @@ test('behavior: a stale push snapshot does not overwrite a concurrent entry edit
   expect(outcome.created).toEqual([{ id: 'a', issue: `${repo}#1` }])
   expect(outcome.committed).toBeUndefined()
   expect(instance.messages(repo)).toEqual(['initial', 'chore: edit friction'])
+  // The concurrent edit is on the default branch, and nothing must have overwritten it there.
   const written = instance.files(repo)[`${dir}/a/friction.md`] ?? ''
   const parsed = Entry.parse(written, { id: 'a' })
   expect(parsed.title).toBe('Edited concurrently')

--- a/app/src/handlers/push.ts
+++ b/app/src/handlers/push.ts
@@ -16,6 +16,8 @@ export type Outcome = {
   created: readonly comment.Link[]
   /** Entries left pending, and why. */
   deferred: readonly { id: string; reason: string }[]
+  /** Reconciling pull request the links went to, when the default branch is not written directly. */
+  pullRequest?: number | undefined
 }
 
 /**
@@ -30,24 +32,31 @@ export type Outcome = {
  * already filed cost a lookup and nothing else.
  *
  * Self-terminating: the commit written here triggers another push, on which every entry already carries
- * a link, so nothing is pending and no commit is made.
+ * a link, so nothing is pending and no commit is made. Under review that link is on the reconciling
+ * branch rather than this one, which is why that branch is read too.
  *
  * @returns What happened.
  */
 export async function push(options: push.Options): Promise<Outcome> {
-  const {
-    branch,
-    client,
-    delivery,
-    installation,
-    registry,
-    repo,
-    serialize = serialization.direct,
-  } = options
+  const { branch, client, installation, registry, repo, serialize = serialization.direct } = options
 
   const settings = await config.read(client, { ref: branch, repo })
+  const review = settings.pullRequest.enabled
   const { entries } = await Repository.read(client, { ref: branch, repo })
-  const { pending } = filing.partition(entries)
+
+  // Under review the link lands on the reconciling branch, not here, so this branch goes on showing the
+  // entry as pending. Without reading that branch too, every later push would re-file and re-commit the
+  // same links, and the write-back would never settle.
+  const reviewed = review
+    ? await Repository.read(client, { ref: settings.pullRequest.branch, repo }).catch(
+        () => undefined,
+      )
+    : undefined
+  const awaiting = new Set(
+    (reviewed?.entries ?? []).filter((entry) => entry.issue).map((entry) => entry.id),
+  )
+
+  const { pending } = filing.partition(entries.filter((entry) => !awaiting.has(entry.id)))
 
   if (pending.length === 0) return { commented: [], created: [], deferred: [] }
 
@@ -78,18 +87,36 @@ export async function push(options: push.Options): Promise<Outcome> {
     }
 
     return Repository.commit(client, {
-      branch,
-      message: 'chore: link friction log to issues',
+      branch: review ? settings.pullRequest.branch : branch,
+      message: 'chore: sync friction log',
       repo,
+      ...(review ? { base: branch } : {}),
       writes,
     })
   })
+
+  // The same branch and pull request the issue handler reconciles through, so the links and the
+  // closures land in one review rather than two. Without this the setting only half covers a protected
+  // default branch: reconciliation would route around it and this write-back would still be refused.
+  const pullRequest =
+    review && committed
+      ? await Repository.upsert(client, {
+          base: branch,
+          body:
+            'Issue links for friction filed from this repository, and entries reconciled against issues that closed or reopened.\n\n' +
+            'Merging keeps the friction log true. Until then it lists friction that is already resolved, and omits links to issues already filed.',
+          branch: settings.pullRequest.branch,
+          repo,
+          title: 'chore: sync friction log',
+        })
+      : undefined
 
   return {
     commented: filed.commented,
     created: filed.created,
     deferred: filed.deferred,
     ...(committed ? { committed } : {}),
+    ...(pullRequest ? { pullRequest } : {}),
   }
 }
 
@@ -102,8 +129,6 @@ export declare namespace push {
     branch: string
     /** Installation client for the repository. */
     client: Octokit
-    /** GitHub delivery id used to make issue publishing replay-safe. */
-    delivery?: string | undefined
     /** Resolves an installation client for another repository. */
     installation: (repo: string) => Promise<Octokit | undefined>
     /** Registry base URL. Overridden in tests. */

--- a/app/src/internal/file.ts
+++ b/app/src/internal/file.ts
@@ -45,7 +45,7 @@ export async function file(options: file.Options): Promise<Filing> {
   }
 
   const stack = resolvers.resolvers({
-    allowedRepos: config.outbound.allowedRepos,
+    outbound: config.outbound,
     installation: installed,
     self: origin,
     ...(registry ? { registry } : {}),
@@ -74,16 +74,6 @@ export async function file(options: file.Options): Promise<Filing> {
     }
 
     const { labels, repo: destination } = resolution.target
-
-    // Filing upstream unattended is opt-in per sender. An entry written in a private repository can
-    // carry detail that should not become a public issue without somebody reading it first.
-    if (destination !== origin && !config.outbound.auto) {
-      deferred.push({
-        id: entry.id,
-        reason: `\`${destination}\` is upstream, and \`outbound.auto\` is off. Run \`frog publish\`.`,
-      })
-      continue
-    }
 
     candidates.push({ destination, entry, ...(labels ? { labels } : {}) })
   }
@@ -146,10 +136,9 @@ export async function file(options: file.Options): Promise<Filing> {
           labels: Github.toLabels({
             entry,
             labels: applied,
-            severityLabels: config.severityLabels,
           }),
           // `origin` is where the file lives, which is not the destination when reporting upstream.
-          marker: { hash, origin, path: Store.toPath(entry.id) },
+          marker: { hash, origin, path: Store.toPath(entry.id), severity: entry.severity },
           provenance: { ...(actor ? { author: actor } : {}), ...(pr ? { pr } : {}) },
           repo: destination,
           occurrence: occurrenceOf({ entry, origin, ...(pr ? { pr } : {}) }),

--- a/app/src/internal/resolvers.test.ts
+++ b/app/src/internal/resolvers.test.ts
@@ -34,7 +34,7 @@ describe('resolvers', () => {
   test('error: propagates a transient target config failure', async () => {
     const instance = await github({}, { errors: { [upstream]: 503 } })
     const stack = resolvers({
-      allowedRepos: [upstream],
+      outbound: { allowedRepos: [upstream], enabled: true },
       installation: async () => client(instance.url),
       self,
     })
@@ -55,7 +55,7 @@ describe('resolvers', () => {
       },
     )
     const stack = resolvers({
-      allowedRepos: [upstream],
+      outbound: { allowedRepos: [upstream], enabled: true },
       installation: async () => client(target.url),
       self,
     })
@@ -67,7 +67,7 @@ describe('resolvers', () => {
 
   test('error: reports a missing target installation', async () => {
     const stack = resolvers({
-      allowedRepos: [upstream],
+      outbound: { allowedRepos: [upstream], enabled: true },
       installation: async () => undefined,
       self,
     })

--- a/app/src/internal/resolvers.ts
+++ b/app/src/internal/resolvers.ts
@@ -58,10 +58,10 @@ export async function fromRegistry(
  * unchanged, which is the point of `Target` taking them as arguments.
  */
 export function resolvers(options: resolvers.Options): Target.resolve.Options {
-  const { allowedRepos, installation, registry: url, self } = options
+  const { outbound, installation, registry: url, self } = options
 
   return {
-    allowedRepos,
+    outbound,
     async readConfig(repo) {
       const client = await installation(repo)
       if (!client) throw new InstallationMissingError(repo)
@@ -82,8 +82,8 @@ export function resolvers(options: resolvers.Options): Target.resolve.Options {
 export declare namespace resolvers {
   /** Options for {@link resolvers}. */
   type Options = {
-    /** Targets the sender may file against, from its base-branch config. */
-    allowedRepos: readonly string[]
+    /** Sender's outbound policy, from its base-branch config. */
+    outbound: Config.Outbound
     /** Resolves the installation client authorized to read each target repository. */
     installation: (repo: string) => Promise<Octokit | undefined>
     /** Registry base URL. Overridden in tests. */

--- a/schema.json
+++ b/schema.json
@@ -66,42 +66,10 @@
             "pattern": "^[\\w.-]+\\/(?:[\\w.-]+|\\*)$"
           }
         },
-        "auto": {
-          "default": false,
-          "description": "Let the GitHub App file cross-repo without a human running publish. Off, because a private repository can leak proprietary detail upstream.",
+        "enabled": {
+          "default": true,
+          "description": "Report friction to other repositories. Off refuses every target but this one.",
           "type": "boolean"
-        }
-      }
-    },
-    "publishOnLog": {
-      "default": false,
-      "description": "Make `log` file the issue immediately, without needing `--publish`.",
-      "type": "boolean"
-    },
-    "repo": {
-      "description": "`owner/name` this repository's own friction is filed against. Defaults to the origin remote.",
-      "type": "string",
-      "pattern": "^[\\w.-]+\\/[\\w.-]+$"
-    },
-    "severityLabels": {
-      "description": "Issue label applied for each severity.",
-      "default": {},
-      "type": "object",
-      "properties": {
-        "blocker": {
-          "default": "friction:blocker",
-          "type": "string",
-          "minLength": 1
-        },
-        "major": {
-          "default": "friction:major",
-          "type": "string",
-          "minLength": 1
-        },
-        "minor": {
-          "default": "friction:minor",
-          "type": "string",
-          "minLength": 1
         }
       }
     },
@@ -122,6 +90,11 @@
           }
         }
       ]
+    },
+    "repo": {
+      "description": "`owner/name` this repository's own friction is filed against. Defaults to the origin remote.",
+      "type": "string",
+      "pattern": "^[\\w.-]+\\/[\\w.-]+$"
     }
   }
 }

--- a/src/Config.test.ts
+++ b/src/Config.test.ts
@@ -16,28 +16,19 @@ describe('from', () => {
         "maxPerRun": 10,
         "outbound": {
           "allowedRepos": [],
-          "auto": false,
+          "enabled": true,
         },
-        "publishOnLog": false,
         "pullRequest": {
           "branch": "frog/sync",
           "enabled": true,
-        },
-        "severityLabels": {
-          "blocker": "friction:blocker",
-          "major": "friction:major",
-          "minor": "friction:minor",
         },
       }
     `)
   })
 
   test('behavior: fills nested defaults around a partial override', () => {
-    expect(
-      Config.from({ inbound: { labels: ['dx'] }, severityLabels: { minor: 'nit' } }),
-    ).toMatchObject({
+    expect(Config.from({ inbound: { labels: ['dx'] } })).toMatchObject({
       inbound: { enabled: false, labels: ['dx'] },
-      severityLabels: { blocker: 'friction:blocker', major: 'friction:major', minor: 'nit' },
     })
   })
 
@@ -97,7 +88,7 @@ describe('resolve', () => {
     )
     expect(await Config.resolve({ root })).toMatchObject({
       maxPerRun: 3,
-      outbound: { allowedRepos: ['wevm/viem'], auto: false },
+      outbound: { allowedRepos: ['wevm/viem'], enabled: true },
     })
   })
 

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -63,34 +63,13 @@ export const Schema = z.object({
         .describe(
           'Targets this repository may file against. Always read from the base branch, never a pull request head.',
         ),
-      auto: z
+      enabled: z
         .boolean()
-        .default(false)
-        .describe(
-          'Let the GitHub App file cross-repo without a human running publish. Off, because a private repository can leak proprietary detail upstream.',
-        ),
+        .default(true)
+        .describe('Report friction to other repositories. Off refuses every target but this one.'),
     })
     .prefault({})
     .describe('Where friction may be reported, and whether automation may do it unattended.'),
-  publishOnLog: z
-    .boolean()
-    .default(false)
-    .describe('Make `log` file the issue immediately, without needing `--publish`.'),
-  repo: z
-    .string()
-    .regex(repoPattern)
-    .optional()
-    .describe(
-      "`owner/name` this repository's own friction is filed against. Defaults to the origin remote.",
-    ),
-  severityLabels: z
-    .object({
-      blocker: z.string().min(1).default('friction:blocker'),
-      major: z.string().min(1).default('friction:major'),
-      minor: z.string().min(1).default('friction:minor'),
-    })
-    .prefault({})
-    .describe('Issue label applied for each severity.'),
   pullRequest: z
     .union([z.boolean(), z.object({ branch: z.string().min(1).optional() })])
     .default(true)
@@ -101,6 +80,13 @@ export const Schema = z.object({
       branch: (typeof value === 'object' ? value.branch : undefined) ?? 'frog/sync',
       enabled: value !== false,
     })),
+  repo: z
+    .string()
+    .regex(repoPattern)
+    .optional()
+    .describe(
+      "`owner/name` this repository's own friction is filed against. Defaults to the origin remote.",
+    ),
 })
 
 /**
@@ -123,6 +109,9 @@ export type WrittenConfig = z.input<typeof Schema>
  * checked against cannot drift.
  */
 export type Inbound = Config['inbound']
+
+/** Normalized outbound policy. */
+export type Outbound = Config['outbound']
 
 /**
  * Whether `sender` is allowed to report friction to a project.

--- a/src/Github.test.ts
+++ b/src/Github.test.ts
@@ -168,20 +168,15 @@ describe('renderBody and parseBody', () => {
 })
 
 describe('toLabels', () => {
-  const severityLabels = {
-    blocker: 'friction:blocker',
-    major: 'friction:major',
-    minor: 'friction:minor',
-  }
-
-  test('behavior: combines configured, severity, and entry labels', () => {
+  // Severity is carried by the marker, not by a label: a label would sit in the receiver's namespace,
+  // and cross-repo the two projects need not name severities the same way.
+  test('behavior: combines configured and entry labels, and no severity', () => {
     expect(
       Github.toLabels({
         entry: { labels: ['tooling'], severity: 'blocker' },
         labels: ['friction'],
-        severityLabels,
       }),
-    ).toEqual(['friction', 'friction:blocker', 'tooling'])
+    ).toEqual(['friction', 'tooling'])
   })
 
   test('behavior: deduplicates', () => {
@@ -189,7 +184,6 @@ describe('toLabels', () => {
       Github.toLabels({
         entry: { labels: ['friction', 'friction:minor'], severity: 'minor' },
         labels: ['friction'],
-        severityLabels,
       }),
     ).toEqual(['friction', 'friction:minor'])
   })
@@ -233,17 +227,15 @@ describe('fromIssue', () => {
     id: 'a',
     labels: ['friction'],
     repo,
-    severityLabels: {
-      blocker: 'friction:blocker',
-      major: 'friction:major',
-      minor: 'friction:minor',
-    },
   } as const
 
   test('behavior: recovers body, severity, and extra labels', () => {
     const issue = {
-      body: Github.renderBody({ body: 'The filter was swallowed.', marker: { hash: 'x' } }),
-      labels: ['friction', 'friction:blocker', 'tooling'],
+      body: Github.renderBody({
+        body: 'The filter was swallowed.',
+        marker: { hash: 'x', severity: 'blocker' },
+      }),
+      labels: ['friction', 'tooling'],
       number: 7,
       state: 'open',
       title,
@@ -267,12 +259,17 @@ describe('fromIssue', () => {
   test('behavior: omits labels when only managed ones remain', () => {
     const issue = {
       body: 'Body.',
-      labels: ['friction', 'friction:major'],
+      labels: ['friction'],
       number: 1,
       state: 'open',
       title,
     }
     expect(Github.fromIssue(issue, options)).not.toHaveProperty('labels')
+  })
+
+  test('behavior: an issue with no marker severity comes back as minor', () => {
+    const issue = { body: 'Body.', labels: ['friction'], number: 1, state: 'open', title }
+    expect(Github.fromIssue(issue, options).severity).toBe('minor')
   })
 })
 

--- a/src/Github.ts
+++ b/src/Github.ts
@@ -181,6 +181,8 @@ export type Marker = {
   origin?: string | undefined
   /** Path of the mirroring file, so close and reopen act without scanning. */
   path?: string | undefined
+  /** How much the friction hurt, so a reopen restores the entry at the severity it was filed with. */
+  severity?: Entry.Severity | undefined
 }
 
 /**
@@ -192,6 +194,7 @@ export function renderMarker(marker: Marker): string {
   const parts = [`hash=${marker.hash}`]
   if (marker.path) parts.push(`path=${marker.path}`)
   if (marker.origin) parts.push(`origin=${marker.origin}`)
+  if (marker.severity) parts.push(`severity=${marker.severity}`)
   return `<!-- frog:${markerVersion} ${parts.join(' ')} -->`
 }
 
@@ -214,10 +217,13 @@ export function parseMarker(body: string | null | undefined): Marker | undefined
   const hash = fields.get('hash')
   if (!hash) return undefined
 
+  const severity = Entry.severities.find((value) => value === fields.get('severity'))
+
   return {
     hash,
     ...(fields.get('origin') ? { origin: fields.get('origin') } : {}),
     ...(fields.get('path') ? { path: fields.get('path') } : {}),
+    ...(severity ? { severity } : {}),
   }
 }
 
@@ -299,8 +305,8 @@ export function parseBody(body: string | null | undefined): string {
  * @returns Labels in that order, deduplicated.
  */
 export function toLabels(options: toLabels.Options): readonly string[] {
-  const { entry, labels, severityLabels } = options
-  return [...new Set([...labels, severityLabels[entry.severity], ...(entry.labels ?? [])])]
+  const { entry, labels } = options
+  return [...new Set([...labels, ...(entry.labels ?? [])])]
 }
 
 export declare namespace toLabels {
@@ -310,8 +316,6 @@ export declare namespace toLabels {
     entry: Pick<Entry.Entry, 'labels' | 'severity'>
     /** Labels applied to every issue, from config. */
     labels: readonly string[]
-    /** Label to apply for each severity, from config. */
-    severityLabels: Record<Entry.Severity, string>
   }
 }
 
@@ -324,12 +328,13 @@ export declare namespace toLabels {
  * @returns The rebuilt entry, already linked to the issue.
  */
 export function fromIssue(issue: Issue, options: fromIssue.Options): Entry.Entry {
-  const { id, labels, repo, severityLabels } = options
+  const { id, labels, repo } = options
 
   const names = toLabelNames(issue)
-  const severity =
-    Entry.severities.find((value) => names.includes(severityLabels[value])) ?? 'minor'
-  const managed = new Set<string>([...labels, ...Object.values(severityLabels)])
+  // From the marker, not the labels: a label would be in the receiver's namespace, and cross-repo the
+  // two projects need not agree on what a severity is called.
+  const severity = parseMarker(issue.body)?.severity ?? 'minor'
+  const managed = new Set<string>(labels)
   const extra = names.filter((name) => !managed.has(name))
 
   return {
@@ -352,7 +357,6 @@ export declare namespace fromIssue {
     /** Repository holding the issue, as `owner/name`. */
     repo: string
     /** Label to apply for each severity, from config. Reversed to recover severity. */
-    severityLabels: Record<Entry.Severity, string>
   }
 }
 

--- a/src/Sync.test.ts
+++ b/src/Sync.test.ts
@@ -6,12 +6,6 @@ import * as Sync from './Sync.js'
 
 const repo = 'wevm/demo'
 const labels = ['friction']
-const severityLabels = {
-  blocker: 'friction:blocker',
-  major: 'friction:major',
-  minor: 'friction:minor',
-} as const
-
 function entry(overrides: Partial<Entry.Entry> = {}): Entry.Entry {
   return { body: 'Body.', id: 'a', severity: 'minor', title: 'Filters ignored', ...overrides }
 }
@@ -20,9 +14,14 @@ function issue(overrides: Partial<Github.Issue> = {}): Github.Issue {
   return {
     body: Github.renderBody({
       body: 'Body.',
-      marker: { hash: Github.hash('Filters ignored'), origin: repo, path: Store.toPath('a') },
+      marker: {
+        hash: Github.hash('Filters ignored'),
+        origin: repo,
+        path: Store.toPath('a'),
+        severity: 'minor',
+      },
     }),
-    labels: ['friction', 'friction:minor'],
+    labels: ['friction'],
     number: 1,
     state: 'open',
     title: 'Filters ignored',
@@ -41,7 +40,6 @@ function plan(
     labels,
     ...(mirrors ? { mirrors } : {}),
     repo,
-    severityLabels,
   })
 }
 
@@ -90,7 +88,24 @@ describe('plan', () => {
   })
 
   test('behavior: an open issue with no local file is rebuilt', () => {
-    const result = plan([], [issue({ labels: ['friction', 'friction:blocker', 'tooling'] })])
+    const result = plan(
+      [],
+      [
+        issue({
+          // Severity rides in the marker now, so this is what proves it survives a rebuild.
+          body: Github.renderBody({
+            body: 'Body.',
+            marker: {
+              hash: Github.hash('Filters ignored'),
+              origin: repo,
+              path: Store.toPath('a'),
+              severity: 'blocker',
+            },
+          }),
+          labels: ['friction', 'tooling'],
+        }),
+      ],
+    )
     expect(result.write).toEqual([
       {
         body: 'Body.',
@@ -207,7 +222,7 @@ describe('plan across repositories', () => {
         body: 'Body.',
         marker: { hash: Github.hash('Filters ignored'), origin: repo, path: Store.toPath('a') },
       }),
-      labels: ['friction', 'friction:minor'],
+      labels: ['friction'],
       number: 1,
       state: 'open',
       title: 'Filters ignored',
@@ -216,7 +231,7 @@ describe('plan across repositories', () => {
   }
 
   function across(entries: readonly Entry.Entry[], issues: readonly Github.Issue[]): Sync.Plan {
-    return Sync.plan({ entries, issues, labels, origin: repo, repo: upstream, severityLabels })
+    return Sync.plan({ entries, issues, labels, origin: repo, repo: upstream })
   }
 
   test('behavior: an upstream issue that closed removes the entry mirroring it', () => {

--- a/src/Sync.ts
+++ b/src/Sync.ts
@@ -32,7 +32,7 @@ export type Plan = {
  * @returns The edits to apply. Applying a plan and re-planning yields an empty plan.
  */
 export function plan(options: plan.Options): Plan {
-  const { entries, issues, labels, mirrors = [], repo, severityLabels } = options
+  const { entries, issues, labels, mirrors = [], repo } = options
   // Where the files are, which is only the same as where the issues are when reporting to yourself.
   const origin = options.origin ?? repo
 
@@ -88,7 +88,7 @@ export function plan(options: plan.Options): Plan {
 
       const id = Store.toId(path)
       if (!id) continue
-      write.push(Github.fromIssue(issue, { id, labels, repo, severityLabels }))
+      write.push(Github.fromIssue(issue, { id, labels, repo }))
       present.add(path)
     }
   }
@@ -117,7 +117,6 @@ export declare namespace plan {
     /** Repository the issues live in, as `owner/name`. */
     repo: string
     /** Label to apply for each severity, from config. */
-    severityLabels: Record<Entry.Severity, string>
   }
 }
 

--- a/src/Target.test.ts
+++ b/src/Target.test.ts
@@ -17,13 +17,19 @@ describe('classify', () => {
 
 describe('resolve', () => {
   /** Resolver stack backed by plain data, since resolution is all policy and no transport. */
-  function options(overrides: Partial<Target.resolve.Options> = {}): Target.resolve.Options {
+  function options(
+    overrides: Partial<Omit<Target.resolve.Options, 'outbound'>> & {
+      allowedRepos?: Config.Outbound['allowedRepos'] | undefined
+      outbound?: Partial<Config.Outbound> | undefined
+    } = {},
+  ): Target.resolve.Options {
+    const { allowedRepos = [], outbound, ...rest } = overrides
     return {
-      allowedRepos: [],
+      outbound: { allowedRepos, enabled: true, ...outbound },
       readConfig: async () => undefined,
       readRepo: async () => undefined,
       self,
-      ...overrides,
+      ...rest,
     }
   }
 
@@ -198,6 +204,25 @@ describe('resolve', () => {
         options({ allowedRepos: [upstream], readConfig: accepts({ allowFrom: ['acme/*'] }) }),
       )
       expect(result.ok).toBe(true)
+    })
+
+    // Refused before `readConfig` runs: a repository that sends nothing should not spend a request
+    // asking a target whether it would have accepted.
+    test('error: outbound is disabled, so no target but this repository resolves', async () => {
+      let asked = false
+      const result = await Target.resolve(
+        upstream,
+        options({
+          allowedRepos: [upstream],
+          outbound: { enabled: false },
+          readConfig: async () => {
+            asked = true
+            return { enabled: true }
+          },
+        }),
+      )
+      expect(result.ok === false && result.code).toBe('OUTBOUND_DISABLED')
+      expect(asked).toBe(false)
     })
 
     test('error: the target is not on the sender allowedRepos list', async () => {

--- a/src/Target.ts
+++ b/src/Target.ts
@@ -64,6 +64,7 @@ export type Resolution =
  * Two gates guard a target that is not this repository. The receiver must have committed a config
  * accepting inbound friction, and may restrict who reports. And the sender must have listed the target in
  * `outbound.allowedRepos`, read from the base branch so a pull request cannot name its own destination.
+ * Setting `outbound.enabled` to false refuses every target but this repository.
  *
  * @returns The target, or a refusal naming which gate stopped it.
  */
@@ -71,7 +72,7 @@ export async function resolve(
   value: string | undefined,
   options: resolve.Options,
 ): Promise<Resolution> {
-  const { allowedRepos, readConfig, self } = options
+  const { outbound, readConfig, self } = options
 
   // No target means this repository, which needs nobody's consent.
   if (!value) {
@@ -91,6 +92,15 @@ export async function resolve(
 
   if (repo === self) return { ok: true, target: { kind: 'self', repo } }
 
+  // Checked before asking the target for consent: there is no point spending a request on a report this
+  // repository has switched off sending.
+  if (!outbound.enabled)
+    return {
+      code: 'OUTBOUND_DISABLED',
+      message: `\`${repo}\` cannot be reported: \`outbound.enabled\` is off.`,
+      ok: false,
+    }
+
   const inbound = await readConfig(repo)
   if (!inbound)
     return {
@@ -108,7 +118,7 @@ export async function resolve(
       ok: false,
     }
 
-  if (!allowed(allowedRepos, repo))
+  if (!allowed(outbound.allowedRepos, repo))
     return {
       code: 'TARGET_NOT_ALLOWED',
       message: `\`${repo}\` is not listed in \`outbound.allowedRepos\`.`,
@@ -129,8 +139,8 @@ export async function resolve(
 export declare namespace resolve {
   /** Options for {@link resolve}. */
   type Options = {
-    /** Targets this repository may file against, from the sender's base-branch config. */
-    allowedRepos: readonly string[]
+    /** Whether this repository reports outbound at all, and where, from its base-branch config. */
+    outbound: Config.Outbound
     /**
      * Reads a repository's committed inbound policy from its default branch.
      *

--- a/src/cli/commands/log.test.ts
+++ b/src/cli/commands/log.test.ts
@@ -247,26 +247,14 @@ describe('--publish', () => {
     expect(instance.issues.get(repo)?.[0]?.title).toBe(title)
   })
 
-  test('behavior: publishOnLog config makes it the default', async () => {
+  // Filing is opt-in even when GitHub is reachable: the entry belongs in the same commit as the work,
+  // and an issue filed on every `log` would publish drafts the author has not finished.
+  test('behavior: files nothing unless asked', async () => {
     const cwd = await helpers.repo({ remote })
     const instance = await github()
-    await helpers.writeFile(Config.file, JSON.stringify({ publishOnLog: true }), cwd)
 
     const result = await cli.data<Logged & { issue?: string }>(
       ['log', title, '--body', body, '--cwd', cwd],
-      { GITHUB_API_URL: instance.url, GITHUB_TOKEN: 'test-token' },
-    )
-
-    expect(result.issue).toBe(`${repo}#1`)
-  })
-
-  test('behavior: --no-publish opts out of the config default', async () => {
-    const cwd = await helpers.repo({ remote })
-    const instance = await github()
-    await helpers.writeFile(Config.file, JSON.stringify({ publishOnLog: true }), cwd)
-
-    const result = await cli.data<Logged & { issue?: string }>(
-      ['log', title, '--body', body, '--no-publish', '--cwd', cwd],
       { GITHUB_API_URL: instance.url, GITHUB_TOKEN: 'test-token' },
     )
 

--- a/src/cli/commands/log.ts
+++ b/src/cli/commands/log.ts
@@ -68,7 +68,7 @@ export const log = Cli.create('log', {
     publish: z
       .boolean()
       .optional()
-      .describe('File the issue immediately. Defaults to the `publishOnLog` config value.'),
+      .describe('File the issue immediately, rather than leaving it for `publish`.'),
     severity: Entry.Severity.optional().describe('Impact. Defaults to minor.'),
     token: z.string().min(1).optional().describe('GitHub token. Overrides the environment.'),
     target: z
@@ -146,7 +146,7 @@ export const log = Cli.create('log', {
       !body && c.options.target
         ? await attempt(
             form.scaffold(c.options.target, {
-              allowedRepos: config.outbound.allowedRepos,
+              outbound: config.outbound,
               env: c.env,
               root,
               self: repo,
@@ -218,7 +218,7 @@ export const log = Cli.create('log', {
       if (!edited.ok) return c.error({ code: edited.code, message: edited.message })
     }
 
-    if (!(c.options.publish ?? config.publishOnLog))
+    if (!c.options.publish)
       return c.ok(
         { artifacts: Store.toArtifacts(id), file, id, title },
         {
@@ -248,7 +248,7 @@ export const log = Cli.create('log', {
         const resolution = await Target.resolve(
           entry.target,
           target.resolvers({
-            allowedRepos: config.outbound.allowedRepos,
+            outbound: config.outbound,
             client: ready.client,
             root,
             self: ready.repo,

--- a/src/cli/commands/publish.test.ts
+++ b/src/cli/commands/publish.test.ts
@@ -34,11 +34,12 @@ test('behavior: files a pending entry and writes the link back', async () => {
 
   const issue = instance.issues.get(repo)?.[0]
   expect(issue?.title).toBe('Filters ignored')
-  expect(issue?.labels).toEqual(['friction', 'friction:major'])
+  expect(issue?.labels).toEqual(['friction'])
   expect(Github.parseMarker(issue?.body)).toEqual({
     hash: Github.hash('Filters ignored'),
     origin: repo,
     path: '.agents/friction-log/a/friction.md',
+    severity: 'major',
   })
 })
 
@@ -110,9 +111,7 @@ test('behavior: commits the links by default', async () => {
   const result = await cli.data<Outcome>(['publish', '--cwd', cwd], env(instance.url))
 
   expect(result.committed).toBe(true)
-  expect(await helpers.git(['log', '-1', '--format=%s'], cwd)).toBe(
-    'chore: link friction log to issues',
-  )
+  expect(await helpers.git(['log', '-1', '--format=%s'], cwd)).toBe('chore: sync friction log')
   expect(await helpers.git(['status', '--porcelain'], cwd)).toBe('')
 })
 
@@ -243,11 +242,7 @@ describe('cross-repo', () => {
 
     await cli.data<Outcome>(['publish', '--cwd', cwd], env(instance.url))
 
-    expect(instance.issues.get(upstream)?.[0]?.labels).toEqual([
-      'friction',
-      'from-consumer',
-      'friction:minor',
-    ])
+    expect(instance.issues.get(upstream)?.[0]?.labels).toEqual(['friction', 'from-consumer'])
   })
 
   test('behavior: records the consumer repository as the origin', async () => {
@@ -397,7 +392,7 @@ describe('cross-repo', () => {
     expect(result.committed).toBe(true)
     expect(await helpers.git(['status', '--porcelain'], cwd)).toBe('')
     expect((await helpers.git(['log', '--format=%s'], cwd)).split('\n')[0]).toBe(
-      'chore: link friction log to issues',
+      'chore: sync friction log',
     )
   })
 })

--- a/src/cli/commands/publish.ts
+++ b/src/cli/commands/publish.ts
@@ -96,7 +96,7 @@ export const publish = Cli.create('publish', {
     // Each entry's target is resolved through the consent gates before anything is filed, and entries
     // are grouped by destination so one repository costs one index lookup however many entries it has.
     const resolvers = target.resolvers({
-      allowedRepos: config.outbound.allowedRepos,
+      outbound: config.outbound,
       client: ready.client,
       root,
       self: ready.repo,
@@ -169,7 +169,7 @@ export const publish = Cli.create('publish', {
     const committed = await (async () => {
       if (c.options.commit === false || c.options.dryRun || written.length === 0) return false
       await Git.add(written, { cwd: root })
-      return Git.commit('chore: link friction log to issues', { cwd: root, files: written })
+      return Git.commit('chore: sync friction log', { cwd: root, files: written })
     })()
 
     return c.ok(

--- a/src/cli/commands/sync.test.ts
+++ b/src/cli/commands/sync.test.ts
@@ -1,6 +1,7 @@
 import * as cli from '../../../test/cli.js'
 import { github } from '../../../test/github.js'
 import * as helpers from '../../../test/helpers.js'
+import * as Entry from '../../Entry.js'
 import * as Github from '../../Github.js'
 import * as Mirrors from '../../Mirrors.js'
 import * as Store from '../../Store.js'
@@ -20,10 +21,15 @@ function env(url: string): Record<string, string> {
   return { GITHUB_API_URL: url, GITHUB_TOKEN: 'test-token' }
 }
 
-function issueBody(id: string, body = 'Body.'): string {
+function issueBody(id: string, body = 'Body.', severity?: Entry.Severity): string {
   return Github.renderBody({
     body,
-    marker: { hash: Github.hash(title), origin: repo, path: Store.toPath(id) },
+    marker: {
+      hash: Github.hash(title),
+      origin: repo,
+      path: Store.toPath(id),
+      ...(severity ? { severity } : {}),
+    },
   })
 }
 
@@ -127,7 +133,7 @@ test('behavior: an edited issue rewrites the entry', async () => {
 test('behavior: an open issue whose file was deleted is rebuilt', async () => {
   const cwd = await helpers.repo({ remote })
   const instance = await github({
-    [repo]: [{ body: issueBody('a'), labels: ['friction', 'friction:blocker'], title }],
+    [repo]: [{ body: issueBody('a', 'Body.', 'blocker'), labels: ['friction'], title }],
   })
 
   expect((await cli.data<Outcome>(['sync', '--cwd', cwd], env(instance.url))).updated).toEqual([

--- a/src/cli/commands/sync.ts
+++ b/src/cli/commands/sync.ts
@@ -117,7 +117,6 @@ export const sync = Cli.create('sync', {
           // The files are always here, whichever repository the issues are in.
           origin: ready.repo,
           repo: destination,
-          severityLabels: config.severityLabels,
         }),
       )
 

--- a/src/cli/internal/form.ts
+++ b/src/cli/internal/form.ts
@@ -1,3 +1,4 @@
+import * as Config from '../../Config.js'
 import * as Github from '../../Github.js'
 import * as IssueForm from '../../IssueForm.js'
 import * as Target from '../../Target.js'
@@ -21,7 +22,7 @@ export async function scaffold(
   value: string,
   options: scaffold.Options,
 ): Promise<string | undefined> {
-  const { allowedRepos, env, root, self } = options
+  const { env, outbound, root, self } = options
 
   const token = await octokit.token({ env, ...(options.token ? { token: options.token } : {}) })
   const client = octokit.client({
@@ -29,10 +30,7 @@ export async function scaffold(
     ...(env.GITHUB_API_URL ? { baseUrl: env.GITHUB_API_URL } : {}),
   })
 
-  const resolution = await Target.resolve(
-    value,
-    target.resolvers({ allowedRepos, client, root, self }),
-  )
+  const resolution = await Target.resolve(value, target.resolvers({ client, outbound, root, self }))
   // A refused target is reported by publishing, which says why. Here it only means there is no form to
   // write against, and the entry still has to be written.
   if (!resolution.ok || resolution.target.kind === 'self') return undefined
@@ -50,8 +48,8 @@ export async function scaffold(
 export declare namespace scaffold {
   /** Options for {@link scaffold}. */
   type Options = {
-    /** Targets this repository may file against, from config. */
-    allowedRepos: readonly string[]
+    /** Outbound policy from config: whether to report at all, and where. */
+    outbound: Config.Outbound
     /** Environment, for the API base URL and the token. */
     env: octokit.token.Options['env'] & { GITHUB_API_URL?: string | undefined }
     /** Repository root, holding `node_modules`. */

--- a/src/cli/internal/publish.ts
+++ b/src/cli/internal/publish.ts
@@ -169,11 +169,10 @@ export async function file(options: file.Options): Promise<Outcome> {
       labels: Github.toLabels({
         entry: entry,
         labels: applied,
-        severityLabels: config.severityLabels,
       }),
       // `origin` is the repository holding the file, which is not the destination when reporting
       // upstream. Getting this wrong would leave a closed issue unable to find its mirror.
-      marker: { hash, origin, path },
+      marker: { hash, origin, path, severity: entry.severity },
       provenance: { ...provenance, ...(pr ? { pr } : {}) },
       repo,
       ...(existing ? { existing } : {}),

--- a/src/cli/internal/target.ts
+++ b/src/cli/internal/target.ts
@@ -16,10 +16,10 @@ const concurrency = 8
  * supplies its own pair, which is why `Target` takes them rather than importing any of it.
  */
 export function resolvers(options: resolvers.Options): Target.resolve.Options {
-  const { allowedRepos, client, root, self, store } = options
+  const { outbound, client, root, self, store } = options
 
   return {
-    allowedRepos,
+    outbound,
     readConfig: reader({ client, ...(store ? { store } : {}) }),
     readRepo: (name) => repoOf(name, root),
     self,
@@ -29,8 +29,8 @@ export function resolvers(options: resolvers.Options): Target.resolve.Options {
 export declare namespace resolvers {
   /** Options for {@link resolvers}. */
   type Options = {
-    /** Targets this repository may file against, from config. */
-    allowedRepos: readonly string[]
+    /** Outbound policy from config: whether to report at all, and where. */
+    outbound: Config.Outbound
     /** Authenticated client, for reading a target repository's committed config. */
     client: Github.Client
     /** Repository root, holding `node_modules`. */


### PR DESCRIPTION
Removes three config options that either duplicated an existing switch or gated something that should not have been optional.

- `severityLabels` is gone; severity now travels in the `frog:v1` marker, so it survives a receiving project that renames or drops labels.
- `publishOnLog` is gone; `--publish` is the only way to file on `log`.
- `outbound.auto` becomes `outbound.enabled`, defaulting to `true`. Anything in `outbound.allowedRepos` is filed automatically, and the gate moved into `Target.resolve` so it applies to the CLI as well as the App.

Schema keys are now sorted alphabetically.
