### PR TITLE
feat(app): describe the reconciling pull request

### DIFF
--- a/.changeset/sync-pull-request-body.md
+++ b/.changeset/sync-pull-request-body.md
@@ -1,0 +1,5 @@
+---
+'frog': patch
+---
+
+The reconciling pull request now describes what merging it would do, rewritten on every run so it covers every closure on the branch rather than only the first.

--- a/.changeset/sync-pull-request-body.md
+++ b/.changeset/sync-pull-request-body.md
@@ -1,5 +1,0 @@
----
-'frog': patch
----
-
-The reconciling pull request now describes what merging it would do, rewritten on every run so it covers every closure on the branch rather than only the first.

--- a/app/src/Repository.ts
+++ b/app/src/Repository.ts
@@ -295,7 +295,12 @@ export async function upsert(client: Octokit, options: upsert.Options): Promise<
   const { owner, repo: name } = Github.split(repo)
 
   const existing = await review(client, { base, branch, repo })
-  if (existing) return existing
+  if (existing) {
+    // The branch accumulates closures across deliveries, so the description is rewritten each time
+    // rather than left describing only what the first one did.
+    await client.rest.pulls.update({ body: options.body, owner, pull_number: existing, repo: name })
+    return existing
+  }
 
   const created = await client.rest.pulls.create({
     base,
@@ -315,7 +320,7 @@ export declare namespace upsert {
     base: string
     /** Branch the reconciling commits land on. */
     branch: string
-    /** Description, used only when opening. */
+    /** Description. Rewritten on every reconciliation, so it always describes the whole branch. */
     body: string
     /** Repository holding both branches, as `owner/name`. */
     repo: string

--- a/app/src/handlers/issues.test.ts
+++ b/app/src/handlers/issues.test.ts
@@ -353,14 +353,21 @@ describe('pullRequest', () => {
     expect(instance.messages(consumer)).toEqual(['initial'])
 
     expect(outcome.pullRequest).toBeDefined()
-    expect(instance.reviews(consumer)).toEqual([
-      {
-        base: 'main',
-        head: 'frog/sync',
-        number: outcome.pullRequest,
-        title: 'chore: sync friction log',
-      },
-    ])
+    const [review] = instance.reviews(consumer)
+    const { body: description, ...opened } = review ?? {}
+    expect(opened).toEqual({
+      base: 'main',
+      head: 'frog/sync',
+      number: outcome.pullRequest,
+      title: 'chore: sync friction log',
+    })
+    expect(description).toMatchInlineSnapshot(`
+      "Opened by the [frog](https://github.com/wevm/frog) GitHub App. Merging syncs the friction log with its issues.
+
+      ## Resolved
+
+      -   [acme/app#1](https://github.com/acme/app/issues/1) Filters ignored"
+    `)
   })
 
   // Three closures, one review. The point of a long-lived branch rather than one per event.
@@ -411,6 +418,11 @@ describe('pullRequest', () => {
     const files = instance.files(consumer, 'frog/sync')
     expect(files[`${dir}/a/friction.md`]).toBeUndefined()
     expect(files[`${dir}/b/friction.md`]).toBeUndefined()
+
+    // And the description covers both, not just the closure that opened it.
+    const description = instance.reviews(consumer)[0]?.body ?? ''
+    expect(description).toContain(`[${consumer}#1](https://github.com/${consumer}/issues/1)`)
+    expect(description).toContain(`[${consumer}#2](https://github.com/${consumer}/issues/2)`)
   })
 
   // The reopen has to reverse a deletion that is still only queued. Planning against the default branch

--- a/app/src/handlers/issues.test.ts
+++ b/app/src/handlers/issues.test.ts
@@ -362,7 +362,7 @@ describe('pullRequest', () => {
       title: 'chore: sync friction log',
     })
     expect(description).toMatchInlineSnapshot(`
-      "Opened by the [frog](https://github.com/wevm/frog) GitHub App. Merging syncs the friction log with its issues.
+      "Opened by the [frog](https://github.com/wevm/frog) GitHub App.
 
       ## Resolved
 

--- a/app/src/handlers/issues.ts
+++ b/app/src/handlers/issues.ts
@@ -3,6 +3,7 @@ import type { Octokit } from 'octokit'
 import * as config from '../internal/config.js'
 import * as mirrors from '../internal/mirrors.js'
 import * as serialization from '../internal/serialize.js'
+import * as summary from '../internal/summary.js'
 import * as Repository from '../Repository.js'
 
 /** What reconciling an issue event did. */
@@ -161,9 +162,11 @@ export async function issues(options: issues.Options): Promise<Outcome> {
       review && committed
         ? await Repository.upsert(source, {
             base: branch,
-            body:
-              'Entries whose issues have closed, and entries restored because an issue reopened.\n\n' +
-              'Merging keeps the friction log true. Until then it lists friction that is already resolved.',
+            body: await summary.describe(source, {
+              base: branch,
+              branch: settings.pullRequest.branch,
+              repo: origin,
+            }),
             branch: settings.pullRequest.branch,
             repo: origin,
             title: 'chore: sync friction log',

--- a/app/src/handlers/push.ts
+++ b/app/src/handlers/push.ts
@@ -4,6 +4,7 @@ import type * as comment from '../internal/comment.js'
 import * as config from '../internal/config.js'
 import * as filing from '../internal/file.js'
 import * as serialization from '../internal/serialize.js'
+import * as summary from '../internal/summary.js'
 import * as Repository from '../Repository.js'
 
 /** What a push run did. */
@@ -102,9 +103,11 @@ export async function push(options: push.Options): Promise<Outcome> {
     review && committed
       ? await Repository.upsert(client, {
           base: branch,
-          body:
-            'Issue links for friction filed from this repository, and entries reconciled against issues that closed or reopened.\n\n' +
-            'Merging keeps the friction log true. Until then it lists friction that is already resolved, and omits links to issues already filed.',
+          body: await summary.describe(client, {
+            base: branch,
+            branch: settings.pullRequest.branch,
+            repo,
+          }),
           branch: settings.pullRequest.branch,
           repo,
           title: 'chore: sync friction log',

--- a/app/src/internal/summary.test.ts
+++ b/app/src/internal/summary.test.ts
@@ -1,0 +1,69 @@
+import type { Entry } from 'frog'
+import * as summary from './summary.js'
+
+const repo = 'acme/app'
+
+function entry(id: string, overrides: Partial<Entry.Entry> = {}): Entry.Entry {
+  return {
+    body: 'The filter was swallowed.',
+    id,
+    severity: 'minor',
+    title: `Friction ${id}`,
+    ...overrides,
+  }
+}
+
+test('behavior: an entry the branch drops is resolved', () => {
+  const body = summary.render({
+    base: [entry('a', { issue: `${repo}#1` })],
+    branch: [],
+  })
+
+  expect(body).toContain('## Resolved')
+  expect(body).toContain(`[${repo}#1](https://github.com/${repo}/issues/1) Friction a`)
+})
+
+test('behavior: an entry the branch adds back is reopened', () => {
+  const body = summary.render({
+    base: [],
+    branch: [entry('a', { issue: `${repo}#1` })],
+  })
+
+  expect(body).toContain('## Reopened')
+  expect(body).not.toContain('## Resolved')
+})
+
+test('behavior: an entry gaining a link is listed as linked', () => {
+  const body = summary.render({
+    base: [entry('a')],
+    branch: [entry('a', { issue: `${repo}#1` })],
+  })
+
+  expect(body).toContain('## Linked')
+  expect(body).not.toContain('## Reopened')
+})
+
+// One pull request accumulates several closures, so the description has to cover all of them at once.
+test('behavior: every kind of change appears together', () => {
+  const body = summary.render({
+    base: [entry('a', { issue: `${repo}#1` }), entry('b')],
+    branch: [entry('b', { issue: `${repo}#2` }), entry('c', { issue: `${repo}#3` })],
+  })
+
+  expect(body.indexOf('## Resolved')).toBeLessThan(body.indexOf('## Reopened'))
+  expect(body.indexOf('## Reopened')).toBeLessThan(body.indexOf('## Linked'))
+  expect(body).toContain('Friction a')
+  expect(body).toContain('Friction c')
+  expect(body).toContain('Friction b')
+})
+
+test('behavior: an unlinked entry falls back to its id', () => {
+  expect(summary.render({ base: [entry('a')], branch: [] })).toContain('`a` Friction a')
+})
+
+test('behavior: no differences leaves the explanation alone', () => {
+  const body = summary.render({ base: [entry('a')], branch: [entry('a')] })
+
+  expect(body).not.toContain('## Resolved')
+  expect(body).toContain('Opened by the [frog](https://github.com/wevm/frog) GitHub App')
+})

--- a/app/src/internal/summary.ts
+++ b/app/src/internal/summary.ts
@@ -1,0 +1,89 @@
+import { type Entry, Github } from 'frog'
+import type { Octokit } from 'octokit'
+import * as Repository from '../Repository.js'
+
+const intro =
+  'Opened by the [frog](https://github.com/wevm/frog) GitHub App. Merging syncs the friction log ' +
+  'with its issues.'
+
+function link(entry: Entry.Entry): string {
+  const parsed = entry.issue ? Github.parseLink(entry.issue) : undefined
+  if (!parsed) return `\`${entry.id}\` ${entry.title}`
+  return `[${entry.issue}](https://github.com/${parsed.repo}/issues/${parsed.issue}) ${entry.title}`
+}
+
+function section(title: string, entries: readonly Entry.Entry[]): string | undefined {
+  if (entries.length === 0) return undefined
+  return `## ${title}\n\n${entries.map((entry) => `-   ${link(entry)}`).join('\n\n')}`
+}
+
+/**
+ * Describes what merging the reconciling pull request would do.
+ *
+ * Derived from the branch rather than from the delivery that last wrote to it. One pull request
+ * accumulates several closures, so a description built from one delivery would describe only the most
+ * recent and quietly misrepresent the rest.
+ *
+ * @returns Markdown body.
+ */
+export function render(options: render.Options): string {
+  const { base, branch } = options
+
+  const current = new Map(base.map((entry) => [entry.id, entry]))
+  const proposed = new Map(branch.map((entry) => [entry.id, entry]))
+
+  const resolved = base.filter((entry) => !proposed.has(entry.id))
+  const reopened = branch.filter((entry) => !current.has(entry.id))
+  const linked = branch.filter((entry) => {
+    const existing = current.get(entry.id)
+    return existing && !existing.issue && entry.issue
+  })
+
+  const sections = [
+    section('Resolved', resolved),
+    section('Reopened', reopened),
+    section('Linked', linked),
+  ].filter((value) => value !== undefined)
+
+  if (sections.length === 0) return intro
+  return `${intro}\n\n${sections.join('\n\n')}`
+}
+
+export declare namespace render {
+  /** Options for {@link render}. */
+  type Options = {
+    /** Entries on the branch being merged into. */
+    base: readonly Entry.Entry[]
+    /** Entries on the reconciling branch. */
+    branch: readonly Entry.Entry[]
+  }
+}
+
+/**
+ * Reads both branches and describes the difference between them.
+ *
+ * @param client - Installation client for the repository.
+ * @returns Markdown body for the reconciling pull request.
+ */
+export async function describe(client: Octokit, options: describe.Options): Promise<string> {
+  const { base, branch, repo } = options
+
+  const [current, proposed] = await Promise.all([
+    Repository.read(client, { ref: base, repo }),
+    Repository.read(client, { ref: branch, repo }),
+  ])
+
+  return render({ base: current.entries, branch: proposed.entries })
+}
+
+export declare namespace describe {
+  /** Options for {@link describe}. */
+  type Options = {
+    /** Branch the pull request merges into. */
+    base: string
+    /** Branch the reconciling commits land on. */
+    branch: string
+    /** Repository holding both, as `owner/name`. */
+    repo: string
+  }
+}

--- a/app/src/internal/summary.ts
+++ b/app/src/internal/summary.ts
@@ -2,9 +2,7 @@ import { type Entry, Github } from 'frog'
 import type { Octokit } from 'octokit'
 import * as Repository from '../Repository.js'
 
-const intro =
-  'Opened by the [frog](https://github.com/wevm/frog) GitHub App. Merging syncs the friction log ' +
-  'with its issues.'
+const intro = 'Opened by the [frog](https://github.com/wevm/frog) GitHub App.'
 
 function link(entry: Entry.Entry): string {
   const parsed = entry.issue ? Github.parseLink(entry.issue) : undefined

--- a/test/github.ts
+++ b/test/github.ts
@@ -29,7 +29,7 @@ export type Instance = {
   /** Pull requests opened through the API, in creation order. */
   reviews: (
     repo: string,
-  ) => readonly { base: string; head: string; number: number; title: string }[]
+  ) => readonly { base: string; body: string; head: string; number: number; title: string }[]
   /** Replaces a file on a branch, for asserting what happens once an entry is edited. */
   write: (repo: string, path: string, contents: string, branch?: string) => void
 }
@@ -153,6 +153,7 @@ export async function github(seed: Seed = {}, options: Options = {}): Promise<In
   /** Pull requests opened through the API, for the reconciling one. */
   const reviews: {
     base: string
+    body: string
     head: string
     number: number
     repo: string
@@ -269,10 +270,16 @@ export async function github(seed: Seed = {}, options: Options = {}): Promise<In
           )
         }
         if (request.method === 'POST') {
-          const payload = await readBody<{ base?: string; head?: string; title?: string }>(request)
+          const payload = await readBody<{
+            base?: string
+            body?: string
+            head?: string
+            title?: string
+          }>(request)
           const number = nextNumber(name)
           const review = {
             base: payload.base ?? 'main',
+            body: payload.body ?? '',
             head: payload.head ?? '',
             number,
             repo: name,
@@ -282,6 +289,19 @@ export async function github(seed: Seed = {}, options: Options = {}): Promise<In
           reviews.push(review)
           return json(response, 201, review)
         }
+      }
+
+      const pullPath = /^\/repos\/([^/]+)\/([^/]+)\/pulls\/(\d+)$/.exec(url.pathname)
+      if (pullPath && request.method === 'PATCH') {
+        const name = `${pullPath[1]}/${pullPath[2]}`
+        const payload = await readBody<{ body?: string; title?: string }>(request)
+        const review = reviews.find(
+          (candidate) => candidate.repo === name && candidate.number === Number(pullPath[3]),
+        )
+        if (!review) return json(response, 404, { message: 'Not Found' })
+        if (payload.body !== undefined) review.body = payload.body
+        if (payload.title !== undefined) review.title = payload.title
+        return json(response, 200, review)
       }
 
       // `repos.get`, for whether this token may label issues here.
@@ -585,7 +605,7 @@ export async function github(seed: Seed = {}, options: Options = {}): Promise<In
     reviews(repo) {
       return reviews
         .filter((review) => review.repo === repo)
-        .map(({ base, head, number, title }) => ({ base, head, number, title }))
+        .map(({ base, body, head, number, title }) => ({ base, body, head, number, title }))
     },
     url: `http://127.0.0.1:${address.port}`,
     write(repo, path, contents, branch = 'main') {


### PR DESCRIPTION
The reconciling pull request now describes what merging it would do, in the shape the changesets release pull request uses.

Built from the diff between the branch and its base rather than from the delivery that last wrote to it, so it covers every closure the branch has accumulated. Rewritten on each run, since one pull request outlives many deliveries.
