### PR TITLE
refactor(init): drop TEMPLATE.md in favour of the issue form

### DIFF
--- a/src/cli/commands/init.test.ts
+++ b/src/cli/commands/init.test.ts
@@ -5,7 +5,6 @@ import * as helpers from '../../../test/helpers.js'
 import * as Config from '../../Config.js'
 import * as Entry from '../../Entry.js'
 import * as IssueForm from '../../IssueForm.js'
-import * as Store from '../../Store.js'
 
 test('behavior: scaffolds the directory', async () => {
   const cwd = await helpers.repo()
@@ -14,7 +13,6 @@ test('behavior: scaffolds the directory', async () => {
     {
       "created": [
         ".agents/friction-log/README.md",
-        ".agents/friction-log/TEMPLATE.md",
         ".agents/friction-log/config.json",
       ],
       "existing": [],
@@ -25,19 +23,6 @@ test('behavior: scaffolds the directory', async () => {
   expect(await Config.resolve({ root: cwd })).toEqual(Config.from({}))
 })
 
-test('behavior: the template it writes parses as an entry', async () => {
-  const cwd = await helpers.repo()
-  await cli.data(['init', '--cwd', cwd])
-
-  const template = await fs.readFile(path.join(cwd, Store.dir, 'TEMPLATE.md'), 'utf8')
-  await fs.mkdir(path.join(cwd, Store.toDir('from-template')), { recursive: true })
-  await fs.writeFile(path.join(cwd, Store.toPath('from-template')), template, 'utf8')
-
-  expect((await Store.get('from-template', { root: cwd })).title).toBe(
-    'One line, specific enough to search for',
-  )
-})
-
 test('behavior: re-running never clobbers local edits', async () => {
   const cwd = await helpers.repo()
   await cli.data(['init', '--cwd', cwd])
@@ -45,11 +30,7 @@ test('behavior: re-running never clobbers local edits', async () => {
 
   expect(await cli.data(['init', '--cwd', cwd])).toMatchObject({
     created: [],
-    existing: [
-      '.agents/friction-log/README.md',
-      '.agents/friction-log/TEMPLATE.md',
-      '.agents/friction-log/config.json',
-    ],
+    existing: ['.agents/friction-log/README.md', '.agents/friction-log/config.json'],
   })
   expect((await Config.resolve({ root: cwd })).maxPerRun).toBe(3)
 })

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -36,7 +36,7 @@ frog list    # what is already known
 frog log     # add one
 \`\`\`
 
-Follow [\`TEMPLATE.md\`](./TEMPLATE.md). Ids are when the friction was hit plus its title, so this
+\`frog log\` writes the sections to fill in. Ids are when the friction was hit plus its title, so this
 directory reads oldest-first and shows at a glance how long something has gone unresolved.
 
 Put anything that reproduces the friction in that entry's \`${Store.artifacts}/\` and reference it from the
@@ -50,16 +50,6 @@ Add this to \`AGENTS.md\`:
 
 Managed by [frog](https://github.com/wevm/frog).
 `
-
-const template = `---
-title: 'One line, specific enough to search for'
-severity: minor # blocker | major | minor
-# target: viem  # an upstream package or owner/repo. Omit for this repository.
-# labels:
-#   - tooling
----
-
-${Entry.template}`
 
 const schema = 'https://unpkg.com/frog/schema.json'
 
@@ -124,7 +114,6 @@ export const init = Cli.create('init', {
 
     const files = [
       [`${Store.dir}/README.md`, readme],
-      [`${Store.dir}/TEMPLATE.md`, template],
       [Config.file, c.options.library ? libraryConfig : config],
       // Only for a project accepting reports: it is what a consumer's frog writes its entry against.
       ...(c.options.library ? ([[`${IssueForm.dir}/${IssueForm.filename}`, form]] as const) : []),

--- a/src/cli/commands/list.ts
+++ b/src/cli/commands/list.ts
@@ -48,7 +48,7 @@ export const list = Cli.create('list', {
         code: entries.code,
         message: entries.message,
         cta: {
-          commands: [{ command: 'init', description: 'Recreate the template to compare against' }],
+          commands: [{ command: 'list', description: 'Check that every entry parses' }],
           description: 'Fix the file, then:',
         },
       })

--- a/src/cli/commands/log.test.ts
+++ b/src/cli/commands/log.test.ts
@@ -53,6 +53,33 @@ test('behavior: records severity, target, and labels', async () => {
   })
 })
 
+// A project that publishes a form has said how it wants friction written. That answer should hold for
+// its own entries too, not only for whoever reports to it.
+test('behavior: scaffolds from this repository own issue form', async () => {
+  const cwd = await helpers.repo()
+  await helpers.writeFile(
+    '.github/ISSUE_TEMPLATE/friction.yml',
+    [
+      'name: Friction',
+      'description: Something cost you time.',
+      'body:',
+      '  - type: textarea',
+      '    attributes:',
+      '      label: What Broke',
+      '      description: The thing that cost you time.',
+    ].join('\n'),
+    cwd,
+  )
+
+  const { id } = await cli.data<Logged>(['log', title, '--cwd', cwd])
+
+  expect((await Store.get(id, { root: cwd })).body).toMatchInlineSnapshot(`
+    "### What Broke
+
+    <!-- The thing that cost you time. -->"
+  `)
+})
+
 test('error: a title is required', async () => {
   const cwd = await helpers.repo()
   expect(await cli.error(['log', '--body', body, '--cwd', cwd])).toMatchInlineSnapshot(`

--- a/src/cli/commands/log.ts
+++ b/src/cli/commands/log.ts
@@ -142,6 +142,10 @@ export const log = Cli.create('log', {
     // An upstream project judges a report against its own issue form, so scaffold from that rather than
     // from frog's sections. Fetched only when the answers would be used, and never fatal: a target that
     // cannot be reached costs the scaffold, not the entry.
+    // This repository's own form when there is no target, so a project that publishes one gets it used
+    // for its own entries too rather than only by whoever reports to it.
+    const own = !body && !c.options.target ? await attempt(form.own(root)) : undefined
+
     const upstream =
       !body && c.options.target
         ? await attempt(
@@ -154,7 +158,8 @@ export const log = Cli.create('log', {
             }),
           )
         : undefined
-    const scaffold = upstream?.ok ? upstream.value : undefined
+    const scaffold =
+      (upstream?.ok ? upstream.value : undefined) ?? (own?.ok ? own.value : undefined)
 
     // A scaffold is the detail this is asking for, one question at a time, so it satisfies the guard.
     // Without a terminal there is otherwise no way to reach a template at all, which would leave the

--- a/src/cli/internal/form.ts
+++ b/src/cli/internal/form.ts
@@ -1,3 +1,5 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
 import * as Config from '../../Config.js'
 import * as Github from '../../Github.js'
 import * as IssueForm from '../../IssueForm.js'
@@ -59,4 +61,27 @@ export declare namespace scaffold {
     /** Explicit token, overriding the environment. */
     token?: string | undefined
   }
+}
+
+/**
+ * Renders the scaffold an entry about this repository should be written against.
+ *
+ * The same discovery as an upstream target, off disk rather than over the API. A project that publishes
+ * a form has already said how it wants friction written, and that answer should not differ depending on
+ * who is doing the writing.
+ *
+ * @param root - Repository root.
+ * @returns The scaffold, or `undefined` when this repository publishes no form.
+ */
+export async function own(root: string): Promise<string | undefined> {
+  const form = await IssueForm.find({
+    list: (at) =>
+      fs
+        .readdir(path.join(root, at))
+        .then((names) => names.map((name) => `${at}/${name}`))
+        .catch(() => []),
+    read: (at) => fs.readFile(path.join(root, at), 'utf8').catch(() => undefined),
+  })
+
+  return form ? IssueForm.scaffold(form) : undefined
 }


### PR DESCRIPTION
Removes `.agents/friction-log/TEMPLATE.md`, which was written by `init` and linked from the generated README but never read: `log` already writes the sections into each new entry.

`log` now scaffolds an entry about this repository from its own `.github/ISSUE_TEMPLATE/friction.yml` when it publishes one, using the same discovery already applied to an upstream target. A project that says how it wants friction written gets that answer used for its own entries too.
