### PR TITLE
refactor: tighten prose across comments, docs, and CLI strings

### DIFF
--- a/app/src/App.ts
+++ b/app/src/App.ts
@@ -7,12 +7,11 @@ import * as serialization from './internal/serialize.js'
 /**
  * Builds the App and registers every handler.
  *
- * Cross-repo filing needs a token per installation, so the resolver below mints one on demand. A
- * repository with no installation resolves to `undefined`, and that is the consent gate: the App
- * physically cannot file where it has not been installed.
+ * The resolver below mints a token per installation on demand. A repository with no installation
+ * resolves to `undefined`, so the App cannot file where it has not been installed.
  *
- * Handlers are allowed to throw. Delivery claims are only completed after the handler succeeds, and
- * replay markers keep a repeated external mutation from duplicating an issue or comment.
+ * Handlers are allowed to throw. A delivery claim completes only after the handler succeeds, and replay
+ * markers keep a repeated external mutation from duplicating an issue or comment.
  */
 export function create(options: create.Options): App {
   const { appId, coordinator, privateKey, registry, secret } = options
@@ -74,8 +73,8 @@ export function create(options: create.Options): App {
     // Only the default branch: a topic branch's entries are handled as a pull request.
     if (payload.ref !== `refs/heads/${branch}`) return
 
-    // The write-back is self-terminating anyway, but skipping our own push saves a pointless round
-    // trip on every commit this App makes.
+    // Skipping our own push saves a round trip on every commit this App makes. The write-back
+    // terminates either way.
     if (payload.sender?.login && payload.sender.login === (await self())) return
 
     await push({
@@ -101,8 +100,8 @@ export function create(options: create.Options): App {
             (label): label is NonNullable<typeof label> => label !== null,
           ),
           number: payload.issue.number,
-          // Taken from the action rather than the payload field: the action is what happened, and the
-          // field is optional in the delivered shape.
+          // Taken from the action rather than the payload field, which is optional in the delivered
+          // shape.
           state: payload.action === 'closed' ? 'closed' : 'open',
           title: payload.issue.title,
         },

--- a/app/src/Delivery.ts
+++ b/app/src/Delivery.ts
@@ -9,7 +9,7 @@ export const maxBytes = 127_800
 type Installation = { id: number }
 type Repository = { full_name: string }
 
-/** The compact, versioned webhook projection persisted in Queue. */
+/** Compact, versioned webhook projection persisted in Queue. */
 export type Delivery =
   | {
       id: string
@@ -103,7 +103,7 @@ function repository(payload: ObjectValue): Repository {
  *
  * A delivery queued before these fields existed decodes as an unwritable fork rather than throwing, so
  * an in-flight message survives the deployment that added them instead of retrying to the dead letter
- * queue. Without a branch to write to there is nothing to lose: the link is written when the work lands.
+ * queue. Nothing is lost: the link is written when the work lands.
  */
 function pullHead(value: ObjectValue): {
   ref: string
@@ -143,7 +143,7 @@ function action<Action extends string>(
   return allowed.find((candidate) => candidate === name)
 }
 
-/** Whether an event header names a webhook Frog handles. */
+/** Whether an event header names a webhook frog handles. */
 export function supports(name: string): name is Delivery['name'] {
   return name === 'issues' || name === 'pull_request' || name === 'push'
 }
@@ -261,8 +261,8 @@ export function bytes(delivery: Delivery): number {
 /**
  * Expands a queued delivery into the minimal event Octokit's handlers consume.
  *
- * Issue events are rehydrated only after the durable delivery claim is acquired. This supplies the
- * current marker for routing; reconciliation refetches again under the origin repository lease.
+ * Rehydrates an issue event only after the durable delivery claim is acquired, supplying the current
+ * marker for routing. Reconciliation refetches under the origin repository lease.
  */
 export async function toEvent(
   delivery: Delivery,
@@ -296,7 +296,7 @@ export async function toEvent(
   }
 }
 
-/** A signed or queued delivery does not match Frog's supported projection. */
+/** Thrown when a signed or queued delivery does not match frog's supported projection. */
 export class InvalidError extends Error {
   override readonly name = 'Delivery.InvalidError'
 

--- a/app/src/Repository.ts
+++ b/app/src/Repository.ts
@@ -5,18 +5,16 @@ import type { Octokit } from 'octokit'
 export type Contents = {
   /** Entries that parsed. */
   entries: readonly Entry.Entry[]
-  /** Ids of entries that did not parse, with the reason, for reporting back on the pull request. */
+  /** Ids of entries that did not parse, with the reason. */
   malformed: readonly { id: string; reason: string }[]
 }
 
 /**
- * Reads every entry at a ref, without cloning.
+ * Reads every entry at a ref through the API instead of cloning.
  *
- * Not cloning is what lets this read a pull request head at all: the App holds an installation, not a
- * working copy, and a fork's head is not a branch it could check out.
+ * The App has no working copy, and could not check out a fork's head.
  *
- * A file that fails to parse is collected rather than thrown, so one broken entry does not hide the
- * rest and the contributor can be told which one it was.
+ * Collects a file that fails to parse rather than throwing, so one broken entry does not hide the rest.
  *
  * @param client - Installation client for the repository.
  * @returns Parsed entries, and anything that failed to parse.
@@ -24,7 +22,7 @@ export type Contents = {
 export async function read(client: Octokit, options: read.Options): Promise<Contents> {
   const { ref, repo } = options
 
-  // Entries are directories, so the write-up inside each one is what gets read.
+  // Each entry is a directory containing the write-up to read.
   const directories = await Github.listDirectories(client.rest, {
     path: Store.dir,
     repo,
@@ -35,8 +33,8 @@ export async function read(client: Octokit, options: read.Options): Promise<Cont
   const malformed: { id: string; reason: string }[] = []
 
   for (const directory of directories) {
-    // Validated through `toId` rather than by slicing the prefix off, so what counts as an entry is
-    // decided in one place for both transports.
+    // Validated through `toId` rather than by slicing the prefix off. One definition of an entry
+    // serves both transports.
     const id = Store.toId(`${directory}/${Store.filename}`)
     if (!id) continue
 
@@ -68,10 +66,9 @@ export declare namespace read {
 }
 
 /**
- * Writes and deletions applied as a single commit.
+ * Applies writes and deletions as a single commit.
  *
- * Built through the git data API rather than the contents API, which would emit one commit per file.
- * One tree and one commit keeps a reconciliation of ten entries from looking like ten changes.
+ * Uses the git data API. The contents API would emit one commit per file.
  *
  * @param client - Installation client for the repository.
  * @returns The new commit's sha, or `undefined` when there was nothing to do.
@@ -85,8 +82,8 @@ export async function commit(
 
   const { owner, repo: name } = Github.split(repo)
 
-  // The reconciling branch may not exist yet, and is created from `base` when it does not. Committing on
-  // top of it when it does is what lets one pull request accumulate several closures.
+  // Creates the reconciling branch from `base` when it does not exist yet. Committing on top of an
+  // existing branch lets one pull request accumulate several closures.
   const reference = await client.rest.git
     .getRef({ owner, ref: `heads/${branch}`, repo: name })
     .catch((error: { status?: number }) => {
@@ -105,8 +102,8 @@ export async function commit(
     ).data.object.sha
   const parent = await client.rest.git.getCommit({ commit_sha: head, owner, repo: name })
 
-  // A directory has to be expanded into its blobs: the API deletes paths, not trees. Read from the base
-  // tree so an entry's artifacts go with its write-up.
+  // Expand a directory into its blobs: the API deletes paths, not trees. Read from the base tree so an
+  // entry's artifacts go with its write-up.
   const removed = [...deletes]
   if (directories.length > 0) {
     const tree = await client.rest.git.getTree({
@@ -123,7 +120,7 @@ export async function commit(
     }
   }
 
-  // Each blob carries its own path out of the promise, so there is no index to line back up.
+  // Each blob carries its own path out of the promise.
   const blobs = await Promise.all(
     writes.map(async (write) => {
       const blob = await client.rest.git.createBlob({
@@ -147,7 +144,7 @@ export async function commit(
         sha: blob.sha,
         type: 'blob' as const,
       })),
-      // A null sha against a base tree is how the API expresses a deletion.
+      // The API expresses a deletion as a null sha against a base tree.
       ...removed.map((path) => ({
         mode: '100644' as const,
         path,
@@ -157,8 +154,8 @@ export async function commit(
     ],
   })
 
-  // Nothing to say. A plan that plans against a ref other than the one it commits to, or a redelivery
-  // reaching here at all, would otherwise stack an empty commit per delivery.
+  // Nothing to say. A plan built against a ref other than the one it commits to, or a redelivery,
+  // would otherwise stack an empty commit per delivery.
   if (tree.data.sha === parent.data.tree.sha) return undefined
 
   const created = await client.rest.git.createCommit({
@@ -208,10 +205,10 @@ export declare namespace commit {
 }
 
 /**
- * Number of the reconciling pull request, when one is open.
+ * Finds the reconciling pull request, when one is open.
  *
- * Asked before committing, because the answer decides whether the branch carries pending state worth
- * building on or is the leftover of a merge.
+ * Asked before committing. An open pull request means the branch carries pending state worth building
+ * on, and none means it is the leftover of a merge.
  *
  * @param client - Installation client for the repository.
  * @returns The number, or `undefined` when nothing is open.
@@ -248,10 +245,9 @@ export declare namespace review {
 /**
  * Points a branch back at its base, discarding whatever it held.
  *
- * A squash merge leaves the branch behind with a history that is no longer an ancestor of the base, so a
- * later commit on it is diffed from a merge base that predates the merge. Restoring an entry there
- * produces no diff at all, and the restoration is silently lost. Resetting first is what keeps a retained
- * branch from poisoning the next reconciliation.
+ * A squash merge leaves the branch on a history the base no longer descends from, where restoring an
+ * entry produces no diff at all and is silently lost. Resetting first keeps a retained branch from
+ * corrupting the next reconciliation.
  *
  * @param client - Installation client for the repository.
  * @returns Whether a branch was there to reset.
@@ -284,8 +280,8 @@ export async function reset(client: Octokit, options: review.Options): Promise<b
 /**
  * Opens the reconciling pull request, or finds the one already open.
  *
- * One long-lived branch and one pull request, updated in place, so closing three issues produces one
- * review rather than three. The same shape the changesets bot uses for its version pull request.
+ * Keeps one long-lived branch and one pull request, updated in place, so closing three issues produces
+ * one review. Matches the changesets bot's version pull request.
  *
  * @param client - Installation client for the repository.
  * @returns The pull request number.
@@ -296,8 +292,7 @@ export async function upsert(client: Octokit, options: upsert.Options): Promise<
 
   const existing = await review(client, { base, branch, repo })
   if (existing) {
-    // The branch accumulates closures across deliveries, so the description is rewritten each time
-    // rather than left describing only what the first one did.
+    // Rewrite the description each time. The branch accumulates closures across deliveries.
     await client.rest.pulls.update({ body: options.body, owner, pull_number: existing, repo: name })
     return existing
   }
@@ -320,7 +315,7 @@ export declare namespace upsert {
     base: string
     /** Branch the reconciling commits land on. */
     branch: string
-    /** Description. Rewritten on every reconciliation, so it always describes the whole branch. */
+    /** Description. Rewritten on every reconciliation to describe the whole branch. */
     body: string
     /** Repository holding both branches, as `owner/name`. */
     repo: string

--- a/app/src/handlers/issues.ts
+++ b/app/src/handlers/issues.ts
@@ -23,13 +23,12 @@ export type Outcome = {
 /**
  * Reconciles the files mirroring an issue after it changes.
  *
- * The marker names a candidate repository, then a committed entry or recovery record must prove that
- * repository already mirrors this exact issue. Paths always come from that repository-owned state.
- * This lets an upstream issue delete or restore its consumer mirror without allowing editable issue
- * text to authorize arbitrary writes.
+ * The marker only names a candidate repository. A committed entry or recovery record there must prove
+ * that repository already mirrors this exact issue, and paths always come from that repository-owned
+ * state. Editable issue text therefore cannot authorize arbitrary writes.
  *
- * The decisions come from `Sync.plan`, unchanged, so the App and the CLI cannot disagree about what a
- * closed or reopened issue means.
+ * Decisions come from `Sync.plan` unchanged, so the App and the CLI agree on what a closed or reopened
+ * issue means.
  *
  * @returns What happened, or why nothing did.
  */
@@ -51,12 +50,11 @@ export async function issues(options: issues.Options): Promise<Outcome> {
     const settings = await config.read(source, { repo: origin })
     const review = settings.pullRequest.enabled
 
-    // Pending state lives on the reconciling branch, so that is what a later event has to plan against: an
-    // issue that closes and then reopens before the review merges must be able to reverse the deletion
-    // already queued there, not plan against a default branch that still has the entry.
+    // Plan against the reconciling branch, where pending state lives. An issue that closes and then
+    // reopens before the review merges has to reverse the deletion already queued there.
     //
-    // With no review open the branch is the leftover of a merge, and a squash leaves it on a history the
-    // base no longer descends from. Resetting it first is what stops that stale tree deciding the diff.
+    // With no review open the branch is the leftover of a merge. Reset it first: a squash leaves it on
+    // a history the base no longer descends from, and that stale tree would decide the diff.
     const queued = review
       ? await Repository.review(source, {
           base: branch,
@@ -88,7 +86,7 @@ export async function issues(options: issues.Options): Promise<Outcome> {
     if (!bindings.some((binding) => binding.issue === current))
       return { ignored: 'untrusted frog marker', origin }
 
-    // This runs inside the origin lease and refetches current issue state. The delivered snapshot only
+    // Runs inside the origin lease and refetches current issue state. The delivered snapshot only
     // routes us here, so an older close cannot overwrite a newer reopen.
     const target = await config.read(client, { repo })
     const label = target.inbound.labels?.[0] ?? settings.labels[0] ?? 'friction'
@@ -190,8 +188,7 @@ export declare namespace issues {
     /**
      * Resolves an installation client for another repository.
      *
-     * The files may live somewhere else entirely, and without an installation there the App cannot
-     * reconcile them.
+     * The files may live elsewhere, and the App cannot reconcile them without an installation there.
      */
     installation: (repo: string) => Promise<Octokit | undefined>
     /** The issue that changed, from the event payload. */

--- a/app/src/handlers/pullRequest.ts
+++ b/app/src/handlers/pullRequest.ts
@@ -9,16 +9,15 @@ import * as Repository from '../Repository.js'
 /**
  * Files the entries a pull request introduces, and reports back on the pull request.
  *
- * Reads the head commit from the **base** repository rather than the head one. GitHub makes a pull
- * request's head commit reachable there, so this works for a fork without the installation needing any
- * access to that fork.
+ * Reads the head commit from the **base** repository, where GitHub makes a pull request's head commit
+ * reachable. The installation needs no access to the fork.
  *
- * The `issue:` link is written straight onto the pull request's own branch, so the entry lands already
- * filed and the merge needs no follow-up commit. That costs one extra `synchronize` delivery, on which
- * the entry is already linked and so is neither re-filed nor re-reported.
+ * Writes the `issue:` link straight onto the pull request's own branch, so the merge needs no follow-up
+ * commit. The extra `synchronize` delivery this costs sees a linked entry, and neither re-files nor
+ * re-reports it.
  *
- * A fork's branch belongs to a repository the App has no installation on, so there the link still waits
- * for the push handler to write it once the work has landed.
+ * A fork's branch belongs to a repository the App has no installation on. There the push handler writes
+ * the link once the work has landed.
  *
  * @returns What happened, already reported on the pull request.
  */
@@ -39,9 +38,9 @@ export async function pullRequest(options: pullRequest.Options): Promise<comment
   const settings = await config.read(client, { ref: baseRef, repo: base })
   const contents = await Repository.read(client, { ref: head, repo: base })
 
-  // Only what this pull request actually changed. Reading the head alone would report every entry the
-  // base branch already carries, and file issues for any of them still unpublished, crediting them to
-  // whoever happened to open an unrelated pull request.
+  // Only what this pull request changed. Reading the head alone would report every entry the base
+  // branch already carries, and file the unpublished ones against whoever opened an unrelated pull
+  // request.
   const before = await Repository.read(client, { ref: baseRef, repo: base })
   const changed = introduced(contents.entries, before.entries)
 
@@ -62,13 +61,13 @@ export async function pullRequest(options: pullRequest.Options): Promise<comment
     serialize,
   })
 
-  // Best effort. The issue is already filed, so a branch this App cannot write to, whether protected by
-  // a ruleset or simply gone, must not fail the delivery and lose the report on the pull request. The
-  // push handler writes the link when the work lands, which is the same path a fork takes.
+  // Write the link if we can. A branch this App cannot write to, whether protected by a ruleset or
+  // simply gone, must not fail the delivery and lose the report on the pull request. The push handler
+  // writes the link when the work lands, the same path a fork takes.
   if (headRepo === base && filed.links.size > 0)
     await serialize(base, async () => {
-      // Filing takes several requests. Re-read under the lease so a concurrent push is not overwritten
-      // with the snapshot this delivery started from.
+      // Re-read under the lease so a concurrent push is not overwritten with the snapshot this
+      // delivery started from. Filing takes several requests.
       const current = await Repository.read(client, { ref: headRef, repo: base })
       const writes = current.entries.flatMap((entry) => {
         const issue = filed.links.get(entry.id)
@@ -136,8 +135,8 @@ export declare namespace pullRequest {
     /**
      * Resolves an installation client for another repository.
      *
-     * Returns `undefined` when frog is not installed there, which is what makes the receiver's
-     * installation the consent gate for cross-repo filing.
+     * Returns `undefined` when frog is not installed there, gating cross-repo filing on the receiver's
+     * installation.
      */
     installation: (repo: string) => Promise<Octokit | undefined>
     /** Pull request number. */

--- a/app/src/handlers/push.ts
+++ b/app/src/handlers/push.ts
@@ -24,17 +24,16 @@ export type Outcome = {
 /**
  * Files anything still pending once the work has landed, and writes the links back.
  *
- * This is where `issue:` gets written, rather than on the pull request branch: here the branch belongs
- * to the repository the App is installed on, so it is reachable, and a fork's contribution has already
- * been merged.
+ * Writes `issue:` here rather than on the pull request branch. This branch belongs to the repository
+ * the App is installed on, so it is reachable.
  *
- * It also closes the fork case. A fork's pull request had its issues filed but could not have its files
- * updated, so the link is written the moment the merge lands. Filing is idempotent, so the entries
- * already filed cost a lookup and nothing else.
+ * A fork's pull request had its issues filed but could not have its files updated, so the link is
+ * written the moment the merge lands. Filing is idempotent, so an entry already filed costs a lookup
+ * and nothing else.
  *
- * Self-terminating: the commit written here triggers another push, on which every entry already carries
- * a link, so nothing is pending and no commit is made. Under review that link is on the reconciling
- * branch rather than this one, which is why that branch is read too.
+ * The commit written here triggers another push, on which every entry already carries a link and
+ * nothing is pending. Under review that link lands on the reconciling branch, which is why that branch
+ * is read too.
  *
  * @returns What happened.
  */
@@ -45,9 +44,8 @@ export async function push(options: push.Options): Promise<Outcome> {
   const review = settings.pullRequest.enabled
   const { entries } = await Repository.read(client, { ref: branch, repo })
 
-  // Under review the link lands on the reconciling branch, not here, so this branch goes on showing the
-  // entry as pending. Without reading that branch too, every later push would re-file and re-commit the
-  // same links, and the write-back would never settle.
+  // Under review the link lands on the reconciling branch, so this branch goes on showing the entry as
+  // pending. Reading that branch too stops every later push from re-filing the same links.
   const reviewed = review
     ? await Repository.read(client, { ref: settings.pullRequest.branch, repo }).catch(
         () => undefined,
@@ -74,8 +72,8 @@ export async function push(options: push.Options): Promise<Outcome> {
 
   const initial = new Map(pending.map((entry) => [entry.id, Entry.serialize(entry)]))
   const committed = await serialize(repo, async () => {
-    // Filing can take several requests. Re-read under the repository lease so a concurrent sync or
-    // push cannot be overwritten with the stale snapshot from the start of this delivery.
+    // Re-read under the repository lease so a concurrent sync or push is not overwritten with the
+    // snapshot this delivery started from. Filing can take several requests.
     const current = await Repository.read(client, { ref: branch, repo })
     const writes: { contents: string; path: string }[] = []
     for (const entry of current.entries) {
@@ -96,9 +94,9 @@ export async function push(options: push.Options): Promise<Outcome> {
     })
   })
 
-  // The same branch and pull request the issue handler reconciles through, so the links and the
-  // closures land in one review rather than two. Without this the setting only half covers a protected
-  // default branch: reconciliation would route around it and this write-back would still be refused.
+  // Reuses the branch and pull request the issue handler reconciles through, so the links and the
+  // closures land in one review rather than two. A protected default branch would otherwise refuse this
+  // write-back while reconciliation routed around it.
   const pullRequest =
     review && committed
       ? await Repository.upsert(client, {

--- a/app/src/internal/cache.ts
+++ b/app/src/internal/cache.ts
@@ -1,10 +1,10 @@
 import type { Cache } from 'frog'
 
 /**
- * A cache in memory.
+ * Builds an in-memory cache.
  *
- * There is no filesystem here. An isolate stays warm across deliveries, so this still spares repeated
- * lookups of the same repository, and a cold start simply fetches again.
+ * There is no filesystem here. A warm isolate spares repeated lookups of the same repository, and a
+ * cold start fetches again.
  */
 export function memory(store = new Map<string, string>()): Cache.Cache {
   return {

--- a/app/src/internal/comment.ts
+++ b/app/src/internal/comment.ts
@@ -4,8 +4,8 @@ import type { Octokit } from 'octokit'
 /**
  * Marks the one comment frog keeps on a pull request.
  *
- * An explicit marker rather than matching on the bot's login: the login can be renamed, and a marker
- * also leaves room for a second kind of comment later without the two being confused.
+ * An explicit marker rather than a match on the bot's login, which can be renamed. It also leaves room
+ * for a second kind of comment without confusing the two.
  */
 export const marker = '<!-- frog:comment -->'
 
@@ -34,9 +34,7 @@ export type Link = {
 /**
  * Renders the comment body.
  *
- * Pure, so what a contributor reads is snapshot-testable without a webhook.
- *
- * @returns Markdown, or `undefined` when there is nothing worth saying.
+ * @returns Markdown, or `undefined` when there is nothing to report.
  */
 export function render(report: Report): string | undefined {
   const { commented, created, deferred, linked, malformed } = report
@@ -93,9 +91,6 @@ export function render(report: Report): string | undefined {
 
 /**
  * Posts the comment, or updates the one already there.
- *
- * Updating rather than appending is what keeps a branch that gets pushed twenty times from collecting
- * twenty comments.
  *
  * @param client - Installation client for the repository.
  */

--- a/app/src/internal/config.ts
+++ b/app/src/internal/config.ts
@@ -4,12 +4,12 @@ import type { Octokit } from 'octokit'
 /**
  * Reads a repository's config.
  *
- * Always from a branch, never from a pull request head. A pull request must not get to say where its
+ * Always from a branch, never from a pull request head. A pull request must not control where its
  * issues go, who may receive them, or whether filing upstream is automatic.
  *
  * @param client - Installation client for the repository.
- * @returns Normalized config. A missing or unparseable file yields defaults, so a repository with no
- * config still works rather than failing closed on every event.
+ * @returns Normalized config. A missing or unparseable file yields defaults, so one broken config
+ * cannot stop the App handling events.
  */
 export async function read(client: Octokit, options: read.Options): Promise<Config.Config> {
   const { ref, repo } = options

--- a/app/src/internal/coordinatorState.ts
+++ b/app/src/internal/coordinatorState.ts
@@ -1,7 +1,7 @@
 /** How long an active delivery or repository mutation owns its lease. */
 export const lease = 15 * 60 * 1_000
 
-/** Delivery ids outlive GitHub's three-day manual-redelivery window. */
+/** Retains delivery ids past GitHub's three-day manual-redelivery window. */
 export const retention = 7 * 24 * 60 * 60 * 1_000
 
 /** State held by one deterministically named coordinator object. */

--- a/app/src/internal/dispatch.ts
+++ b/app/src/internal/dispatch.ts
@@ -4,8 +4,8 @@ import * as serialization from './serialize.js'
 /**
  * Claims a queued delivery before expanding or dispatching it.
  *
- * Expansion may perform GitHub reads, so completed and concurrently processing duplicates must be
- * decided first. The expanded event must retain the original GitHub delivery id.
+ * Completed and concurrently processing duplicates are decided before expansion, which may perform
+ * GitHub reads. The expanded event must retain the original GitHub delivery id.
  */
 export function queued(
   namespace: serialization.Namespace,

--- a/app/src/internal/file.ts
+++ b/app/src/internal/file.ts
@@ -20,8 +20,8 @@ export type Filing = {
 /**
  * Resolves each entry's destination, applies every gate, and files what is allowed through.
  *
- * Shared by the pull request and push handlers, which differ only in what they do afterwards: one
- * comments, the other writes the links back. The gates themselves must not differ between them.
+ * Shared by the pull request and push handlers, which must apply identical gates. They differ only
+ * afterwards: one comments, the other writes the links back.
  */
 export async function file(options: file.Options): Promise<Filing> {
   const {
@@ -92,7 +92,7 @@ export async function file(options: file.Options): Promise<Filing> {
       })
   }
 
-  /** Grouped after every gate, so deferred entries do not consume the per-run ceiling. */
+  /** Grouped after every gate. Deferred entries do not consume the per-run ceiling. */
   const groups = new Map<string, { entries: Entry.Entry[]; labels?: readonly string[] }>()
   let accepted = 0
   for (const candidate of candidates) {
@@ -124,7 +124,7 @@ export async function file(options: file.Options): Promise<Filing> {
         label: applied[0] ?? 'friction',
         repo: destination,
       })
-      /** Filed during this run, so two entries with one title collapse onto one issue. */
+      /** Filed during this run. Two entries sharing a title collapse onto one issue. */
       const seen = new Map<string, Github.Issue>()
 
       for (const entry of group.entries) {
@@ -137,7 +137,7 @@ export async function file(options: file.Options): Promise<Filing> {
             entry,
             labels: applied,
           }),
-          // `origin` is where the file lives, which is not the destination when reporting upstream.
+          // `origin` is where the entry file lives, not the destination when reporting upstream.
           marker: { hash, origin, path: Store.toPath(entry.id), severity: entry.severity },
           provenance: { ...(actor ? { author: actor } : {}), ...(pr ? { pr } : {}) },
           repo: destination,
@@ -158,16 +158,13 @@ export async function file(options: file.Options): Promise<Filing> {
 }
 
 /**
- * Stable key for one report of one friction, used to make a repeat comment idempotent.
+ * Stable key for one report of one friction, making a repeat comment idempotent.
  *
- * Derived from what is being reported rather than from the delivery reporting it. A pull request receives
- * many deliveries, one per push, and keying on the delivery made every one of them a fresh occurrence: the
- * issue collected a "Hit again" comment per push, for an entry nobody had touched.
+ * Keyed on the entry rather than the delivery. A pull request receives one delivery per push, so a
+ * delivery-keyed occurrence would add a "Hit again" comment per push for an entry nobody touched.
  *
- * The body is folded in so an edited entry does speak up again, which is the one repeat worth having. It
- * goes in verbatim: `Github.hash` normalizes for titles, discarding punctuation and case, which would
- * collapse edits that matter, such as adding the `--` a command was missing. `renderOccurrence` digests
- * the whole key anyway, so nothing is gained by hashing a part of it first.
+ * Includes the body so an edited entry reports again. The body goes in verbatim because `Github.hash`
+ * normalizes for titles, discarding the punctuation and case that distinguish a meaningful edit.
  */
 function occurrenceOf(options: { entry: Entry.Entry; origin: string }): string {
   const { entry, origin } = options

--- a/app/src/internal/queue.ts
+++ b/app/src/internal/queue.ts
@@ -2,7 +2,7 @@ import * as Delivery from '../Delivery.js'
 
 const maximumDelay = 60 * 60
 
-/** Retry delay for one failed Queue attempt, with a one-hour ceiling. */
+/** Computes the retry delay for one failed Queue attempt, capped at one hour. */
 export function retryDelay(attempts: number): number {
   return Math.min(30 * 2 ** Math.max(0, attempts - 1), maximumDelay)
 }
@@ -17,8 +17,8 @@ export async function consume(
       const delivery = Delivery.fromQueue(message.body)
       const result = await options.process(delivery)
       if (result.status === 'processing') {
-        // The active owner can still fail. Preserve this duplicate until that lease completes or
-        // expires instead of acknowledging the only attempt capable of recovery.
+        // The active owner can still fail. Keep this duplicate until that lease completes or expires.
+        // Acknowledging it would discard the only attempt capable of recovery.
         message.retry({ delaySeconds: retryDelay(message.attempts) })
       } else {
         message.ack()

--- a/app/src/internal/resolvers.ts
+++ b/app/src/internal/resolvers.ts
@@ -5,15 +5,13 @@ import type { Octokit } from 'octokit'
 export const registry = 'https://registry.npmjs.org'
 
 /**
- * Repository a package declares, from the npm registry.
+ * Reads the repository a package declares, from the npm registry.
  *
- * The App has no `node_modules` to inspect, so the offline path the CLI uses does not exist here. The
- * registry serves the same `repository` field, which is where a package names the repository its issues
- * belong on.
+ * The App has no `node_modules`, so the CLI's offline path is unavailable here. The registry serves the
+ * same `repository` field.
  *
- * Resolved at `latest` rather than the version a consumer has pinned. Which repository a package belongs
- * to is not something that varies by patch release, and resolving a range here would mean reading the
- * consumer's lockfile.
+ * Resolves `latest`, not the version a consumer has pinned. A package's repository does not vary by
+ * patch release, and resolving a range would mean reading the consumer's lockfile.
  *
  * @param name - npm package name.
  * @returns The repository as `owner/name`, or `undefined` when the package declares none on GitHub.
@@ -54,8 +52,8 @@ export async function fromRegistry(
 /**
  * Builds the resolver stack `Target.resolve` needs, backed by the API and the registry.
  *
- * The same two lookups the CLI supplies from disk, over the network instead. Every consent gate is
- * unchanged, which is the point of `Target` taking them as arguments.
+ * Supplies over the network the same two lookups the CLI reads from disk. Every consent gate is
+ * unchanged.
  */
 export function resolvers(options: resolvers.Options): Target.resolve.Options {
   const { outbound, installation, registry: url, self } = options
@@ -93,7 +91,7 @@ export declare namespace resolvers {
   }
 }
 
-/** Signals that target consent could not be read because the App is not installed there. */
+/** Thrown when the App is not installed on a target repository, so its consent cannot be read. */
 export class InstallationMissingError extends Error {
   /** Repository whose installation is missing. */
   repo: string

--- a/app/src/internal/serialize.ts
+++ b/app/src/internal/serialize.ts
@@ -14,7 +14,7 @@ export type Namespace = {
   getByName(name: string): Coordinator
 }
 
-/** Another delivery currently owns a conflicting repository mutation. */
+/** Thrown when another delivery already owns a conflicting repository mutation. */
 export class RepositoryBusyError extends Error {
   override readonly name = 'RepositoryBusyError'
 

--- a/app/src/internal/summary.ts
+++ b/app/src/internal/summary.ts
@@ -18,9 +18,8 @@ function section(title: string, entries: readonly Entry.Entry[]): string | undef
 /**
  * Describes what merging the reconciling pull request would do.
  *
- * Derived from the branch rather than from the delivery that last wrote to it. One pull request
- * accumulates several closures, so a description built from one delivery would describe only the most
- * recent and quietly misrepresent the rest.
+ * Derived from the branch, not from the delivery that last wrote to it. One pull request accumulates
+ * several closures, and a delivery-derived description would cover only the most recent.
  *
  * @returns Markdown body.
  */

--- a/app/src/internal/webhook.ts
+++ b/app/src/internal/webhook.ts
@@ -12,8 +12,8 @@ export async function receive(request: Request, options: receive.Options): Promi
   const body = await request.text()
   if (!(await options.verify(body, signature))) return new Response('Unauthorized', { status: 401 })
 
-  // GitHub sends many event actions the App does not subscribe to. A verified unsupported delivery
-  // is accepted without parsing or queueing, as Octokit's dispatcher did before Queue was introduced.
+  // GitHub sends many event actions the App does not subscribe to. A verified unsupported delivery is
+  // accepted without parsing or queueing.
   if (!Delivery.supports(name))
     return Response.json({ accepted: true, queued: false }, { status: 202 })
 
@@ -36,8 +36,8 @@ export async function receive(request: Request, options: receive.Options): Promi
   if (Delivery.bytes(delivery) > Delivery.maxBytes)
     return new Response('Payload Too Large', { status: 413 })
 
-  // Awaiting this write is the durability boundary. Returning before Queue accepts the message would
-  // lose a delivery because GitHub does not automatically redeliver failed webhooks.
+  // Awaiting this write is the durability boundary. Returning before Queue accepts the message loses
+  // the delivery: GitHub does not automatically redeliver failed webhooks.
   try {
     await options.enqueue(delivery)
   } catch (error) {

--- a/app/src/worker.ts
+++ b/app/src/worker.ts
@@ -22,9 +22,9 @@ export type Env = {
 }
 
 /**
- * Cached across requests in a warm isolate, so a burst of deliveries mints one set of tokens.
+ * Apps cached across requests in a warm isolate. A burst of deliveries mints one set of tokens.
  *
- * Keyed by app id, so a redeployment with different bindings cannot reuse the wrong App.
+ * Keyed by app id: a redeployment with different bindings cannot reuse the wrong App.
  */
 const apps = new Map<string, ReturnType<typeof create>>()
 
@@ -35,7 +35,7 @@ function app(env: Env): ReturnType<typeof create> {
   const created = create({
     appId: env.APP_ID,
     coordinator: env.COORDINATOR,
-    // Newlines do not survive an environment variable, so they are restored here.
+    // Restore newlines, which do not survive an environment variable.
     privateKey: env.PRIVATE_KEY.replace(/\\n/g, '\n'),
     secret: env.WEBHOOK_SECRET,
   })
@@ -68,8 +68,8 @@ async function processQueued(env: Env, delivery: Delivery.Delivery) {
           return response.data
         },
       }),
-    // The projection deliberately contains only fields our handlers read. Keep the OpenAPI escape
-    // hatch at this one boundary rather than letting unvalidated payloads flow through the App.
+    // The projection contains only the fields our handlers read. Keep the OpenAPI escape hatch at this
+    // one boundary rather than letting unvalidated payloads flow through the App.
     receive: (event) => app(env).webhooks.receive(event as unknown as WebhookEvent),
   })
 }

--- a/schema.json
+++ b/schema.json
@@ -49,7 +49,7 @@
           }
         },
         "template": {
-          "description": "Issue form reported friction should be written against, as a path or a filename under `.github/ISSUE_TEMPLATE`. Absent looks for `friction.yml`, then the only form there.",
+          "description": "Issue form reported friction is written against, as a path or a filename under `.github/ISSUE_TEMPLATE`. Absent looks for `friction.yml`, then the only form there.",
           "type": "string",
           "minLength": 1
         }
@@ -66,7 +66,7 @@
     },
     "maxPerRun": {
       "default": 10,
-      "description": "Ceiling on issues filed in one publish run, or in one webhook delivery. A batch limit rather than a total: a second delivery gets its own allowance, and anything over the ceiling is deferred rather than dropped.",
+      "description": "Ceiling on issues filed in one publish run, or in one webhook delivery. A second delivery gets its own allowance, and anything over the ceiling is deferred rather than dropped.",
       "type": "integer",
       "exclusiveMinimum": 0,
       "maximum": 9007199254740991
@@ -94,7 +94,7 @@
     },
     "pullRequest": {
       "default": true,
-      "description": "Reconcile a closed or reopened issue through a pull request. An object names the branch it is opened from. Set `false` to commit straight to the default branch instead, which keeps the log true without a merge but fails outright where that branch is protected.",
+      "description": "Reconcile a closed or reopened issue through a pull request. An object names the branch it is opened from. Set `false` to commit straight to the default branch instead, which needs no merge but fails where that branch is protected.",
       "anyOf": [
         {
           "type": "boolean"

--- a/src/Cache.ts
+++ b/src/Cache.ts
@@ -2,11 +2,10 @@
 export const ttl = 24 * 60 * 60 * 1000
 
 /**
- * Somewhere to keep the answers to network lookups.
+ * Storage for the answers to network lookups.
  *
- * Injected rather than assumed, because the two callers have nothing in common: the CLI caches to disk
- * across runs, and the App runs where there is no filesystem at all. Keeping this out of the module also
- * keeps `node:fs` out of a Workers bundle.
+ * Injected because the CLI caches to disk across runs and the App runs where there is no filesystem.
+ * Keeping the implementation out of this module keeps `node:fs` out of a Workers bundle.
  */
 export type Cache = {
   /**
@@ -16,7 +15,7 @@ export type Cache = {
    */
   get: (key: string) => Promise<string | undefined>
   /**
-   * Writes a cached entry. Failures are the cache's business, not the caller's.
+   * Writes a cached entry. Failures are swallowed.
    *
    * @param key - What was looked up.
    * @param value - Serialized entry.
@@ -53,8 +52,7 @@ export async function read<value>(
 /**
  * Caches a value.
  *
- * Callers are expected to cache definitive absences too. Most repositories accept no inbound friction, so
- * caching that answer is what stops every run re-asking about the same dependencies.
+ * Callers are expected to cache definitive absences too.
  *
  * @param key - What was looked up.
  * @param at - Time of the lookup.

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -10,11 +10,11 @@ const repoPattern = /^[\w.-]+\/[\w.-]+$/
 const repoAllowPattern = /^[\w.-]+\/(?:[\w.-]+|\*)$/
 
 /**
- * One schema serves both shapes: `z.input` is what a user writes (everything optional), `z.output`
- * is what the code consumes (every default applied).
+ * Config schema, serving both shapes: `z.input` is the written config, with everything optional;
+ * `z.output` is the normalized config, with every default applied.
  *
  * Field docs live in `.describe()` rather than TSDoc so they reach `schema.json`, where `$schema`
- * turns them into editor autocomplete for whoever is actually writing the config.
+ * turns them into editor autocomplete for whoever is writing the config.
  */
 export const Schema = z.object({
   commit: z
@@ -53,7 +53,7 @@ export const Schema = z.object({
         .min(1)
         .optional()
         .describe(
-          'Issue form reported friction should be written against, as a path or a filename under `.github/ISSUE_TEMPLATE`. Absent looks for `friction.yml`, then the only form there.',
+          'Issue form reported friction is written against, as a path or a filename under `.github/ISSUE_TEMPLATE`. Absent looks for `friction.yml`, then the only form there.',
         ),
     })
     .prefault({})
@@ -68,7 +68,7 @@ export const Schema = z.object({
     .positive()
     .default(10)
     .describe(
-      'Ceiling on issues filed in one publish run, or in one webhook delivery. A batch limit rather than a total: a second delivery gets its own allowance, and anything over the ceiling is deferred rather than dropped.',
+      'Ceiling on issues filed in one publish run, or in one webhook delivery. A second delivery gets its own allowance, and anything over the ceiling is deferred rather than dropped.',
     ),
   outbound: z
     .object({
@@ -89,7 +89,7 @@ export const Schema = z.object({
     .union([z.boolean(), z.object({ branch: z.string().min(1).optional() })])
     .default(true)
     .describe(
-      'Reconcile a closed or reopened issue through a pull request. An object names the branch it is opened from. Set `false` to commit straight to the default branch instead, which keeps the log true without a merge but fails outright where that branch is protected.',
+      'Reconcile a closed or reopened issue through a pull request. An object names the branch it is opened from. Set `false` to commit straight to the default branch instead, which needs no merge but fails where that branch is protected.',
     )
     .transform((value) => ({
       branch: (typeof value === 'object' ? value.branch : undefined) ?? 'frog/sync',
@@ -107,10 +107,9 @@ export const Schema = z.object({
 /**
  * Normalized config, with every default applied.
  *
- * Field documentation lives on {@link Schema} as `.describe()` rather than as TSDoc here. That is
- * deliberate and the one exception in this package: `.describe()` is what reaches `schema.json`, where
- * `$schema` turns it into autocomplete for the person writing the JSON. Duplicating the same prose as
- * TSDoc would give two sources that drift. Run `frog publish --schema` to read it.
+ * Field documentation lives on {@link Schema} as `.describe()`, the one exception in this package.
+ * Only `.describe()` reaches `schema.json`, and duplicating it as TSDoc would give two sources that
+ * drift. Run `frog publish --schema` to read it.
  */
 export type Config = z.output<typeof Schema>
 
@@ -120,8 +119,8 @@ export type WrittenConfig = z.input<typeof Schema>
 /**
  * How a project accepts inbound friction.
  *
- * Derived from {@link Schema} rather than declared again, so the committed config and the shape consent is
- * checked against cannot drift.
+ * Derived from {@link Schema} so the committed config and the shape consent is checked against cannot
+ * drift.
  */
 export type Inbound = Config['inbound']
 
@@ -150,8 +149,8 @@ export function allows(inbound: Inbound, sender: string | undefined): boolean {
 /**
  * Normalizes already-loaded config.
  *
- * The one chokepoint between written and normalized config, so anything reading config over the
- * network (the App, a consent check on a target) gets identical defaults to the CLI reading it off disk.
+ * The one chokepoint between written and normalized config. Config read over the network gets the
+ * same defaults as config the CLI reads off disk.
  */
 export function from(value: unknown, options: from.Options = {}): Config {
   const written = value ?? {}

--- a/src/Entry.ts
+++ b/src/Entry.ts
@@ -35,9 +35,8 @@ export type Frontmatter = {
 /**
  * Schema for {@link Frontmatter}.
  *
- * Annotated rather than inferred, because TSDoc written on a schema's fields does not survive
- * `z.infer`. The hand-written type above is the documented public shape, and this annotation stops
- * the two drifting: a schema change that alters the parsed shape fails to compile here.
+ * Annotated rather than inferred: TSDoc written on a schema's fields does not survive `z.infer`. The
+ * annotation stops the hand-written type and the schema drifting.
  */
 export const Frontmatter: z.ZodType<Frontmatter> = z.object({
   issue: z
@@ -61,8 +60,8 @@ export type Entry = Frontmatter & {
 /**
  * Splits leading YAML frontmatter from the markdown body.
  *
- * Lazy, so the first `---` after the opening one closes the block and a body containing a horizontal
- * rule cannot swallow it. `[^]` rather than `.` because the frontmatter spans newlines.
+ * Lazy: the first `---` after the opening one closes the block, so a horizontal rule in the body
+ * cannot swallow it. `[^]` rather than `.` because the frontmatter spans newlines.
  */
 const frontmatterRegex = /\s*---([^]*?)\n\s*---(\s*(?:\n|$)[^]*)/
 
@@ -103,7 +102,7 @@ export function parse(contents: string, options: parse.Options): Entry {
 export declare namespace parse {
   /** Options for {@link parse}. */
   type Options = {
-    /** Entry id. Named in errors so they point at a real entry. */
+    /** Entry id. Named in error messages. */
     id: string
   }
 }
@@ -137,11 +136,11 @@ export function serialize(entry: serialize.Options): string {
 }
 
 export declare namespace serialize {
-  /** The entry to serialize. The id is the directory name, so it is not part of the contents. */
+  /** The entry to serialize. The id is the directory name, not part of the contents. */
   type Options = Omit<Entry, 'id'>
 }
 
-/** Words a slug keeps. Enough to recognize the entry, short enough to stay scannable in a path. */
+/** Words a slug keeps. */
 const maxWords = 3
 
 /** Hard bound on slug length, for a title whose words are pathologically long. */
@@ -150,9 +149,7 @@ const maxSlug = 48
 /**
  * Turns a title into a path-safe slug.
  *
- * The first few words only: the full title lives in the write-up, so the directory name just has to be
- * recognizable at a glance. Never empty, because a title of nothing but punctuation still has to name a
- * directory.
+ * Never empty: a title of nothing but punctuation still has to name a directory.
  *
  * @param title - Title as written.
  * @returns Up to three lowercased words joined by hyphens.
@@ -165,9 +162,9 @@ export function slug(title: string): string {
 /**
  * Builds an id for a new entry: when the friction was hit, then the title.
  *
- * Timestamped rather than numbered because entries are deleted when their friction is resolved, so a
- * sequence counter would hand the same number to something unrelated. A timestamp is never reused, sorts
- * oldest-first as plain text, and two branches logging at once still get distinct ids.
+ * Timestamped rather than numbered: entries are deleted when their friction is resolved, so a sequence
+ * counter would hand the same number to something unrelated. A timestamp also sorts oldest-first as
+ * plain text.
  *
  * @returns An id such as `20260725143012-filters-are-ignored`.
  */
@@ -210,35 +207,32 @@ export type Section = {
 /**
  * What a friction entry is asked for, in order.
  *
- * Nothing enforces these. They exist so an entry lands as something reproducible rather than a one-line
- * complaint, which is what a flat friction log tends to produce. Expectation is separated from
- * description on purpose: friction is the gap between the two, and naming both is what turns a complaint
- * into a report somebody can act on.
+ * Nothing enforces these. Expected and current behavior are separate prompts because friction is the
+ * gap between the two.
  *
- * Held as data because two things are rendered from it: the markdown scaffold below, and the issue form
+ * Held as data because two things render from it: the markdown scaffold below, and the issue form
  * `init --library` publishes so a consumer's agent finds the same questions.
  */
 export const sections: readonly Section[] = [
   {
-    description: 'Tell us what should happen.',
+    description: 'Describe what should happen.',
     label: 'Expected Behavior',
   },
   {
-    description: 'Tell us what happens instead of the expected behavior.',
+    description: 'Describe what happens instead.',
     label: 'Current Behavior',
   },
   {
-    description: 'Not obligatory, but suggest a fix or a reason for the friction.',
+    description: 'Optional. Suggest a fix or a reason for the friction.',
     label: 'Possible Solution',
   },
   {
     description:
-      'A minimal reproducible example in `artifacts/`, or an unambiguous set of steps to reproduce this. Include code to reproduce, if relevant.',
+      'Add a minimal reproducible example under `artifacts/`, or an unambiguous set of steps to reproduce this. Include code where relevant.',
     label: 'Minimal Reproducible Example',
   },
   {
-    description:
-      'How has this affected you, and what were you trying to accomplish? Context is what makes a solution useful in the real world rather than in the abstract.',
+    description: 'Describe how this affected you, and what you were trying to accomplish.',
     label: 'Context',
   },
 ]

--- a/src/Git.ts
+++ b/src/Git.ts
@@ -51,7 +51,7 @@ export async function head(options: Options = {}): Promise<string | undefined> {
 /**
  * Local committer name from git config.
  *
- * Used to attribute an entry that has not been committed yet, where there is no commit to read.
+ * Attributes an entry that has not been committed yet.
  *
  * @returns The name, or `undefined` when `user.name` is unset.
  */
@@ -79,8 +79,7 @@ const separator = '\u001f'
  * Reads the commit that *added* the file, so a later edit does not reattribute the report.
  *
  * @param file - Repository-relative path.
- * @returns The provenance, or `undefined` for a file that is not committed yet, leaving the caller to
- * decide what an unknown reporter renders as.
+ * @returns The provenance, or `undefined` for a file that is not committed yet.
  */
 export async function provenance(
   file: string,
@@ -146,8 +145,7 @@ export declare namespace rm {
     /**
      * Succeed for paths git does not track.
      *
-     * Reconciliation deletes entries that may never have been committed, where a strict `git rm`
-     * would fail on the pathspec.
+     * Reconciliation deletes entries that may never have been committed.
      */
     ignoreUnmatch?: boolean | undefined
   }
@@ -158,7 +156,6 @@ export declare namespace rm {
  *
  * @param message - Commit message.
  * @returns `true` when a commit was made, `false` when none of the requested paths were staged.
- * Reporting rather than throwing keeps a no-op run from looking like a failure.
  */
 export async function commit(message: string, options: commit.Options): Promise<boolean> {
   if (options.files.length === 0) return false

--- a/src/Github.ts
+++ b/src/Github.ts
@@ -5,8 +5,7 @@ import * as Entry from './Entry.js'
 /**
  * The slice of Octokit this module uses.
  *
- * Narrow on purpose: the App passes Probot's client, which is the same endpoint-methods object, so
- * neither caller has to construct the other's.
+ * Narrow so the App can pass Probot's client, which is the same endpoint-methods object.
  */
 export type Client = Pick<Octokit['rest'], 'issues' | 'repos'>
 
@@ -20,7 +19,7 @@ export type Label =
 
 /** The parts of a GitHub issue this module reads. */
 export type Issue = {
-  /** Issue body. `null` when GitHub has none, which is how the API reports an empty body. */
+  /** Issue body. `null` when the API reports an empty body. */
   body?: string | null | undefined
   /** Labels on the issue. */
   labels?: readonly Label[] | undefined
@@ -33,7 +32,7 @@ export type Issue = {
 }
 
 /**
- * Label names on an issue, flattening GitHub's two representations.
+ * Lists the label names on an issue, flattening GitHub's two representations.
  *
  * @returns Every label name, with unnamed entries dropped.
  */
@@ -65,14 +64,11 @@ const componentRegex = /^[\w.-]+$/
 /**
  * Normalizes a repository reference into `owner/name`.
  *
- * Handles what a package's `repository` field and a git remote actually contain in the wild: `git+https`,
- * `ssh`, `scp`, and `git` URLs, npm's `github:owner/name` and bare `owner/name` shorthands, and URLs
- * carrying a trailing subdirectory. Across the 790 packages installed here this resolves 98.5%, with the
- * remainder declaring no repository at all.
+ * Accepts `git+https`, `ssh`, `scp`, and `git` URLs, npm's `github:owner/name` and bare `owner/name`
+ * shorthands, and URLs carrying a trailing subdirectory.
  *
  * @param value - A repository URL or npm shorthand.
- * @returns The repository as `owner/name`, or `undefined` when it is absent or not on GitHub. Only GitHub
- * resolves, because an issue can only be filed there.
+ * @returns The repository as `owner/name`, or `undefined` when it is absent or not on GitHub.
  */
 export function parseRepository(
   value: string | undefined,
@@ -143,10 +139,7 @@ export function parseLink(link: string): { issue: number; repo: string } | undef
 }
 
 /**
- * Dedupe key for a title.
- *
- * Normalized first, so the same friction reported with different capitalization and punctuation
- * lands on one issue.
+ * Hashes a title into a dedupe key.
  *
  * @param title - Title as written.
  * @returns The first 12 hex characters of the normalized title's sha256.
@@ -155,12 +148,12 @@ export function hash(title: string): string {
   return createHash('sha256').update(Entry.normalizeTitle(title)).digest('hex').slice(0, 12)
 }
 
-/** Marker format version, so a future format change can be recognized rather than misread. */
+/** Marker format version, so a later format change is recognized rather than misread. */
 export const markerVersion = 'v1'
 
 const markerRegex = /<!--\s*frog:v1\s+([^>]*?)\s*-->/
 
-/** Version of the marker that makes one external publish occurrence replay-safe. */
+/** Format version of the marker that makes one external publish occurrence replay-safe. */
 const occurrenceVersion = 'v1'
 
 function renderOccurrence(occurrence: string): string {
@@ -171,17 +164,17 @@ function renderOccurrence(occurrence: string): string {
 /**
  * Hidden state carried in an issue body.
  *
- * This is the whole basis of idempotency and of sync: it is how a second publish recognizes an issue
- * it already filed, and how an issue event finds the file mirroring it.
+ * Lets a second publish recognize an issue it already filed, and an issue event find the file
+ * mirroring it.
  */
 export type Marker = {
   /** Dedupe key. */
   hash: string
   /** Repository holding the mirroring file. Lets an issue closed here sync a file elsewhere. */
   origin?: string | undefined
-  /** Path of the mirroring file, so close and reopen act without scanning. */
+  /** Path of the mirroring file. */
   path?: string | undefined
-  /** How much the friction hurt, so a reopen restores the entry at the severity it was filed with. */
+  /** How much the friction hurt. A reopen restores the entry at this severity. */
   severity?: Entry.Severity | undefined
 }
 
@@ -230,8 +223,7 @@ export function parseMarker(body: string | null | undefined): Marker | undefined
 /**
  * Who hit the friction, and where.
  *
- * Every field is optional: an entry logged moments ago is not committed yet, so none of this is
- * always knowable.
+ * Every field is optional: an entry logged moments ago is not committed yet.
  */
 export type Provenance = {
   /** Commit author name, or the GitHub actor when the App files on someone's behalf. */
@@ -288,7 +280,7 @@ export declare namespace renderBody {
 /**
  * Recovers the entry body from an issue body.
  *
- * The inverse of {@link renderBody}, which the reopen path depends on to rebuild a deleted file.
+ * The inverse of {@link renderBody}. The reopen path uses it to rebuild a deleted file.
  *
  * @param body - Issue body, which may be absent.
  * @returns The entry body. A body with no marker is returned trimmed but otherwise untouched.
@@ -322,8 +314,8 @@ export declare namespace toLabels {
 /**
  * Rebuilds an entry from the issue mirroring it.
  *
- * Used when an issue reopens after its file was deleted. `severity` and extra labels are recovered by
- * reversing {@link toLabels}; `target` cannot be, because nothing on the issue records it.
+ * Used when an issue reopens after its file was deleted. Severity comes from the marker and extra
+ * labels from reversing {@link toLabels}. `target` cannot be recovered: nothing on the issue records it.
  *
  * @returns The rebuilt entry, already linked to the issue.
  */
@@ -331,8 +323,8 @@ export function fromIssue(issue: Issue, options: fromIssue.Options): Entry.Entry
   const { id, labels, repo } = options
 
   const names = toLabelNames(issue)
-  // From the marker, not the labels: a label would be in the receiver's namespace, and cross-repo the
-  // two projects need not agree on what a severity is called.
+  // From the marker, not the labels: cross-repo, the two projects need not agree on what a severity
+  // is called.
   const severity = parseMarker(issue.body)?.severity ?? 'minor'
   const managed = new Set<string>(labels)
   const extra = names.filter((name) => !managed.has(name))
@@ -356,20 +348,19 @@ export declare namespace fromIssue {
     labels: readonly string[]
     /** Repository holding the issue, as `owner/name`. */
     repo: string
-    /** Label to apply for each severity, from config. Reversed to recover severity. */
   }
 }
 
 /**
  * Indexes existing friction issues by dedupe hash.
  *
- * Listing by label rather than searching: the search index is eventually consistent, so two publishes
- * moments apart can both miss and open duplicates. Listing is deterministic and paginates.
+ * Lists by label rather than searching. The search index is eventually consistent, so two publishes
+ * moments apart can both miss and open duplicates.
  *
- * Issues with no marker are indexed by their title hash, so an issue filed by hand still dedupes.
+ * Issues with no marker are indexed by their title hash. An issue filed by hand still dedupes.
  *
  * @param client - Authenticated client for the target repository.
- * @returns Issues keyed by dedupe hash. Where several share a hash, the canonical one wins: open
+ * @returns Issues keyed by dedupe hash. Where several share a hash, the canonical one is kept: open
  * before closed, then lowest number.
  */
 export async function index(client: Client, options: index.Options): Promise<Map<string, Issue>> {
@@ -380,7 +371,7 @@ function toIndex(issues: readonly Issue[]): Map<string, Issue> {
   const indexed = new Map<string, Issue>()
   for (const issue of issues) {
     const key = parseMarker(issue.body)?.hash ?? hash(issue.title)
-    // Prefer an open issue, then the lowest number, so comments land on the canonical one.
+    // Prefer an open issue, then the lowest number.
     const current = indexed.get(key)
     if (!current) indexed.set(key, issue)
     else if (current.state !== 'open' && issue.state === 'open') indexed.set(key, issue)
@@ -392,7 +383,7 @@ function toIndex(issues: readonly Issue[]): Map<string, Issue> {
 /**
  * Reads a file from a repository's default branch.
  *
- * Used to check whether a repository has committed a config accepting inbound friction. Always the
+ * Used to check whether a repository has committed a config accepting inbound friction. Reads the
  * default branch, never a pull request head: the untrusted side of a boundary must not get to say
  * where issues are filed.
  *
@@ -435,12 +426,12 @@ export declare namespace fetchFile {
 /**
  * Lists the directories directly inside a directory.
  *
- * An entry is a directory, so this is how entries are enumerated without cloning, which is what allows
- * reading a pull request head.
+ * An entry is a directory, so this enumerates entries without cloning, including at a pull request
+ * head.
  *
  * @param client - Authenticated client for the repository.
  * @returns Repository-relative paths of subdirectories, excluding files. Empty when the directory does
- * not exist, which is the ordinary case for a repository that has logged no friction.
+ * not exist.
  */
 export async function listDirectories(
   client: Client,
@@ -454,7 +445,7 @@ export async function listDirectories(
  *
  * @param client - Authenticated client for the repository.
  * @returns Repository-relative paths of files, excluding subdirectories. Empty when the directory does
- * not exist, which is the ordinary case for a repository with no issue templates.
+ * not exist.
  */
 export async function listFiles(
   client: Client,
@@ -484,11 +475,11 @@ async function listing(
 }
 
 /**
- * One issue by number.
+ * Reads one issue by number.
  *
- * Needed because {@link list} filters by label, so an issue that merely lost its label is
- * indistinguishable from one that never existed. Clearing a link on that basis would send the entry
- * back to pending and let the next publish open a duplicate.
+ * Needed because {@link list} filters by label: an issue that merely lost its label is
+ * indistinguishable from one that never existed. Clearing a link on that basis would let the next
+ * publish open a duplicate.
  *
  * @param client - Authenticated client for the repository.
  * @returns The issue, or `undefined` when it genuinely does not exist.
@@ -517,16 +508,15 @@ export declare namespace get {
 }
 
 /**
- * Whether the token may label issues in a repository.
+ * Checks whether the token may label issues in a repository.
  *
- * GitHub silently drops `labels` on issue creation for a token without push access, which is the
- * normal case when reporting friction upstream. That matters twice: the receiver's labels never get
- * applied, and {@link index} cannot find the issue afterwards, because it finds issues *by* that
- * label. {@link find} is the fallback.
+ * GitHub silently drops `labels` on issue creation for a token without push access, the normal case
+ * when reporting friction upstream. {@link index} then cannot find the issue afterwards, because it
+ * finds issues by that label. {@link find} is the fallback.
  *
  * @param client - Authenticated client for the repository.
- * @returns Whether labels will stick. Defaults to `false` when the answer cannot be read, since the
- * only consequence is choosing the slower, label-independent lookup.
+ * @returns Whether labels will stick. Defaults to `false` when the answer cannot be read, which only
+ * costs the slower, label-independent lookup.
  */
 export async function permissions(
   client: Client,
@@ -541,7 +531,7 @@ export async function permissions(
 }
 
 /**
- * A repository's default branch.
+ * Reads a repository's default branch.
  *
  * Needed to commit a reconciliation: an issue event says nothing about which branch mirrors it.
  *
@@ -564,8 +554,8 @@ export async function defaultBranch(
 /**
  * Finds the issue already covering a friction, without relying on a label.
  *
- * Lists issues directly rather than using GitHub's eventually consistent search index. It is only
- * used where {@link index} cannot work: a repository the token cannot label.
+ * Lists issues directly rather than using GitHub's eventually consistent search index. Used only
+ * where {@link index} cannot work: a repository the token cannot label.
  *
  * @param client - Authenticated client for the repository.
  * @returns The issue covering this friction, or `undefined`.
@@ -574,8 +564,7 @@ export async function find(client: Client, options: find.Options): Promise<Issue
   const { hash: key, repo } = options
   const candidates = await listAll(client, { repo })
 
-  // A marker is proof. A matching normalized title is the fallback, which is what catches an issue
-  // somebody filed by hand.
+  // A marker is proof. A matching normalized title is the fallback, catching an issue filed by hand.
   return (
     candidates.find((item) => parseMarker(item.body)?.hash === key) ??
     candidates.find((item) => hash(item.title) === key)
@@ -595,7 +584,7 @@ export declare namespace find {
 }
 
 /**
- * Every issue frog manages in a repository.
+ * Lists every issue frog manages in a repository.
  *
  * @param client - Authenticated client for the repository.
  * @returns Issues carrying the label, oldest first, with pull requests filtered out.
@@ -605,8 +594,7 @@ export async function list(client: Client, options: index.Options): Promise<read
 
   const collected: Issue[] = []
   // Paginated rather than one page of 100: missing an older issue would open a duplicate. The page
-  // ceiling is a runaway guard, not a real limit; 5,000 friction issues in one repository is not a
-  // case worth designing for.
+  // ceiling is a runaway guard, not a real limit.
   for (let page = 1; page <= 50; page++) {
     const response = await client.issues.listForRepo({
       ...split(repo),
@@ -652,7 +640,7 @@ export declare namespace index {
     label: string
     /** Repository to index, as `owner/name`. */
     repo: string
-    /** Which issues to consider. Defaults to `all`, so a closed issue still dedupes. */
+    /** Which issues to consider. Defaults to `all`, which dedupes against closed issues too. */
     state?: 'all' | 'open' | undefined
   }
 }
@@ -699,7 +687,7 @@ export async function matcher(client: Client, options: index.Options): Promise<M
       if (existing) return existing
 
       // Even a token with push access can encounter an issue whose configured label was removed.
-      // Fall back once per filing group so a replay still finds the side effect immediately.
+      // The fallback listing runs once per filing group, so a replay still finds the side effect.
       unlabelled ??= listAll(client, options).then(toIndex)
       return (await unlabelled).get(key)
     },
@@ -709,8 +697,8 @@ export async function matcher(client: Client, options: index.Options): Promise<M
 /**
  * Files an entry as an issue, or comments on the issue that already covers it.
  *
- * Commenting rather than opening a duplicate is what makes publishing idempotent, which is required:
- * a pull request `synchronize` event re-runs this over the same entries.
+ * Publishing has to be idempotent: a pull request `synchronize` event re-runs this over the same
+ * entries.
  *
  * @param client - Authenticated client for the target repository.
  * @returns The issue number and whether it was opened or commented on.
@@ -726,7 +714,7 @@ export async function publish(client: Client, options: publish.Options): Promise
 
   if (existing) {
     // Only a still-open issue can be answered by a replay. A closed one carries the same markers but
-    // needs reopening, so short-circuiting there would link an entry to an issue that stays closed.
+    // needs reopening first.
     if (occurrence && existing.state === 'open') {
       const occurrenceMarker = renderOccurrence(occurrence)
       if (existing.body?.includes(occurrenceMarker))

--- a/src/IssueForm.ts
+++ b/src/IssueForm.ts
@@ -3,13 +3,13 @@ import * as YAML from 'yaml'
 /** Directory GitHub reads issue templates from. */
 export const dir = '.github/ISSUE_TEMPLATE'
 
-/** Filename a project can add to say how it wants friction reported, ahead of its other forms. */
+/** Filename a project adds to say how it wants friction reported, ahead of its other forms. */
 export const filename = 'friction.yml'
 
 /** Configuration file that sits alongside the forms and is not one. */
 const config = 'config.yml'
 
-/** Element types that collect an answer. `markdown` is instruction text, so it is not among them. */
+/** Element types that collect an answer. `markdown` is instruction text, so it is excluded. */
 const kinds = ['checkboxes', 'dropdown', 'input', 'textarea'] as const
 
 /** How a form element collects its answer. */
@@ -21,7 +21,7 @@ export type Field = {
   description?: string | undefined
   /** How the answer is collected. */
   kind: Kind
-  /** Heading the answer appears under, which is how a submitted form renders. */
+  /** Heading the answer appears under, as a submitted form renders it. */
   label: string
   /** Choices, for a `checkboxes` or `dropdown` field. */
   options?: readonly string[] | undefined
@@ -42,14 +42,12 @@ export type Form = {
 /**
  * Parses a GitHub issue form.
  *
- * Only the elements that collect an answer survive. A `markdown` block is instruction text for whoever is
- * filling the form in, and carrying it into an entry would put the project's own preamble into the issue
- * body it eventually files.
+ * Only the elements that collect an answer survive. Carrying a `markdown` block into an entry would
+ * put the project's own preamble into the issue body it eventually files.
  *
  * @param contents - The form's YAML.
  * @returns The form, or `undefined` when the YAML is unparseable or has no answerable field. Malformed
- * input is a miss rather than a throw: the caller falls back to frog's own sections, and a broken form
- * upstream must not stop an entry being written.
+ * input is a miss rather than a throw: a broken form upstream must not stop an entry being written.
  */
 export function parse(contents: string): Form | undefined {
   const document = (() => {
@@ -84,9 +82,7 @@ export function parse(contents: string): Form | undefined {
  * Shaped like GitHub's own rendering of a submitted form, `### Label` per field, so an entry written
  * against a project's form arrives looking like one filed through its issue page.
  *
- * Guidance is carried as HTML comments. They tell whoever writes the entry what the field wants, and they
- * render as nothing once the body reaches GitHub, so an unanswered prompt is invisible rather than
- * embarrassing.
+ * Guidance is carried as HTML comments, which render as nothing once the body reaches GitHub.
  *
  * @returns Markdown with a heading per field.
  */
@@ -118,10 +114,9 @@ function render(field: Field): string {
 /**
  * Picks the form to author against, from the files in a project's template directory.
  *
- * `friction.yml` wins because a project that added one is speaking to frog directly. Failing that, a
- * project with a single form has made the choice already, and a project with several is asked for the one
- * named for bugs. Anything less certain than that resolves to nothing, which leaves frog's own sections in
- * place rather than filing a feature request into a bug form.
+ * `friction.yml` takes precedence: a project that added one is speaking to frog directly. Failing
+ * that, a lone form is used, and among several the one named for bugs. Anything less certain resolves
+ * to nothing, leaving frog's own sections in place.
  *
  * @param paths - Repository-relative paths of everything in {@link dir}.
  * @returns The path to read, or `undefined` when no form is the obvious one.
@@ -142,8 +137,8 @@ export function choose(paths: readonly string[]): string | undefined {
 /**
  * Finds and parses the form a project wants friction written against.
  *
- * Three lookups, cheapest first. A named template costs one read. A conventional `friction.yml` costs
- * one more. Listing the directory is the last resort, and only reached for a project that has neither.
+ * Three lookups, cheapest first: the template the project named, then a conventional `friction.yml`,
+ * then a listing of the template directory.
  *
  * @param read - Reads a repository file, or `undefined` when it is not there.
  * @param list - Lists the files in a repository directory.
@@ -154,7 +149,7 @@ export async function find(options: find.Options): Promise<Form | undefined> {
   const { list, named, read } = options
 
   const candidates = [
-    // A bare filename is the common way to name one, so accept it alongside a full path.
+    // Accept a bare filename alongside a full path.
     named ? (named.includes('/') ? named : `${dir}/${named}`) : undefined,
     `${dir}/${filename}`,
   ].filter((path): path is string => path !== undefined)
@@ -217,7 +212,7 @@ function toField(element: Element): Field | undefined {
     )
     .filter((option): option is string => Boolean(option))
 
-  // A checkbox carries its own `required` per option, which is what makes the whole field required.
+  // A checkbox carries `required` per option, and any one of them makes the field required.
   const required =
     element.validations?.required === true ||
     (element.attributes?.options ?? []).some(

--- a/src/Mirrors.ts
+++ b/src/Mirrors.ts
@@ -49,7 +49,7 @@ function normalize(mirrors: readonly Mirror[]): readonly Mirror[] {
 /**
  * Validates and normalizes a loaded journal.
  *
- * Unknown versions fail closed so recovery state is never silently discarded by older code.
+ * Unknown versions fail closed, so older code never silently discards recovery state.
  */
 export function from(value: unknown): State {
   if (!value || typeof value !== 'object' || Array.isArray(value))

--- a/src/Store.ts
+++ b/src/Store.ts
@@ -21,8 +21,7 @@ export type Options = {
  * Directory holding an entry and anything needed to reproduce it.
  *
  * An entry is a directory rather than a single file so a reproduction can ship beside it: the write-up
- * in `friction.md`, the script or fixture that triggers it under `artifacts/`. A reader can then run the
- * thing instead of reconstructing it from prose.
+ * in `friction.md`, the script or fixture that triggers it under `artifacts/`.
  *
  * @param id - Entry id.
  * @returns The repository-relative directory.
@@ -52,8 +51,8 @@ export function toArtifacts(id: string): string {
 /**
  * Id of the entry a repository-relative path refers to.
  *
- * The inverse of {@link toPath}. Only the write-up identifies an entry, so an artifact path resolves to
- * nothing: reconciliation acts on entries, and an artifact is a detail of one.
+ * The inverse of {@link toPath}. Only the write-up identifies an entry, so an artifact path resolves
+ * to nothing.
  *
  * @param file - Repository-relative path.
  * @returns The id, or `undefined` when the path is not an entry's write-up.
@@ -69,8 +68,7 @@ export function toId(file: string): string | undefined {
 /**
  * Reads and parses every entry, sorted by id.
  *
- * @returns Every entry. Throws on the first malformed write-up rather than skipping it, so a broken
- * entry cannot go unnoticed.
+ * @returns Every entry. Throws on the first malformed write-up rather than skipping it.
  */
 export async function read(options: Options): Promise<readonly Entry.Entry[]> {
   const ids = await list(options)
@@ -78,13 +76,11 @@ export async function read(options: Options): Promise<readonly Entry.Entry[]> {
 }
 
 /**
- * Ids of every entry, sorted.
+ * Lists the ids of every entry, sorted.
  *
- * A directory counts as an entry only once it holds a write-up, so a stray directory is ignored rather
- * than breaking the read.
+ * A directory counts as an entry only once it holds a write-up. A stray directory is ignored.
  *
- * @returns Entry ids. A missing directory yields an empty list, so a repository that has never logged
- * friction is not a failure case.
+ * @returns Entry ids. A missing directory yields an empty list.
  */
 export async function list(options: Options): Promise<readonly string[]> {
   const found = await fs
@@ -121,7 +117,7 @@ export async function get(id: string, options: Options): Promise<Entry.Entry> {
 }
 
 /**
- * Every repository-relative path belonging to an entry, write-up and artifacts alike.
+ * Lists every repository-relative path belonging to an entry, write-up and artifacts alike.
  *
  * Needed to stage a deletion: removing an entry means removing its reproduction too.
  *
@@ -146,8 +142,8 @@ export async function files(id: string, options: Options): Promise<readonly stri
 /**
  * Writes an entry, minting an id when one is not supplied.
  *
- * Passing an existing id overwrites the write-up in place, leaving any artifacts alone. That is how the
- * issue link is written back after filing.
+ * Passing an existing id overwrites the write-up in place, leaving any artifacts alone. The issue link
+ * is written back that way after filing.
  *
  * @returns The id used and the path written.
  */
@@ -165,9 +161,9 @@ export async function write(
 /**
  * Reserves a directory for a new entry, returning the id it got.
  *
- * Ids come from the title and the date, so two entries logged the same day about the same thing want the
- * same one. Creating the directory is the claim, which is what stops the second one overwriting the
- * first. Each pass either wins or proves that suffix is taken, and only finitely many can be.
+ * Ids come from the title and the timestamp, so two entries logged in the same second about the same
+ * thing want the same id. Creating the directory is the claim: each pass either claims the id or proves that
+ * suffix is taken, and only finitely many can be.
  */
 async function claim(title: string, options: Options): Promise<string> {
   const base = Entry.newId({ title })

--- a/src/Sync.ts
+++ b/src/Sync.ts
@@ -8,32 +8,29 @@ export type Plan = {
   /**
    * Entries whose linked issue no longer exists.
    *
-   * Written back without the link, returning them to pending so publishing can file them again.
+   * Written back without the link, returning them to pending.
    */
   clearLink: readonly Entry.Entry[]
-  /** Ids of entries whose issue closed. The friction is resolved, so the mirror goes away. */
+  /** Ids of entries whose issue closed. */
   remove: readonly string[]
   /** Entries to write: content pulled from their issue, or rebuilt for one that reopened. */
   write: readonly Entry.Entry[]
 }
 
 /**
- * Works out what reconciling would change, without changing anything.
+ * Computes what reconciling would change, without changing anything.
  *
- * Pure by design, for two reasons. The CLI applies a plan with git while the App applies the same plan
- * through the GitHub API, so the decisions cannot live in either. And this is the only stateful corner
- * of the system, which makes it the one worth testing exhaustively without any I/O.
+ * Pure because the CLI applies a plan with git while the App applies the same plan through the GitHub
+ * API.
  *
- * The issue is canonical, so this only ever pulls issue into file. That is what removes the need for a
- * watermark recording when the last sync ran: there is no "who changed last" question to answer, and a
- * maintainer's edits on an issue can never be clobbered. The one push, file into issue, belongs to the
- * App's pull request handler, where a diff proves the file actually changed.
+ * Pulls issue into file only. The issue is canonical, so a maintainer's edits on an issue can never be
+ * clobbered. The one push, file into issue, belongs to the App's pull request handler.
  *
  * @returns The edits to apply. Applying a plan and re-planning yields an empty plan.
  */
 export function plan(options: plan.Options): Plan {
   const { entries, issues, labels, mirrors = [], repo } = options
-  // Where the files are, which is only the same as where the issues are when reporting to yourself.
+  // Where the files are. Only the same as where the issues are when reporting to yourself.
   const origin = options.origin ?? repo
 
   const byNumber = new Map(issues.map((issue) => [issue.number, issue]))
@@ -55,7 +52,7 @@ export function plan(options: plan.Options): Plan {
     if (!entry.issue) continue
 
     const link = Github.parseLink(entry.issue)
-    // A link into another repository is not ours to reconcile from here.
+    // A link into another repository is not reconciled from here.
     if (!link || link.repo !== repo) continue
 
     const issue = byNumber.get(link.issue)
@@ -111,12 +108,11 @@ export declare namespace plan {
      * Repository holding the entries, as `owner/name`. Defaults to `repo`.
      *
      * Differs from `repo` whenever friction was reported upstream: the issues are there, the files are
-     * here. A marker records this one, so rebuilding a deleted file matches against it.
+     * here.
      */
     origin?: string | undefined
     /** Repository the issues live in, as `owner/name`. */
     repo: string
-    /** Label to apply for each severity, from config. */
   }
 }
 
@@ -128,12 +124,10 @@ export function empty(plan: Plan): boolean {
 /**
  * Assembles the issue set {@link plan} needs.
  *
- * A linked issue absent from the listing may simply have lost its label, so each one is confirmed
- * directly before {@link plan} can conclude it is gone. Skipping this turns a label edit into a
- * cleared link, and the next publish into a duplicate issue.
+ * A linked issue absent from the listing may simply have lost its label. Each one is confirmed directly,
+ * so a label edit does not become a cleared link and then a duplicate issue.
  *
- * Shared by both adapters through injected lookups: the CLI reads with a user token, the App with an
- * installation token, and the reconciliation must not differ between them.
+ * Lookups are injected: the CLI reads with a user token, the App with an installation token.
  *
  * @returns Every issue relevant to reconciling `repo`, listing plus confirmations.
  */

--- a/src/Target.ts
+++ b/src/Target.ts
@@ -6,10 +6,10 @@ export type Kind = 'npm' | 'repo'
 const repoPattern = /^[\w.-]+\/[\w.-]+$/
 
 /**
- * How a target string names a repository.
+ * Classifies how a target string names a repository.
  *
- * Only two forms exist, because an issue can only be filed on a GitHub repository: name that repository,
- * or name a package that declares it.
+ * Two forms only, because an issue can only be filed on a GitHub repository: the repository itself, or
+ * a package that declares it.
  *
  * @param value - Target as written in frontmatter or passed to `--target`.
  * @returns The name to look up, and how to look it up.
@@ -56,13 +56,12 @@ export type Resolution =
 /**
  * Resolves where an entry's issue belongs, applying every consent gate.
  *
- * Naming and consent are separate steps. A target string only ever names a repository, whether directly or
- * through a package's `repository` field, and consent is then read from that repository's own default
- * branch. Nothing a package or a third party says can redirect a report to a repository that has not
- * itself opted in.
+ * Naming and consent are separate steps. A target string only ever names a repository, whether
+ * directly or through a package's `repository` field, and consent is then read from that repository's
+ * own default branch.
  *
  * Two gates guard a target that is not this repository. The receiver must have committed a config
- * accepting inbound friction, and may restrict who reports. And the sender must have listed the target in
+ * accepting inbound friction, and may restrict who reports. The sender must have listed the target in
  * `outbound.allowedRepos`, read from the base branch so a pull request cannot name its own destination.
  * Setting `outbound.enabled` to false refuses every target but this repository.
  *
@@ -92,8 +91,8 @@ export async function resolve(
 
   if (repo === self) return { ok: true, target: { kind: 'self', repo } }
 
-  // Checked before asking the target for consent: there is no point spending a request on a report this
-  // repository has switched off sending.
+  // Checked before asking the target for consent: a sender that has switched off sending need not
+  // spend a request.
   if (!outbound.enabled)
     return {
       code: 'OUTBOUND_DISABLED',
@@ -144,14 +143,13 @@ export declare namespace resolve {
     /**
      * Reads a repository's committed inbound policy from its default branch.
      *
-     * Injected because the CLI reads it over the REST API while the App reads it with an installation
-     * token, and neither belongs in this module.
+     * Injected: the CLI reads it over the REST API, the App with an installation token.
      */
     readConfig: (repo: string) => Promise<Config.Inbound | undefined>
     /**
      * Resolves a package name to the repository it declares.
      *
-     * Injected for the same reason: the CLI reads `node_modules`, and the App asks the npm registry.
+     * Injected for the same reason: the CLI reads `node_modules`, the App asks the npm registry.
      */
     readRepo: (name: string) => Promise<string | undefined>
     /** This repository, as `owner/name`. The default target, and the sender for `allowFrom`. */

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -7,7 +7,7 @@ import * as IssueForm from '../../IssueForm.js'
 import * as Store from '../../Store.js'
 import * as context from '../internal/context.js'
 
-/** The rule to paste into `AGENTS.md`, and the reason it says *when* rather than just *what*. */
+/** The rule to paste into `AGENTS.md`. */
 export const rule =
   'Log papercuts and friction (tooling, docs, APIs, tests, conventions) as you hit them with ' +
   '`frog log`. Run `frog list` first to see what is already known.'
@@ -22,12 +22,11 @@ Friction hit while working in this repository, one directory per item:
   ${`${Store.artifacts}/`.padEnd(14)}optional, whatever reproduces it
 \`\`\`
 
-Filing an entry gives it an owner. The write-up then carries an \`issue:\` link, mirrors what happens to
-it, and the whole directory is deleted once the friction is resolved. So this is a live list of friction
-that is still outstanding, including friction in dependencies.
+Filing an entry gives it an owner. The write-up then carries an \`issue:\` link and mirrors what happens
+to it. The whole directory is deleted once the friction is resolved. Every entry left here is still
+outstanding, including friction in dependencies.
 
-Do not maintain an index here. This directory is the index, and it is kept true without anyone
-remembering to.
+Do not maintain an index here. This directory is the index.
 
 ## Logging Friction
 
@@ -36,11 +35,11 @@ frog list    # what is already known
 frog log     # add one
 \`\`\`
 
-\`frog log\` writes the sections to fill in. Ids are when the friction was hit plus its title, so this
-directory reads oldest-first and shows at a glance how long something has gone unresolved.
+\`frog log\` writes the sections to fill in. Each id is when the friction was hit plus its title, so
+the directory reads oldest-first.
 
 Put anything that reproduces the friction in that entry's \`${Store.artifacts}/\` and reference it from the
-write-up, so the next reader runs the reproduction instead of rebuilding it.
+write-up. The next reader runs the reproduction instead of rebuilding it.
 
 ## For Agents
 
@@ -71,8 +70,8 @@ const libraryConfig = `{
  * The issue form a project serves so consumers report friction the way it wants.
  *
  * Rendered from the same sections as the entry scaffold, so the two cannot drift. A consumer's frog finds
- * this by convention and writes its entry against it, and a human filing through the issue page gets the
- * same questions.
+ * it by convention and writes its entry against it. A human filing through the issue page gets the same
+ * questions.
  */
 const form = `name: Friction
 description: Something about this project cost you time.
@@ -115,7 +114,7 @@ export const init = Cli.create('init', {
     const files = [
       [`${Store.dir}/README.md`, readme],
       [Config.file, c.options.library ? libraryConfig : config],
-      // Only for a project accepting reports: it is what a consumer's frog writes its entry against.
+      // Only for a project accepting reports: a consumer's frog writes its entry against it.
       ...(c.options.library ? ([[`${IssueForm.dir}/${IssueForm.filename}`, form]] as const) : []),
     ] as const
 

--- a/src/cli/commands/log.test.ts
+++ b/src/cli/commands/log.test.ts
@@ -95,7 +95,7 @@ test('error: a body is required when not interactive', async () => {
   expect(await cli.error(['log', title, '--cwd', cwd])).toMatchInlineSnapshot(`
     {
       "code": "MISSING_BODY",
-      "message": "A body is required. An entry with no detail is not actionable.",
+      "message": "A body is required.",
     }
   `)
 })

--- a/src/cli/commands/log.ts
+++ b/src/cli/commands/log.ts
@@ -54,13 +54,13 @@ export const log = Cli.create('log', {
       .optional()
       .describe('API base URL. Set automatically inside Actions.'),
     GITHUB_TOKEN: z.string().optional().describe('Token used by --publish.'),
-    VISUAL: z.string().optional().describe('Preferred over EDITOR when both are set.'),
+    VISUAL: z.string().optional().describe('Overrides EDITOR when both are set.'),
   }),
   options: z.object({
     body: z
       .string()
       .optional()
-      .describe('Markdown body. Also readable from piped input, or an editor when interactive.'),
+      .describe('Markdown body. Also read from piped input, or from an editor when interactive.'),
     cwd: context.cwdOption,
     force: z.boolean().optional().describe('Log it even if a similar entry already exists.'),
     label: z.array(z.string().min(1)).optional().describe('Extra issue label. Repeatable.'),
@@ -68,7 +68,7 @@ export const log = Cli.create('log', {
     publish: z
       .boolean()
       .optional()
-      .describe('File the issue immediately, rather than leaving it for `publish`.'),
+      .describe('File the issue immediately instead of leaving it for `publish`.'),
     severity: Entry.Severity.optional().describe('Impact. Defaults to minor.'),
     token: z.string().min(1).optional().describe('GitHub token. Overrides the environment.'),
     target: z
@@ -111,11 +111,10 @@ export const log = Cli.create('log', {
     const { config, repo, root } = await context.resolve({ cwd: c.options.cwd })
     const interactive = prompt.interactive()
 
-    // Piped input is the whole entry, shaped like a commit message. It is what makes bare `frog log`
+    // Piped input carries the whole entry, shaped like a commit message. It makes bare `frog log`
     // usable without a terminal, where a prompt cannot run at all.
     //
-    // Not read at all once the arguments cover both parts. Standard input is whatever the caller left
-    // attached, and looking at it when there is nothing to learn only costs the wait.
+    // Skipped once the arguments cover both parts. Reading it then only costs the wait.
     const piped = c.args.title && c.options.body ? undefined : await attempt(stdin.read())
     if (piped && !piped.ok) return c.error({ code: piped.code, message: piped.message })
     const input = piped?.ok && piped.value ? stdin.parse(piped.value) : undefined
@@ -139,11 +138,10 @@ export const log = Cli.create('log', {
 
     const body = c.options.body ?? (input?.body || undefined)
 
-    // An upstream project judges a report against its own issue form, so scaffold from that rather than
-    // from frog's sections. Fetched only when the answers would be used, and never fatal: a target that
-    // cannot be reached costs the scaffold, not the entry.
-    // This repository's own form when there is no target, so a project that publishes one gets it used
-    // for its own entries too rather than only by whoever reports to it.
+    // Scaffold from the target's own issue form rather than from frog's sections. An upstream project
+    // judges a report against its own form. Fetched only when the answers would be used. Never fatal:
+    // an unreachable target costs the scaffold, not the entry.
+    // With no target, use this repository's own form.
     const own = !body && !c.options.target ? await attempt(form.own(root)) : undefined
 
     const upstream =
@@ -161,13 +159,12 @@ export const log = Cli.create('log', {
     const scaffold =
       (upstream?.ok ? upstream.value : undefined) ?? (own?.ok ? own.value : undefined)
 
-    // A scaffold is the detail this is asking for, one question at a time, so it satisfies the guard.
-    // Without a terminal there is otherwise no way to reach a template at all, which would leave the
-    // upstream's questions unreachable by the agents this exists for.
+    // A scaffold satisfies the guard: it asks for the same detail, one question at a time. Without a
+    // terminal it is the only way to reach a template.
     if (!body && !scaffold && !interactive)
       return c.error({
         code: 'MISSING_BODY',
-        message: 'A body is required. An entry with no detail is not actionable.',
+        message: 'A body is required.',
         cta: {
           commands: [
             { command: 'log', description: 'Pipe a title, a blank line, then the detail' },
@@ -179,8 +176,7 @@ export const log = Cli.create('log', {
     const entries = await attempt(Store.read({ root }))
     if (!entries.ok) return c.error({ code: entries.code, message: entries.message })
 
-    // Catching the repeat here, at authoring time, is the only place it is cheap. A flat friction
-    // log has no duplicate check at all, which is how the same item lands five times.
+    // Catch the repeat at authoring time, the only point where it is cheap.
     const duplicate = entries.value.find(
       (entry) => Entry.normalizeTitle(entry.title) === Entry.normalizeTitle(title),
     )
@@ -212,7 +208,7 @@ export const log = Cli.create('log', {
       { root },
     )
 
-    // Only reached interactively, or on request: the editor is the long-form input path.
+    // Reached interactively, or on request. The editor is the long-form input path.
     if (c.options.open ?? (interactive && !body)) {
       const edited = await attempt(
         prompt
@@ -237,8 +233,8 @@ export const log = Cli.create('log', {
         },
       )
 
-    // Filing must never lose the entry. It is already on disk, so every failure past this point
-    // reports why it stayed pending rather than failing the command.
+    // The entry is already on disk. Every failure past this point reports why it stayed pending
+    // rather than failing the command.
     const filed = await attempt(
       (async () => {
         const ready = await publisher.prepare({

--- a/src/cli/commands/publish.ts
+++ b/src/cli/commands/publish.ts
@@ -63,7 +63,7 @@ export const publish = Cli.create('publish', {
       .describe('Entries left pending, and why.'),
     unlabelled: z
       .array(z.string())
-      .describe('Destinations that dropped the labels, because this token cannot label there.'),
+      .describe('Destinations that dropped the labels. This token cannot label there.'),
   }),
   async run(c) {
     const { config, repo, root } = await context.resolve({ cwd: c.options.cwd })
@@ -93,8 +93,8 @@ export const publish = Cli.create('publish', {
         },
       })
 
-    // Each entry's target is resolved through the consent gates before anything is filed, and entries
-    // are grouped by destination so one repository costs one index lookup however many entries it has.
+    // Resolve each entry's target through the consent gates before anything is filed. Group by
+    // destination so one repository costs one index lookup however many entries it has.
     const resolvers = target.resolvers({
       outbound: config.outbound,
       client: ready.client,

--- a/src/cli/commands/sync.ts
+++ b/src/cli/commands/sync.ts
@@ -35,7 +35,7 @@ export const sync = Cli.create('sync', {
     { description: 'Reconcile against issue state' },
     { description: 'See what would change', options: { dryRun: true } },
   ],
-  hint: 'Safe to run repeatedly, and safe to run on a schedule. The issue is always canonical.',
+  hint: 'Safe to run repeatedly. Issue state takes precedence.',
   output: z.object({
     cleared: z
       .array(z.string())
@@ -67,9 +67,9 @@ export const sync = Cli.create('sync', {
         },
       })
 
-    // Every repository these entries point at, not just this one. An entry reported upstream is
-    // mirrored here, so its issue closing has to be noticed here too. Own repository always included:
-    // a reopened issue whose file was deleted has nothing local to notice it by.
+    // Check every repository these entries point at, not just this one. An entry reported upstream is
+    // mirrored here, so its issue closing has to be noticed here too. Always include the own
+    // repository: a reopened issue whose file was deleted has nothing local to notice it by.
     const destinations = [
       ...new Set([
         ready.repo,
@@ -157,9 +157,9 @@ export const sync = Cli.create('sync', {
     if (c.options.dryRun || (Sync.empty(plan) && !mirrorsChanged))
       return c.ok({ cleared, committed: false, removed, updated })
 
-    // Staged before unlinking, so tracked entries have their deletion recorded. The whole directory
-    // goes, artifacts included. `ignoreUnmatch` covers entries that were never committed, which are
-    // then removed from disk below.
+    // Stage before unlinking so tracked entries have their deletion recorded. The whole directory
+    // goes, artifacts included. `ignoreUnmatch` covers entries that were never committed; those are
+    // removed from disk below.
     await Git.rm(removed.map(Store.toDir), { cwd: root, ignoreUnmatch: true })
     for (const id of removed) await Store.remove(id, { root })
 

--- a/src/cli/commands/targets.ts
+++ b/src/cli/commands/targets.ts
@@ -33,8 +33,8 @@ export const targets = Cli.create('targets', {
   async run(c) {
     const { repo, root } = await context.resolve({ cwd: c.options.cwd })
 
-    // Consent lives on the target repository, so this needs a client. Unauthenticated works, at 60
-    // requests an hour, which the day-long cache is what keeps within reach.
+    // Consent lives on the target repository, so this needs a client. Works unauthenticated at 60
+    // requests an hour. The day-long cache keeps runs within that limit.
     const token = await octokit.token({
       env: c.env,
       ...(c.options.token ? { token: c.options.token } : {}),

--- a/src/cli/internal/attempt.ts
+++ b/src/cli/internal/attempt.ts
@@ -5,14 +5,13 @@ export type Attempt<value> =
 /**
  * Runs `promise`, returning a failure instead of throwing.
  *
- * This exists because of a sharp edge in incur: `c.error()` is typed `=> never` but does not throw.
- * It returns a sentinel that is only recognised when it is the return value of `run`, so
- * `return c.error(...)` from inside a nested closure or a `.catch()` silently becomes ordinary data.
- * Wrapping the fallible call means every `c.error()` can stay at the top level of `run`, where it
- * works.
+ * Works around a sharp edge in incur: `c.error()` is typed `=> never` but does not throw, and its
+ * sentinel is recognised only as the return value of `run`, so `return c.error(...)` from inside a
+ * nested closure or a `.catch()` silently becomes ordinary data. Wrapping the fallible call keeps every
+ * `c.error()` at the top level of `run`, where it works.
  *
- * The `code` on our own error classes is picked up here, which is how a domain error keeps its
- * machine-readable code without the core having to depend on incur.
+ * Picks up the `code` on frog's own error classes, so a domain error keeps its machine-readable code
+ * without the core depending on incur.
  */
 export async function attempt<value>(promise: Promise<value>): Promise<Attempt<value>> {
   try {
@@ -23,7 +22,7 @@ export async function attempt<value>(promise: Promise<value>): Promise<Attempt<v
       code: failure.code ?? 'UNKNOWN',
       message: failure.message,
       ok: false,
-      // Octokit puts the HTTP status here, which is what turns "Not Found" into something actionable.
+      // Octokit puts the HTTP status here.
       ...(typeof failure.status === 'number' ? { status: failure.status } : {}),
     }
   }

--- a/src/cli/internal/cache.ts
+++ b/src/cli/internal/cache.ts
@@ -10,9 +10,9 @@ export function dir(env: Record<string, string | undefined> = process.env): stri
 }
 
 /**
- * A cache on disk, so a consent lookup survives between runs.
+ * Caches to disk, so a consent lookup survives between runs.
  *
- * Every failure is swallowed: a cache that cannot be written is a slower run, not a failed one.
+ * Every failure is swallowed: an unwritable cache slows a run, it does not fail one.
  */
 export function file(root: string = dir()): Cache.Cache {
   return {

--- a/src/cli/internal/context.ts
+++ b/src/cli/internal/context.ts
@@ -13,8 +13,7 @@ export type Context = {
 /**
  * Resolves the repository root and config.
  *
- * The one place git and config meet: `Config` stays a pure normalizer, and the origin remote is
- * threaded in as a default rather than duplicated into the config file.
+ * The origin remote is threaded in as a default, keeping `Config` a pure normalizer.
  */
 export async function resolve(options: resolve.Options = {}): Promise<Context> {
   const cwd = options.cwd ?? process.cwd()

--- a/src/cli/internal/form.ts
+++ b/src/cli/internal/form.ts
@@ -10,11 +10,11 @@ import * as target from './target.js'
 /**
  * Renders the scaffold an entry aimed at another project should be written against.
  *
- * A project judges a report by its own form, so the questions worth answering are the ones it asks. The
- * form is fetched at authoring time rather than filing time because that is when the answers get written.
+ * A project judges a report by its own form. The form is fetched at authoring time, when the answers get
+ * written.
  *
- * Anonymous reads are fine here: a public project's issue form is public. A token is used when one is
- * around, for the rate limit rather than the access.
+ * A token is used when one is around, for the rate limit rather than the access. A public project's
+ * issue form reads fine anonymously.
  *
  * @param value - The `--target` as written.
  * @returns The scaffold, or `undefined` when the target resolves to nothing, refuses reports, or has no
@@ -34,7 +34,7 @@ export async function scaffold(
 
   const resolution = await Target.resolve(value, target.resolvers({ client, outbound, root, self }))
   // A refused target is reported by publishing, which says why. Here it only means there is no form to
-  // write against, and the entry still has to be written.
+  // write against.
   if (!resolution.ok || resolution.target.kind === 'self') return undefined
 
   const { repo, template } = resolution.target
@@ -66,9 +66,7 @@ export declare namespace scaffold {
 /**
  * Renders the scaffold an entry about this repository should be written against.
  *
- * The same discovery as an upstream target, off disk rather than over the API. A project that publishes
- * a form has already said how it wants friction written, and that answer should not differ depending on
- * who is doing the writing.
+ * The same discovery as an upstream target, off disk rather than over the API.
  *
  * @param root - Repository root.
  * @returns The scaffold, or `undefined` when this repository publishes no form.

--- a/src/cli/internal/octokit.ts
+++ b/src/cli/internal/octokit.ts
@@ -8,8 +8,8 @@ const exec = promisify(execFile)
 /**
  * Resolves a GitHub token.
  *
- * The `gh auth token` fallback is what makes the common local case need zero configuration: anyone
- * with the GitHub CLI already logged in can publish without setting anything up.
+ * Falls back to `gh auth token`, so anyone already logged in with the GitHub CLI can publish without
+ * configuration.
  */
 export async function token(options: token.Options): Promise<string | undefined> {
   const { env, token } = options
@@ -27,12 +27,12 @@ export declare namespace token {
       GH_TOKEN?: string | undefined
       GITHUB_TOKEN?: string | undefined
     }
-    /** Explicit `--token`, which wins over everything. */
+    /** Explicit `--token`. Overrides every other source. */
     token?: string | undefined
   }
 }
 
-/** Builds a client. `baseUrl` comes from `GITHUB_API_URL`, which Actions sets for you. */
+/** Builds a client. `baseUrl` comes from `GITHUB_API_URL`, which Actions sets. */
 export function client(options: client.Options = {}): Github.Client {
   const { baseUrl, token } = options
   return new Octokit({ ...(token ? { auth: token } : {}), ...(baseUrl ? { baseUrl } : {}) }).rest

--- a/src/cli/internal/prompt.ts
+++ b/src/cli/internal/prompt.ts
@@ -2,13 +2,13 @@ import { spawn } from 'node:child_process'
 import * as clack from '@clack/prompts'
 
 /**
- * Bind every prompt to stderr so stdout stays a clean data channel for pipes and agents.
+ * Binds every prompt to stderr so stdout stays a clean data channel for pipes and agents.
  *
- * Spread this into each clack call rather than wrapping the library, so call sites stay obvious.
+ * Spread into each clack call.
  */
 export const stream = { output: process.stderr } as const
 
-/** True when we can prompt at all. */
+/** Whether the process can prompt at all. */
 export function interactive(): boolean {
   return Boolean(process.stdin.isTTY && process.stderr.isTTY)
 }
@@ -22,8 +22,7 @@ export function required<value>(value: value | symbol): value {
 /**
  * Opens `file` in an editor and waits.
  *
- * The editor edits the real entry rather than a scratch copy, so there is nothing to copy back and
- * nothing to lose if the editor dies.
+ * The editor edits the real entry, not a scratch copy.
  */
 export async function edit(file: string, options: edit.Options): Promise<void> {
   const { command } = options

--- a/src/cli/internal/publish.ts
+++ b/src/cli/internal/publish.ts
@@ -11,17 +11,9 @@ export type Outcome = {
   /** Entries that landed on an issue already covering them. */
   commented: Link[]
   created: Link[]
-  /**
-   * Destinations whose labels were dropped, because the token cannot label there.
-   *
-   * Surfaced so a receiver's `inbound.labels` silently not applying is visible.
-   */
+  /** Destinations whose labels were dropped because the token cannot label there. */
   unlabelled: string[]
-  /**
-   * Paths written, for the caller to stage.
-   *
-   * Filing may span several destinations, and those belong in one commit.
-   */
+  /** Paths written, for the caller to stage. */
   written: string[]
 }
 
@@ -37,8 +29,8 @@ export type Blocked = { code: string; message: string; retryable?: boolean | und
 /**
  * Resolves everything filing needs, or reports what is missing.
  *
- * Shared by `publish` and `log --publish` so the two cannot drift on which token wins or which label
- * dedupe keys off.
+ * Shared by `publish` and `log --publish` so the two cannot drift on which token takes precedence or
+ * which label dedupe keys off.
  */
 export async function prepare(options: prepare.Options): Promise<Blocked | Ready> {
   const { config, env, repo, token } = options
@@ -54,7 +46,7 @@ export async function prepare(options: prepare.Options): Promise<Blocked | Ready
   if (!label)
     return {
       code: 'NO_LABEL',
-      message: '`labels` must not be empty: it is how already-filed issues are found.',
+      message: '`labels` must not be empty. frog finds already-filed issues by the first one.',
     }
 
   const resolved = await octokit.token({ env, ...(token ? { token } : {}) })
@@ -78,8 +70,8 @@ export async function prepare(options: prepare.Options): Promise<Blocked | Ready
 /**
  * Turns an API failure into something a reader can act on.
  *
- * Octokit's own message for a missing repository is `Not Found - <docs url>`, which says nothing
- * about which repository or what to do about it.
+ * Octokit's own message for a missing repository is `Not Found - <docs url>`, which names neither the
+ * repository nor a fix.
  */
 export function toFailure(failure: toFailure.Options): Blocked {
   const { message, repo, status } = failure
@@ -124,12 +116,11 @@ export declare namespace prepare {
 /**
  * Files entries as issues and writes the `issue:` link back into each file.
  *
- * Existing issues are indexed once for the whole run rather than looked up per entry, and an entry
- * whose hash is already indexed gets a comment instead of a duplicate. That is what makes this safe
- * to run repeatedly over the same entries.
+ * Existing issues are indexed once for the whole run. An entry whose hash is already indexed gets a
+ * comment instead of a duplicate, so this is safe to run repeatedly over the same entries.
  *
  * A failure part-way through throws, leaving already-filed entries with their links on disk and the
- * rest pending. Nothing is lost, and re-running picks up where it stopped.
+ * rest pending. Re-running picks up where it stopped.
  */
 export async function file(options: file.Options): Promise<Outcome> {
   const { client, config, dryRun, entries, label, origin, pr, repo, root } = options
@@ -170,8 +161,8 @@ export async function file(options: file.Options): Promise<Outcome> {
         entry: entry,
         labels: applied,
       }),
-      // `origin` is the repository holding the file, which is not the destination when reporting
-      // upstream. Getting this wrong would leave a closed issue unable to find its mirror.
+      // `origin` is the repository holding the file, not the destination when reporting upstream. A
+      // wrong value leaves a closed issue unable to find its mirror.
       marker: { hash, origin, path, severity: entry.severity },
       provenance: { ...provenance, ...(pr ? { pr } : {}) },
       repo,
@@ -190,7 +181,6 @@ export async function file(options: file.Options): Promise<Outcome> {
     commented,
     created,
     written,
-    // Reported rather than swallowed: the receiver asked for these and did not get them.
     unlabelled: !matcher.labelled && applied.length > 0 && !dryRun ? [repo] : [],
   }
 }
@@ -209,8 +199,8 @@ export declare namespace file {
     /**
      * Repository holding the entries, as `owner/name`.
      *
-     * Distinct from `repo`, which is where the issue is filed. They differ whenever friction is
-     * reported upstream, and the marker records this one so a closed issue can find its mirror.
+     * Distinct from `repo`, where the issue is filed. They differ whenever friction is reported
+     * upstream.
      */
     origin: string
     /** Pull request this is filed from, as `owner/name#number`. */

--- a/src/cli/internal/stdin.ts
+++ b/src/cli/internal/stdin.ts
@@ -7,15 +7,15 @@ export const grace = 100
 /**
  * Reads piped input, or nothing when there is none.
  *
- * `isTTY` is not enough on its own, and neither is `fstat`. A terminal and `/dev/null` are character
- * devices and never have input. A redirected file certainly does, and reading one cannot block.
+ * `isTTY` alone is not enough: `/dev/null` is not a terminal and still has no input. Both are character
+ * devices, which is the test used here. A redirected file always has input, and reading one cannot block.
  *
- * Everything else has to prove itself within {@link grace}, because an open channel is not the same as an
- * arriving one. A parent that spawns this and holds the write end open without writing, which is what an
- * agent does, leaves standard input readable forever and never ended.
+ * A pipe or a socket has to produce its first byte within {@link grace}. A parent that spawns this and
+ * holds the write end open without writing, which is what an agent does, leaves standard input readable
+ * forever and never ended.
  *
- * The cost is that a producer slower than the deadline is treated as silent. That is the better failure:
- * a refusal naming `--title`, rather than a process that never returns.
+ * A producer slower than the deadline is treated as silent. That is the better failure: a refusal,
+ * not a process that never returns.
  *
  * @returns The input, or `undefined` when nothing was piped in.
  */
@@ -48,12 +48,11 @@ export declare namespace read {
 /**
  * Lets the process exit even though standard input is still open.
  *
- * Touching standard input references its handle, and the reference outlives the listeners: a parent that
- * spawns this and keeps the write end open would otherwise hold the process alive indefinitely after its
- * work is done, with the entry already written and nothing left to wait for.
+ * Touching standard input references its handle, and the reference outlives the listeners. A parent that
+ * spawns this and keeps the write end open would otherwise hold the process alive indefinitely.
  *
  * Only for a pipe or a socket. A file-backed standard input is an `fs.ReadStream`, which has no `unref`
- * at all, and needs none: a file always reaches its end.
+ * and needs none.
  */
 function release(): void {
   process.stdin.pause()
@@ -106,9 +105,8 @@ function arriving(stream: Readable, deadline: number): Promise<boolean> {
 /**
  * Splits piped input into a title and a body.
  *
- * Shaped like a commit message: the first line is the title, the rest is the body. That avoids asking a
- * caller to quote a multi-line string on a command line, where an apostrophe in the body ends the
- * argument and breaks the whole invocation.
+ * Shaped like a commit message: the first line is the title, the rest is the body. A caller never has to
+ * quote a multi-line string on a command line, where an apostrophe in the body would end the argument.
  *
  * @param contents - Piped input.
  * @returns The title and body, or `undefined` when there is no title to take.

--- a/src/cli/internal/target.ts
+++ b/src/cli/internal/target.ts
@@ -6,14 +6,14 @@ import type * as Github from '../../Github.js'
 import * as GithubModule from '../../Github.js'
 import type * as Target from '../../Target.js'
 
-/** Concurrent config lookups. Bounded so scanning a large dependency list does not open one socket each. */
+/** Concurrent config lookups, bounded so a large dependency list does not open one socket each. */
 const concurrency = 8
 
 /**
  * Builds the resolver stack `Target.resolve` needs.
  *
  * The CLI resolves package names off disk and reads committed config through the REST API. The App
- * supplies its own pair, which is why `Target` takes them rather than importing any of it.
+ * supplies its own pair.
  */
 export function resolvers(options: resolvers.Options): Target.resolve.Options {
   const { outbound, client, root, self, store } = options
@@ -43,10 +43,8 @@ export declare namespace resolvers {
 }
 
 /**
- * Reads a repository's committed inbound policy, optionally through a cache.
- *
- * A repository that accepts nothing is cached as such. Most do not accept inbound friction, so caching
- * the absence is what stops the second run re-asking about every dependency.
+ * Reads a repository's committed inbound policy, optionally through a cache. A repository that accepts
+ * nothing is cached as such.
  *
  * Only pass a store when listing. Filing must read consent fresh, or a day-old yes would authorize an
  * issue on a project that has since opted out.
@@ -102,8 +100,7 @@ export type Accepting = {
  *
  * Scans the declared dependencies rather than walking `node_modules`, which keeps the disk half of this a
  * handful of reads instead of thousands. Consent then costs one API call per distinct repository, cached
- * for a day. This is what the generated skill lists, so an agent never has to recall which upstreams take
- * reports.
+ * for a day.
  */
 export async function accepting(options: accepting.Options): Promise<readonly Accepting[]> {
   const { client, root, self, store } = options
@@ -176,8 +173,7 @@ type Dependencies = {
  * Repository an installed package declares.
  *
  * `repository` is the field npm defines for this, and it resolves 98.5% of what is actually installed
- * here. `homepage` and `bugs` are tried after it for the handful that omit it, since a project that
- * points either at GitHub has named its repository just as clearly.
+ * here. `homepage` and `bugs` are tried after it for the handful that omit it.
  */
 async function repoOf(name: string, root: string): Promise<string | undefined> {
   const contents = await fs

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-/** Caching for network lookups, injected so the CLI and the App can keep it in different places. */
+/** Caching for network lookups, injected so the CLI and the App can store it differently. */
 export * as Cache from './Cache.js'
 
 /**
@@ -10,7 +10,7 @@ export * as Config from './Config.js'
 /** The entry format: frontmatter, body, ids, and title normalization. */
 export * as Entry from './Entry.js'
 
-/** A project's GitHub issue form: parsing it, and rendering the entry scaffold it implies. */
+/** Parses a project's GitHub issue form and renders the entry scaffold it implies. */
 export * as IssueForm from './IssueForm.js'
 
 /** Git queries and mutations the CLI needs. The App uses the GitHub API instead. */


### PR DESCRIPTION
Rewrites JSDoc, inline comments, `.describe()` strings, and CLI text to a single voice: lead with the verb, one idea per sentence, and cut rationale a reader could derive from the identifier. Net 90 lines removed.

Removes 39 `X is what Y` clefts and 8 contest metaphors (`wins`, `poisons`). Normalises all 11 error classes to "Thrown when…".

Also fixes three stale claims the pass surfaced: `Github.fromIssue` still documented severity as recovered by reversing `toLabels` rather than read from the marker, and two orphaned property docs survived the option they described.

No code, identifiers, or control flow changed.
