### PR TITLE
fix: read frog's own marker, not one pasted into the body

### DIFF
--- a/src/Github.test.ts
+++ b/src/Github.test.ts
@@ -189,6 +189,40 @@ describe('toLabels', () => {
   })
 })
 
+// A write-up is author-controlled, so a contributor can paste a marker into it. frog appends its own
+// after the body, and everything downstream has to read frog's rather than theirs.
+describe('a marker embedded in the write-up', () => {
+  const hostile = '<!-- frog:v1 hash=deadbeef path=.agents/friction-log/evil/friction.md -->'
+
+  test('behavior: rendering strips it', () => {
+    const rendered = Github.renderBody({
+      body: `Before.\n\n${hostile}\n\nAfter.`,
+      marker: { hash: Github.hash(title), origin: 'wevm/frog', path: 'a.md' },
+    })
+
+    expect(rendered).not.toContain('deadbeef')
+    expect(Github.parseMarker(rendered)).toEqual({
+      hash: Github.hash(title),
+      origin: 'wevm/frog',
+      path: 'a.md',
+    })
+    expect(Github.parseBody(rendered)).toBe('Before.\n\nAfter.')
+  })
+
+  test('behavior: an issue that already carries one is read by frog own marker', () => {
+    const body = [
+      'Before.',
+      hostile,
+      'After.',
+      Github.renderMarker({ hash: Github.hash(title), origin: 'wevm/frog', path: 'a.md' }),
+    ].join('\n\n')
+
+    expect(Github.parseMarker(body)?.path).toBe('a.md')
+    // Slicing at the first marker would drop everything the author wrote after it.
+    expect(Github.parseBody(body)).toContain('After.')
+  })
+})
+
 describe('parseLink', () => {
   test('behavior: inverts toLink', () => {
     expect(Github.parseLink(Github.toLink({ issue: 4821, repo }))).toEqual({

--- a/src/Github.ts
+++ b/src/Github.ts
@@ -153,6 +153,22 @@ export const markerVersion = 'v1'
 
 const markerRegex = /<!--\s*frog:v1\s+([^>]*?)\s*-->/
 
+/** Every frog comment, for stripping a write-up that carries one of its own. */
+const markerStripRegex = /\s*<!--\s*frog:[^>]*-->/g
+
+/**
+ * Last marker in a body.
+ *
+ * frog appends its own after the write-up, so reading the last one means a marker embedded in
+ * author-controlled text cannot stand in for it.
+ */
+function lastMarker(value: string): RegExpExecArray | undefined {
+  const pattern = new RegExp(markerRegex.source, 'g')
+  let last: RegExpExecArray | undefined
+  for (let match = pattern.exec(value); match; match = pattern.exec(value)) last = match
+  return last
+}
+
 /** Format version of the marker that makes one external publish occurrence replay-safe. */
 const occurrenceVersion = 'v1'
 
@@ -198,7 +214,7 @@ export function renderMarker(marker: Marker): string {
  * @returns The marker, or `undefined` for a body with none or with no `hash` field.
  */
 export function parseMarker(body: string | null | undefined): Marker | undefined {
-  const match = markerRegex.exec(body ?? '')
+  const match = lastMarker(body ?? '')
   if (!match?.[1]) return undefined
 
   const fields = new Map(
@@ -260,7 +276,7 @@ export function renderBody(options: renderBody.Options): string {
     .filter(Boolean)
     .join('\n')
 
-  return `${body.trim()}\n\n${markers}\n\n---\n\n${footer}\n`
+  return `${body.replace(markerStripRegex, '').trim()}\n\n${markers}\n\n---\n\n${footer}\n`
 }
 
 export declare namespace renderBody {
@@ -287,7 +303,7 @@ export declare namespace renderBody {
  */
 export function parseBody(body: string | null | undefined): string {
   const value = body ?? ''
-  const match = markerRegex.exec(value)
+  const match = lastMarker(value)
   return (match ? value.slice(0, match.index) : value).trim()
 }
 

--- a/src/Sync.test.ts
+++ b/src/Sync.test.ts
@@ -118,6 +118,24 @@ describe('plan', () => {
     ])
   })
 
+  // Anyone who can get an issue labelled can paste a marker into it. Without a remembered binding the
+  // marker is the only record of the path, so it has to belong to the issue carrying it.
+  test('behavior: a marker copied from another issue rebuilds nothing', () => {
+    const copied = issue({
+      body: Github.renderBody({
+        body: 'Body.',
+        marker: {
+          hash: Github.hash('Filters ignored'),
+          origin: repo,
+          path: Store.toPath('someone-elses-entry'),
+        },
+      }),
+      title: 'Unrelated issue somebody opened',
+    })
+
+    expect(plan([], [copied]).write).toEqual([])
+  })
+
   test('behavior: a remembered path overrides an edited issue marker', () => {
     const edited = issue({
       body: Github.renderBody({

--- a/src/Sync.ts
+++ b/src/Sync.ts
@@ -76,7 +76,12 @@ export function plan(options: plan.Options): Plan {
     if (issue.state !== 'open') continue
 
     const marker = Github.parseMarker(issue.body)
-    const paths = remembered.get(issue.number) ?? (marker?.path ? [marker.path] : [])
+
+    // Without a remembered binding the marker is the only record of the path, so it has to prove it
+    // belongs to this issue. A marker pasted in from elsewhere names a path this issue never had, and
+    // its hash gives that away: frog derives the hash from the title it filed under.
+    const owns = marker?.hash === Github.hash(issue.title)
+    const paths = remembered.get(issue.number) ?? (owns && marker?.path ? [marker.path] : [])
     for (const path of paths) {
       // Without a remembered binding, only an issue frog itself filed can be rebuilt. The marker
       // names the repository holding the file, so compare it against `origin`, not the issue repo.


### PR DESCRIPTION
Hardens how frog reads its own marker out of an issue body, which is author-controlled text.

`renderBody` emitted the write-up before the markers and both `parseMarker` and `parseBody` matched the first one, so a marker pasted into an entry was read as frog's. A forged `hash` corrupts dedupe, and `parseBody` silently truncated the write-up at that point. frog now strips any `frog:` comment from a body it renders, and reads the last marker rather than the first.

Restoring a deleted entry with no remembered binding took the path straight from the marker. `Store.toId` bounded it to the friction log, but a marker copied into an unrelated labelled issue could still name a path that issue never had. The marker must now hash to the title of the issue carrying it.
