### PR TITLE
docs: add a worked example of the workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 </p>
 
 <p align="center">
-  <a href="#problem">Problem</a> · <a href="#solution">Solution</a> · <a href="#quick-prompt">Quick Prompt</a> · <a href="#install">Install</a> · <a href="#usage">Usage</a> · <a href="#license">License</a>
+  <a href="#problem">Problem</a> · <a href="#solution">Solution</a> · <a href="#workflow">Workflow</a> · <a href="#quick-prompt">Quick Prompt</a> · <a href="#install">Install</a> · <a href="#usage">Usage</a> · <a href="#license">License</a>
 </p>
 
 ## Problem
@@ -47,6 +47,46 @@ agent reads them before it starts guessing.
 Each entry is then filed as an issue, so somebody owns it, and deleted once that issue closes, so the log
 only ever holds what is still unresolved. Friction in a dependency can be reported to that project instead,
 if it has opted in.
+
+## Workflow
+
+```mermaid
+flowchart LR
+    subgraph Author
+        A[Hit friction] --> B[frog log]
+        B --> C[Commit with the work]
+        C --> D[Open PR]
+    end
+    subgraph frog
+        D --> E{{Comment on the PR}}
+        E --> F[/File the issue/]
+        F --> G[Link it on your branch]
+    end
+    subgraph Resolve
+        G --> H[Merge]
+        H --> I[Fix it]
+        I --> J[Close the issue]
+        J --> K[/Open a sync PR/]
+        K --> L[Merge, log is clean]
+    end
+```
+
+Every step below happened in [wevm/frog-demo](https://github.com/wevm/frog-demo), a hello-world server
+whose config loader turned a missing environment variable into the string `"undefined"`. Only the three
+merges were human.
+
+| Step | What happens | Example |
+| --- | --- | --- |
+| 1 | You hit friction while working and run `frog log` | — |
+| 2 | The entry commits alongside the change that provoked it | [`0de4ab6`](https://github.com/wevm/frog-demo/commit/0de4ab6) |
+| 3 | frog comments on the pull request, naming what it found | [#1](https://github.com/wevm/frog-demo/pull/1) |
+| 4 | frog files the issue and writes the `issue:` link onto your branch | [#2](https://github.com/wevm/frog-demo/issues/2) |
+| 5 | You fix the friction and close the issue | [#3](https://github.com/wevm/frog-demo/pull/3) |
+| 6 | frog opens a pull request deleting the resolved entry | [#4](https://github.com/wevm/frog-demo/pull/4) |
+| 7 | Merging leaves the log holding only what is still unresolved | [`e4ac13d`](https://github.com/wevm/frog-demo/commit/e4ac13d) |
+
+The pull request at step 3 was about the feature, not the friction. The entry travelled with it because
+that is when the friction was hit.
 
 ## Quick Prompt
 

--- a/README.md
+++ b/README.md
@@ -52,22 +52,14 @@ if it has opted in.
 
 ```mermaid
 flowchart LR
-    subgraph Author
-        A[Hit friction] --> B[frog log]
-        B --> C[Commit with the work]
-        C --> D[Open PR]
+    subgraph Agent
+        A[Hit friction] --> B[frog log] --> C[Commit and open PR]
     end
     subgraph frog
-        D --> E{{Comment on the PR}}
-        E --> F[/File the issue/]
-        F --> G[Link it on your branch]
+        C --> D[/Comment and file the issue/] --> E[/Link it on the branch/]
     end
     subgraph Resolve
-        G --> H[Merge]
-        H --> I[Fix it]
-        I --> J[Close the issue]
-        J --> K[/Open a sync PR/]
-        K --> L[Merge, log is clean]
+        E --> F[Fix and close] --> G[/Open a sync PR/] --> H[Merge, entry gone]
     end
 ```
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ if it has opted in.
 
 See a demonstration in [wevm/frog-demo](https://github.com/wevm/frog-demo), where an agent adding a
 health endpoint hit a config loader that turns a missing environment variable into the string
-`"undefined"`, and logged it on the way past. Only the three merges were human.
+`"undefined"`, and logged it on the way past.
 
 | Step | What happens | Example |
 | --- | --- | --- |
@@ -63,9 +63,6 @@ health endpoint hit a config loader that turns a missing environment variable in
 | 5 | You fix the friction and close the issue | [#3](https://github.com/wevm/frog-demo/pull/3) |
 | 6 | frog opens a pull request deleting the resolved entry | [#4](https://github.com/wevm/frog-demo/pull/4) |
 | 7 | Merging leaves the log holding only what is still unresolved | [`e4ac13d`](https://github.com/wevm/frog-demo/commit/e4ac13d) |
-
-The pull request at step 3 was about the feature, not the friction. The entry travelled with it because
-that is when the friction was hit.
 
 ## Quick Prompt
 

--- a/README.md
+++ b/README.md
@@ -50,16 +50,16 @@ if it has opted in.
 
 ## Workflow
 
-See a demonstration in [wevm/frog-demo](https://github.com/wevm/frog-demo), a hello-world server whose
-config loader turned a missing environment variable into the string `"undefined"`. Only the three merges
-were human.
+See a demonstration in [wevm/frog-demo](https://github.com/wevm/frog-demo), where an agent adding a
+health endpoint hit a config loader that turns a missing environment variable into the string
+`"undefined"`, and logged it on the way past. Only the three merges were human.
 
 | Step | What happens | Example |
 | --- | --- | --- |
-| 1 | You hit friction while working and run `frog log` | — |
+| 1 | Agent hits friction while working and runs `frog log` | — |
 | 2 | The entry commits alongside the change that provoked it | [`0de4ab6`](https://github.com/wevm/frog-demo/commit/0de4ab6) |
 | 3 | frog comments on the pull request, naming what it found | [#1](https://github.com/wevm/frog-demo/pull/1) |
-| 4 | frog files the issue and writes the `issue:` link onto your branch | [#2](https://github.com/wevm/frog-demo/issues/2) |
+| 4 | frog files the issue and writes the `issue:` link onto the branch | [#2](https://github.com/wevm/frog-demo/issues/2) |
 | 5 | You fix the friction and close the issue | [#3](https://github.com/wevm/frog-demo/pull/3) |
 | 6 | frog opens a pull request deleting the resolved entry | [#4](https://github.com/wevm/frog-demo/pull/4) |
 | 7 | Merging leaves the log holding only what is still unresolved | [`e4ac13d`](https://github.com/wevm/frog-demo/commit/e4ac13d) |

--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ if it has opted in.
 
 ## Workflow
 
-Every step below happened in [wevm/frog-demo](https://github.com/wevm/frog-demo), a hello-world server
-whose config loader turned a missing environment variable into the string `"undefined"`. Only the three
-merges were human.
+See a demonstration in [wevm/frog-demo](https://github.com/wevm/frog-demo), a hello-world server whose
+config loader turned a missing environment variable into the string `"undefined"`. Only the three merges
+were human.
 
 | Step | What happens | Example |
 | --- | --- | --- |

--- a/README.md
+++ b/README.md
@@ -50,19 +50,6 @@ if it has opted in.
 
 ## Workflow
 
-```mermaid
-flowchart LR
-    subgraph Agent
-        A[Hit friction] --> B[frog log] --> C[Commit and open PR]
-    end
-    subgraph frog
-        C --> D[/Comment and file the issue/] --> E[/Link it on the branch/]
-    end
-    subgraph Resolve
-        E --> F[Fix and close] --> G[/Open a sync PR/] --> H[Merge, entry gone]
-    end
-```
-
 Every step below happened in [wevm/frog-demo](https://github.com/wevm/frog-demo), a hello-world server
 whose config loader turned a missing environment variable into the string `"undefined"`. Only the three
 merges were human.


### PR DESCRIPTION
Adds a `Workflow` section: a table walking the loop through a real run in `wevm/frog-demo`, linking each commit, pull request, and issue it produced.