### PR TITLE
feat(init): point at the GitHub App installation

### DIFF
--- a/.changeset/init-app-link.md
+++ b/.changeset/init-app-link.md
@@ -2,4 +2,4 @@
 'frog': minor
 ---
 
-`init` now points at the GitHub App installation, in its call to action and in the friction log it scaffolds.
+Pointed `init` at the GitHub App installation, in its call to action and in the friction log it scaffolds.

--- a/.changeset/init-app-link.md
+++ b/.changeset/init-app-link.md
@@ -1,0 +1,5 @@
+---
+'frog': minor
+---
+
+`init` now points at the GitHub App installation, in its call to action and in the friction log it scaffolds.

--- a/src/cli/commands/init.test.ts
+++ b/src/cli/commands/init.test.ts
@@ -16,9 +16,14 @@ test('behavior: scaffolds the directory', async () => {
         ".agents/friction-log/config.json",
       ],
       "existing": [],
-      "install": "https://github.com/apps/frog-fm/installations/new",
     }
   `)
+
+  // Nothing is filed until the App is installed, and the failure is silent, so the one place a user
+  // is certain to look has to say so.
+  const { envelope } = await cli.run(['init', '--cwd', await helpers.repo()])
+  const cta = envelope.meta?.['cta'] as { description?: string } | undefined
+  expect(cta?.description).toContain('https://github.com/apps/frog-fm/installations/new')
 
   // The scaffolded config must validate against the schema it advertises.
   expect(await Config.resolve({ root: cwd })).toEqual(Config.from({}))

--- a/src/cli/commands/init.test.ts
+++ b/src/cli/commands/init.test.ts
@@ -16,6 +16,7 @@ test('behavior: scaffolds the directory', async () => {
         ".agents/friction-log/config.json",
       ],
       "existing": [],
+      "install": "https://github.com/apps/frog-fm/installations/new",
     }
   `)
 

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -12,7 +12,7 @@ export const rule =
   'Log papercuts and friction (tooling, docs, APIs, tests, conventions) as you hit them with ' +
   '`frog log`. Run `frog list` first to see what is already known.'
 
-/** Where to install the GitHub App. Nothing is filed or reconciled until it is installed. */
+/** Where to install the GitHub App, which is what makes filing and reconciling automatic. */
 const install = 'https://github.com/apps/frog-fm/installations/new'
 
 const readme = `# Friction log
@@ -31,8 +31,9 @@ outstanding, including friction in dependencies.
 
 Do not maintain an index here. This directory is the index.
 
-Filing needs the [frog GitHub App](${install}) installed on this repository. Until it is, entries are
-written and committed as normal but nothing is filed or reconciled.
+Install the [frog GitHub App](${install}) and entries are filed, linked, and removed as their issues
+close, without anyone running anything. Without it, run \`frog publish\` and \`frog sync\` yourself with a
+GitHub token.
 
 ## Logging Friction
 
@@ -148,7 +149,7 @@ export const init = Cli.create('init', {
             { command: 'log', description: 'Write the first entry' },
             { command: 'skills add', description: 'Install the skill that says when to log' },
           ],
-          description: `Install the GitHub App at ${install} so entries are filed, then:`,
+          description: `Install the GitHub App at ${install} to file and reconcile automatically, then:`,
         },
       },
     )

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -12,6 +12,9 @@ export const rule =
   'Log papercuts and friction (tooling, docs, APIs, tests, conventions) as you hit them with ' +
   '`frog log`. Run `frog list` first to see what is already known.'
 
+/** Where to install the GitHub App. Nothing is filed or reconciled until it is installed. */
+const install = 'https://github.com/apps/frog-fm/installations/new'
+
 const readme = `# Friction log
 
 Friction hit while working in this repository, one directory per item:
@@ -27,6 +30,9 @@ to it. The whole directory is deleted once the friction is resolved. Every entry
 outstanding, including friction in dependencies.
 
 Do not maintain an index here. This directory is the index.
+
+Filing needs the [frog GitHub App](${install}) installed on this repository. Until it is, entries are
+written and committed as normal but nothing is filed or reconciled.
 
 ## Logging Friction
 
@@ -107,6 +113,11 @@ export const init = Cli.create('init', {
   output: z.object({
     created: z.array(z.string()).describe('Files written.'),
     existing: z.array(z.string()).describe('Files left alone.'),
+    install: z
+      .string()
+      .describe(
+        'Install the GitHub App here. Entries stay local until it is installed on this repository.',
+      ),
   }),
   async run(c) {
     const { root } = await context.resolve({ cwd: c.options.cwd })
@@ -135,7 +146,7 @@ export const init = Cli.create('init', {
     }
 
     return c.ok(
-      { created, existing },
+      { created, existing, install },
       {
         cta: {
           commands: [

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -113,11 +113,6 @@ export const init = Cli.create('init', {
   output: z.object({
     created: z.array(z.string()).describe('Files written.'),
     existing: z.array(z.string()).describe('Files left alone.'),
-    install: z
-      .string()
-      .describe(
-        'Install the GitHub App here. Entries stay local until it is installed on this repository.',
-      ),
   }),
   async run(c) {
     const { root } = await context.resolve({ cwd: c.options.cwd })
@@ -146,14 +141,14 @@ export const init = Cli.create('init', {
     }
 
     return c.ok(
-      { created, existing, install },
+      { created, existing },
       {
         cta: {
           commands: [
             { command: 'log', description: 'Write the first entry' },
             { command: 'skills add', description: 'Install the skill that says when to log' },
           ],
-          description: 'Next:',
+          description: `Install the GitHub App at ${install} so entries are filed, then:`,
         },
       },
     )


### PR DESCRIPTION
`init` now returns the App installation URL and names it in the generated friction log README. Nothing is filed or reconciled until the App is installed, and previously nothing said so.