### PR TITLE
docs: capitalize Frog in prose

### DIFF
--- a/.agents/friction-log/README.md
+++ b/.agents/friction-log/README.md
@@ -34,4 +34,4 @@ Add this to `AGENTS.md`:
 
 > Log papercuts and friction (tooling, docs, APIs, tests, conventions) as you hit them with `frog log`. Run `frog list` first to see what is already known.
 
-Managed by [frog](https://github.com/wevm/frog).
+Managed by [Frog](https://github.com/wevm/frog).

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset=".github/logo-dark.svg">
   <source media="(prefers-color-scheme: light)" srcset=".github/logo-light.svg">
-  <img alt="frog" src=".github/logo-light.svg" width="100%" height="140px">
+  <img alt="Frog" src=".github/logo-light.svg" width="100%" height="140px">
 </picture>
 
 <p align="center">
@@ -54,15 +54,15 @@ See a demonstration in [wevm/frog-demo](https://github.com/wevm/frog-demo), wher
 health endpoint hit a config loader that turns a missing environment variable into the string
 `"undefined"`, and logged it on the way past.
 
-| Step | What happens | Example |
-| --- | --- | --- |
-| 1 | Agent hits friction while working and runs `frog log` | — |
-| 2 | The entry commits alongside the change that provoked it | [`0de4ab6`](https://github.com/wevm/frog-demo/commit/0de4ab6) |
-| 3 | frog comments on the pull request, naming what it found | [#1](https://github.com/wevm/frog-demo/pull/1) |
-| 4 | frog files the issue and writes the `issue:` link onto the branch | [#2](https://github.com/wevm/frog-demo/issues/2) |
-| 5 | You fix the friction and close the issue | [#3](https://github.com/wevm/frog-demo/pull/3) |
-| 6 | frog opens a pull request deleting the resolved entry | [#4](https://github.com/wevm/frog-demo/pull/4) |
-| 7 | Merging leaves the log holding only what is still unresolved | [`e4ac13d`](https://github.com/wevm/frog-demo/commit/e4ac13d) |
+| Step | What happens                                                      | Example                                                       |
+| ---- | ----------------------------------------------------------------- | ------------------------------------------------------------- |
+| 1    | Agent hits friction while working and runs `frog log`             | —                                                             |
+| 2    | The entry commits alongside the change that provoked it           | [`0de4ab6`](https://github.com/wevm/frog-demo/commit/0de4ab6) |
+| 3    | Frog comments on the pull request, naming what it found           | [#1](https://github.com/wevm/frog-demo/pull/1)                |
+| 4    | Frog files the issue and writes the `issue:` link onto the branch | [#2](https://github.com/wevm/frog-demo/issues/2)              |
+| 5    | You fix the friction and close the issue                          | [#3](https://github.com/wevm/frog-demo/pull/3)                |
+| 6    | Frog opens a pull request deleting the resolved entry             | [#4](https://github.com/wevm/frog-demo/pull/4)                |
+| 7    | Merging leaves the log holding only what is still unresolved      | [`e4ac13d`](https://github.com/wevm/frog-demo/commit/e4ac13d) |
 
 ## Quick Prompt
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ frog list
 Teaches agents **when** to log, which is the part they cannot infer. The rule is _log when you worked around
 something_; see [`SKILL.md`](./SKILL.md) for the full trigger.
 
-`mcp add` exposes each command as a typed tool, so agents call frog directly rather than composing shell.
+`mcp add` exposes each command as a typed tool, so agents call Frog directly rather than composing shell.
 
 ```sh
 frog skills add
@@ -126,7 +126,7 @@ repository's own default branch. So nothing a package says can send a report som
 agreed to receive one.
 
 Naming a target also scaffolds the entry from that project's GitHub issue form, so the report answers the
-questions it actually asks rather than frog's own. A project that names no form keeps frog's sections.
+questions it actually asks rather than Frog's own. A project that names no form keeps Frog's sections.
 
 ```sh
 frog targets

--- a/SKILL.md
+++ b/SKILL.md
@@ -4,7 +4,7 @@ description: Records friction the moment it is hit, and reports it where it can 
 command: frog
 ---
 
-# frog
+# Frog
 
 Log friction the moment you hit it. Each entry is a directory in `.agents/friction-log/`, filed where it
 can be acted on and deleted once the friction is resolved. So the directory is a live list of what is

--- a/app/package.json
+++ b/app/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "version": "0.0.0",
-  "description": "GitHub App that files frog as issues and keeps the two in sync.",
+  "description": "GitHub App that files friction as issues and keeps the two in sync.",
   "scripts": {
     "check:types": "tsc",
     "deploy": "wrangler deploy",

--- a/app/src/Delivery.ts
+++ b/app/src/Delivery.ts
@@ -143,7 +143,7 @@ function action<Action extends string>(
   return allowed.find((candidate) => candidate === name)
 }
 
-/** Whether an event header names a webhook frog handles. */
+/** Whether an event header names a webhook Frog handles. */
 export function supports(name: string): name is Delivery['name'] {
   return name === 'issues' || name === 'pull_request' || name === 'push'
 }
@@ -296,7 +296,7 @@ export async function toEvent(
   }
 }
 
-/** Thrown when a signed or queued delivery does not match frog's supported projection. */
+/** Thrown when a signed or queued delivery does not match Frog's supported projection. */
 export class InvalidError extends Error {
   override readonly name = 'Delivery.InvalidError'
 

--- a/app/src/handlers/issues.test.ts
+++ b/app/src/handlers/issues.test.ts
@@ -233,7 +233,7 @@ describe('cross-repo', () => {
       repo: upstream,
     })
 
-    expect(outcome.ignored).toBe('frog is not installed on `acme/app`')
+    expect(outcome.ignored).toBe('Frog is not installed on `acme/app`')
     expect(instance.files(consumer)[`${dir}/a/friction.md`]).toBeTruthy()
   })
 })
@@ -252,7 +252,7 @@ test('security: an unrecorded marker cannot authorize repository writes', async 
     repo: upstream,
   })
 
-  expect(outcome.ignored).toBe('untrusted frog marker')
+  expect(outcome.ignored).toBe('untrusted Frog marker')
   expect(instance.files(consumer)).toEqual({ 'README.md': '# app' })
   expect(instance.messages(consumer)).toEqual(['initial'])
 })
@@ -300,7 +300,7 @@ test('behavior: an issue with no marker is ignored', async () => {
     repo: consumer,
   })
 
-  expect(outcome.ignored).toBe('no frog marker')
+  expect(outcome.ignored).toBe('no Frog marker')
   expect(instance.messages(consumer)).toEqual(['initial'])
 })
 
@@ -319,7 +319,7 @@ test('behavior: an issue whose marker has no path is ignored', async () => {
     repo: consumer,
   })
 
-  expect(outcome.ignored).toBe('no frog marker')
+  expect(outcome.ignored).toBe('no Frog marker')
 })
 
 describe('pullRequest', () => {
@@ -362,7 +362,7 @@ describe('pullRequest', () => {
       title: 'chore: sync friction log',
     })
     expect(description).toMatchInlineSnapshot(`
-      "Opened by the [frog](https://github.com/wevm/frog) GitHub App.
+      "Opened by the [Frog](https://github.com/wevm/frog) GitHub App.
 
       ## Resolved
 

--- a/app/src/handlers/issues.ts
+++ b/app/src/handlers/issues.ts
@@ -37,11 +37,11 @@ export async function issues(options: issues.Options): Promise<Outcome> {
 
   // A marker is only a routing hint. Committed state below decides whether the issue is ours to act on.
   const marker = Github.parseMarker(issue.body)
-  if (!marker?.path) return { ignored: 'no frog marker' }
+  if (!marker?.path) return { ignored: 'no Frog marker' }
 
   const origin = marker.origin ?? repo
   const source = origin === repo ? client : await installation(origin)
-  if (!source) return { ignored: `frog is not installed on \`${origin}\``, origin }
+  if (!source) return { ignored: `Frog is not installed on \`${origin}\``, origin }
 
   return serialize(origin, async () => {
     const branch = await Github.defaultBranch(source.rest, { repo: origin })
@@ -84,7 +84,7 @@ export async function issues(options: issues.Options): Promise<Outcome> {
 
     const current = Github.toLink({ issue: issue.number, repo })
     if (!bindings.some((binding) => binding.issue === current))
-      return { ignored: 'untrusted frog marker', origin }
+      return { ignored: 'untrusted Frog marker', origin }
 
     // Runs inside the origin lease and refetches current issue state. The delivered snapshot only
     // routes us here, so an older close cannot overwrite a newer reopen.

--- a/app/src/handlers/pullRequest.test.ts
+++ b/app/src/handlers/pullRequest.test.ts
@@ -408,7 +408,7 @@ describe('cross-repo', () => {
 
     const report = await run(instance.url)
 
-    expect(report.deferred[0]?.reason).toBe('frog is not installed on `wevm/viem`.')
+    expect(report.deferred[0]?.reason).toBe('Frog is not installed on `wevm/viem`.')
     expect(instance.issues.get(upstream)).toBeUndefined()
   })
 

--- a/app/src/handlers/pullRequest.ts
+++ b/app/src/handlers/pullRequest.ts
@@ -135,7 +135,7 @@ export declare namespace pullRequest {
     /**
      * Resolves an installation client for another repository.
      *
-     * Returns `undefined` when frog is not installed there, gating cross-repo filing on the receiver's
+     * Returns `undefined` when Frog is not installed there, gating cross-repo filing on the receiver's
      * installation.
      */
     installation: (repo: string) => Promise<Octokit | undefined>

--- a/app/src/internal/comment.ts
+++ b/app/src/internal/comment.ts
@@ -2,7 +2,7 @@ import { Github, Store } from 'frog'
 import type { Octokit } from 'octokit'
 
 /**
- * Marks the one comment frog keeps on a pull request.
+ * Marks the one comment Frog keeps on a pull request.
  *
  * An explicit marker rather than a match on the bot's login, which can be renamed. It also leaves room
  * for a second kind of comment without confusing the two.

--- a/app/src/internal/file.ts
+++ b/app/src/internal/file.ts
@@ -88,7 +88,7 @@ export async function file(options: file.Options): Promise<Filing> {
     for (const candidate of candidates.filter((entry) => entry.destination === destination))
       deferred.push({
         id: candidate.entry.id,
-        reason: `frog is not installed on \`${destination}\`.`,
+        reason: `Frog is not installed on \`${destination}\`.`,
       })
   }
 

--- a/app/src/internal/resolvers.test.ts
+++ b/app/src/internal/resolvers.test.ts
@@ -73,7 +73,7 @@ describe('resolvers', () => {
     })
 
     await expect(stack.readConfig(upstream)).rejects.toMatchObject({
-      message: 'frog is not installed on `wevm/viem`.',
+      message: 'Frog is not installed on `wevm/viem`.',
       repo: upstream,
     })
   })

--- a/app/src/internal/resolvers.ts
+++ b/app/src/internal/resolvers.ts
@@ -97,7 +97,7 @@ export class InstallationMissingError extends Error {
   repo: string
 
   constructor(repo: string) {
-    super(`frog is not installed on \`${repo}\`.`)
+    super(`Frog is not installed on \`${repo}\`.`)
     this.name = 'InstallationMissingError'
     this.repo = repo
   }

--- a/app/src/internal/summary.test.ts
+++ b/app/src/internal/summary.test.ts
@@ -65,5 +65,5 @@ test('behavior: no differences leaves the explanation alone', () => {
   const body = summary.render({ base: [entry('a')], branch: [entry('a')] })
 
   expect(body).not.toContain('## Resolved')
-  expect(body).toContain('Opened by the [frog](https://github.com/wevm/frog) GitHub App')
+  expect(body).toContain('Opened by the [Frog](https://github.com/wevm/frog) GitHub App')
 })

--- a/app/src/internal/summary.ts
+++ b/app/src/internal/summary.ts
@@ -2,7 +2,7 @@ import { type Entry, Github } from 'frog'
 import type { Octokit } from 'octokit'
 import * as Repository from '../Repository.js'
 
-const intro = 'Opened by the [frog](https://github.com/wevm/frog) GitHub App.'
+const intro = 'Opened by the [Frog](https://github.com/wevm/frog) GitHub App.'
 
 function link(entry: Entry.Entry): string {
   const parsed = entry.issue ? Github.parseLink(entry.issue) : undefined

--- a/schema.json
+++ b/schema.json
@@ -1,10 +1,10 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "frog config",
+  "title": "Frog config",
   "type": "object",
   "properties": {
     "commit": {
-      "description": "Messages for the commits frog makes on your behalf.",
+      "description": "Messages for the commits Frog makes on your behalf.",
       "default": {},
       "type": "object",
       "properties": {

--- a/scripts/schema.ts
+++ b/scripts/schema.ts
@@ -7,7 +7,7 @@ const root = path.join(import.meta.dirname, '..')
 
 // `io: 'input'` emits the written shape, where every field is optional. That is what a document on
 // disk is validated against, and what makes `$schema` useful in an editor.
-const schemas = [{ file: 'schema.json', schema: Config.Schema, title: 'frog config' }] as const
+const schemas = [{ file: 'schema.json', schema: Config.Schema, title: 'Frog config' }] as const
 
 for (const { file, schema, title } of schemas) {
   const json = {

--- a/src/Config.test.ts
+++ b/src/Config.test.ts
@@ -111,7 +111,7 @@ test('schema.json matches the written config schema', async () => {
   ) as unknown
   const generated = {
     $schema: 'http://json-schema.org/draft-07/schema#',
-    title: 'frog config',
+    title: 'Frog config',
     ...z.toJSONSchema(Config.Schema, { io: 'input', target: 'draft-7' }),
   }
 

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -31,7 +31,7 @@ export const Schema = z.object({
         .describe('Message for the commit reconciling the log against issue state.'),
     })
     .prefault({})
-    .describe('Messages for the commits frog makes on your behalf.'),
+    .describe('Messages for the commits Frog makes on your behalf.'),
   inbound: z
     .object({
       allowFrom: z

--- a/src/Github.test.ts
+++ b/src/Github.test.ts
@@ -115,7 +115,7 @@ describe('renderBody and parseBody', () => {
 
       ---
 
-      <sub>Logged by Test User in \`acme/app\` at \`0123456\` via acme/app#42. Filed by [frog](https://github.com/wevm/frog).</sub>
+      <sub>Logged by Test User in \`acme/app\` at \`0123456\` via acme/app#42. Filed by [Frog](https://github.com/wevm/frog).</sub>
       "
     `)
   })
@@ -128,7 +128,7 @@ describe('renderBody and parseBody', () => {
 
       ---
 
-      <sub>Logged. Filed by [frog](https://github.com/wevm/frog).</sub>
+      <sub>Logged. Filed by [Frog](https://github.com/wevm/frog).</sub>
       "
     `)
   })
@@ -189,8 +189,8 @@ describe('toLabels', () => {
   })
 })
 
-// A write-up is author-controlled, so a contributor can paste a marker into it. frog appends its own
-// after the body, and everything downstream has to read frog's rather than theirs.
+// A write-up is author-controlled, so a contributor can paste a marker into it. Frog appends its own
+// after the body, and everything downstream has to read Frog's rather than theirs.
 describe('a marker embedded in the write-up', () => {
   const hostile = '<!-- frog:v1 hash=deadbeef path=.agents/friction-log/evil/friction.md -->'
 
@@ -209,7 +209,7 @@ describe('a marker embedded in the write-up', () => {
     expect(Github.parseBody(rendered)).toBe('Before.\n\nAfter.')
   })
 
-  test('behavior: an issue that already carries one is read by frog own marker', () => {
+  test('behavior: an issue that already carries one is read by the marker Frog appended', () => {
     const body = [
       'Before.',
       hostile,

--- a/src/Github.ts
+++ b/src/Github.ts
@@ -153,13 +153,13 @@ export const markerVersion = 'v1'
 
 const markerRegex = /<!--\s*frog:v1\s+([^>]*?)\s*-->/
 
-/** Every frog comment, for stripping a write-up that carries one of its own. */
+/** Every Frog comment, for stripping a write-up that carries one of its own. */
 const markerStripRegex = /\s*<!--\s*frog:[^>]*-->/g
 
 /**
  * Last marker in a body.
  *
- * frog appends its own after the write-up, so reading the last one means a marker embedded in
+ * Frog appends its own after the write-up, so reading the last one means a marker embedded in
  * author-controlled text cannot stand in for it.
  */
 function lastMarker(value: string): RegExpExecArray | undefined {
@@ -270,7 +270,7 @@ export function renderBody(options: renderBody.Options): string {
     .filter(Boolean)
     .join(' ')
 
-  const footer = `<sub>${credits}. Filed by [frog](https://github.com/wevm/frog).</sub>`
+  const footer = `<sub>${credits}. Filed by [Frog](https://github.com/wevm/frog).</sub>`
 
   const markers = [renderMarker(marker), occurrence ? renderOccurrence(occurrence) : undefined]
     .filter(Boolean)
@@ -600,7 +600,7 @@ export declare namespace find {
 }
 
 /**
- * Lists every issue frog manages in a repository.
+ * Lists every issue Frog manages in a repository.
  *
  * @param client - Authenticated client for the repository.
  * @returns Issues carrying the label, oldest first, with pull requests filtered out.
@@ -652,7 +652,7 @@ async function listAll(client: Client, options: { repo: string }): Promise<reado
 export declare namespace index {
   /** Options for {@link index}. */
   type Options = {
-    /** Label every frog issue in this repository carries. Dedupe keys off it. */
+    /** Label every Frog issue in this repository carries. Dedupe keys off it. */
     label: string
     /** Repository to index, as `owner/name`. */
     repo: string

--- a/src/IssueForm.test.ts
+++ b/src/IssueForm.test.ts
@@ -56,7 +56,7 @@ describe('parse', () => {
   })
 
   // The leading `markdown` block is the project's preamble to whoever fills the form in. Carrying it
-  // through would put viem's sponsor pitch into the issue body frog files.
+  // through would put viem's sponsor pitch into the issue body Frog files.
   test('behavior: drops instruction blocks', () => {
     const form = IssueForm.parse(viem)
     expect(form?.fields.some((field) => field.label.includes('Thanks for taking'))).toBe(false)

--- a/src/IssueForm.ts
+++ b/src/IssueForm.ts
@@ -114,9 +114,9 @@ function render(field: Field): string {
 /**
  * Picks the form to author against, from the files in a project's template directory.
  *
- * `friction.yml` takes precedence: a project that added one is speaking to frog directly. Failing
+ * `friction.yml` takes precedence: a project that added one is speaking to Frog directly. Failing
  * that, a lone form is used, and among several the one named for bugs. Anything less certain resolves
- * to nothing, leaving frog's own sections in place.
+ * to nothing, leaving Frog's own sections in place.
  *
  * @param paths - Repository-relative paths of everything in {@link dir}.
  * @returns The path to read, or `undefined` when no form is the obvious one.
@@ -142,8 +142,8 @@ export function choose(paths: readonly string[]): string | undefined {
  *
  * @param read - Reads a repository file, or `undefined` when it is not there.
  * @param list - Lists the files in a repository directory.
- * @returns The form, or `undefined` when the project has none frog can be sure of. Never throws: every
- * caller has frog's own sections to fall back on.
+ * @returns The form, or `undefined` when the project has none Frog can be sure of. Never throws: every
+ * caller has Frog's own sections to fall back on.
  */
 export async function find(options: find.Options): Promise<Form | undefined> {
   const { list, named, read } = options

--- a/src/Sync.ts
+++ b/src/Sync.ts
@@ -79,11 +79,11 @@ export function plan(options: plan.Options): Plan {
 
     // Without a remembered binding the marker is the only record of the path, so it has to prove it
     // belongs to this issue. A marker pasted in from elsewhere names a path this issue never had, and
-    // its hash gives that away: frog derives the hash from the title it filed under.
+    // its hash gives that away: Frog derives the hash from the title it filed under.
     const owns = marker?.hash === Github.hash(issue.title)
     const paths = remembered.get(issue.number) ?? (owns && marker?.path ? [marker.path] : [])
     for (const path of paths) {
-      // Without a remembered binding, only an issue frog itself filed can be rebuilt. The marker
+      // Without a remembered binding, only an issue Frog itself filed can be rebuilt. The marker
       // names the repository holding the file, so compare it against `origin`, not the issue repo.
       if (!remembered.has(issue.number) && marker?.origin && marker.origin !== origin) continue
       if (present.has(path)) continue
@@ -103,7 +103,7 @@ export declare namespace plan {
   type Options = {
     /** Every local entry, from `Store.read`. */
     entries: readonly Entry.Entry[]
-    /** Every issue frog manages in `repo`, from `Github.list`. */
+    /** Every issue Frog manages in `repo`, from `Github.list`. */
     issues: readonly Github.Issue[]
     /** Labels applied to every issue, from config. */
     labels: readonly string[]
@@ -166,7 +166,7 @@ export declare namespace state {
     entries: readonly Entry.Entry[]
     /** Fetches one issue by number, resolving to `undefined` when it does not exist. */
     get: (issue: number) => Promise<Github.Issue | undefined>
-    /** Lists the issues frog manages in `repo`. */
+    /** Lists the issues Frog manages in `repo`. */
     list: () => Promise<readonly Github.Issue[]>
     /** Issue numbers remembered after their final local mirrors were removed. */
     remembered?: readonly number[] | undefined

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -31,7 +31,7 @@ outstanding, including friction in dependencies.
 
 Do not maintain an index here. This directory is the index.
 
-Install the [frog GitHub App](${install}) and entries are filed, linked, and removed as their issues
+Install the [Frog GitHub App](${install}) and entries are filed, linked, and removed as their issues
 close, without anyone running anything. Without it, run \`frog publish\` and \`frog sync\` yourself with a
 GitHub token.
 

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -47,7 +47,7 @@ Add this to \`AGENTS.md\`:
 
 > ${rule}
 
-Managed by [frog](https://github.com/wevm/frog).
+Managed by [Frog](https://github.com/wevm/frog).
 `
 
 const schema = 'https://unpkg.com/frog/schema.json'
@@ -69,7 +69,7 @@ const libraryConfig = `{
 /**
  * The issue form a project serves so consumers report friction the way it wants.
  *
- * Rendered from the same sections as the entry scaffold, so the two cannot drift. A consumer's frog finds
+ * Rendered from the same sections as the entry scaffold, so the two cannot drift. A consumer's Frog finds
  * it by convention and writes its entry against it. A human filing through the issue page gets the same
  * questions.
  */
@@ -101,7 +101,7 @@ export const init = Cli.create('init', {
       .describe('Also accept friction reported by consumers of this project.'),
   }),
   examples: [
-    { description: 'Set up frog' },
+    { description: 'Set up Frog' },
     { description: 'Become a friction target', options: { library: true } },
   ],
   output: z.object({
@@ -114,7 +114,7 @@ export const init = Cli.create('init', {
     const files = [
       [`${Store.dir}/README.md`, readme],
       [Config.file, c.options.library ? libraryConfig : config],
-      // Only for a project accepting reports: a consumer's frog writes its entry against it.
+      // Only for a project accepting reports: a consumer's Frog writes its entry against it.
       ...(c.options.library ? ([[`${IssueForm.dir}/${IssueForm.filename}`, form]] as const) : []),
     ] as const
 

--- a/src/cli/commands/log.test.ts
+++ b/src/cli/commands/log.test.ts
@@ -167,7 +167,7 @@ describe('--target', () => {
       GITHUB_TOKEN: 'test-token',
     })
 
-    // The upstream's questions, not frog's sections.
+    // The upstream's questions, not Frog's sections.
     expect((await Store.get(id, { root: cwd })).body).toMatchInlineSnapshot(`
       "### Viem Version
 

--- a/src/cli/commands/log.ts
+++ b/src/cli/commands/log.ts
@@ -138,7 +138,7 @@ export const log = Cli.create('log', {
 
     const body = c.options.body ?? (input?.body || undefined)
 
-    // Scaffold from the target's own issue form rather than from frog's sections. An upstream project
+    // Scaffold from the target's own issue form rather than from Frog's sections. An upstream project
     // judges a report against its own form. Fetched only when the answers would be used. Never fatal:
     // an unreachable target costs the scaffold, not the entry.
     // With no target, use this repository's own form.

--- a/src/cli/internal/attempt.ts
+++ b/src/cli/internal/attempt.ts
@@ -10,7 +10,7 @@ export type Attempt<value> =
  * nested closure or a `.catch()` silently becomes ordinary data. Wrapping the fallible call keeps every
  * `c.error()` at the top level of `run`, where it works.
  *
- * Picks up the `code` on frog's own error classes, so a domain error keeps its machine-readable code
+ * Picks up the `code` on Frog's own error classes, so a domain error keeps its machine-readable code
  * without the core depending on incur.
  */
 export async function attempt<value>(promise: Promise<value>): Promise<Attempt<value>> {

--- a/src/cli/internal/form.ts
+++ b/src/cli/internal/form.ts
@@ -18,7 +18,7 @@ import * as target from './target.js'
  *
  * @param value - The `--target` as written.
  * @returns The scaffold, or `undefined` when the target resolves to nothing, refuses reports, or has no
- * form frog can be sure of. Every one of those leaves frog's own sections in place.
+ * form Frog can be sure of. Every one of those leaves Frog's own sections in place.
  */
 export async function scaffold(
   value: string,

--- a/src/cli/internal/publish.ts
+++ b/src/cli/internal/publish.ts
@@ -19,7 +19,7 @@ export type Outcome = {
 
 export type Ready = {
   client: Github.Client
-  /** Label used to find issues frog already filed. */
+  /** Label used to find issues Frog already filed. */
   label: string
   repo: string
 }
@@ -46,7 +46,7 @@ export async function prepare(options: prepare.Options): Promise<Blocked | Ready
   if (!label)
     return {
       code: 'NO_LABEL',
-      message: '`labels` must not be empty. frog finds already-filed issues by the first one.',
+      message: '`labels` must not be empty. Frog finds already-filed issues by the first one.',
     }
 
   const resolved = await octokit.token({ env, ...(token ? { token } : {}) })

--- a/test/github.ts
+++ b/test/github.ts
@@ -2,7 +2,7 @@ import { createHash } from 'node:crypto'
 import http from 'node:http'
 
 /**
- * A real HTTP server implementing the GitHub REST endpoints frog uses.
+ * A real HTTP server implementing the GitHub REST endpoints Frog uses.
  *
  * Not a mock: Octokit's `baseUrl` points here and makes genuine requests, so serialization,
  * pagination, and status codes are all exercised. `node:http` rather than a framework keeps this


### PR DESCRIPTION
Capitalizes `Frog` when the prose means the product. The package name, CLI command, marker prefix, URLs, and identifiers stay lowercase.