### PR TITLE
chore: add the changeset for incur 0.4.20

### DIFF
--- a/.changeset/incur-0-4-20.md
+++ b/.changeset/incur-0-4-20.md
@@ -2,4 +2,4 @@
 'frog': patch
 ---
 
-Updated `incur` to 0.4.20, which stopped `skills add` deleting a skill it had just installed when an agent's skills directory is a symlink to the canonical one.
+Updated `incur` to 0.4.20.

--- a/.changeset/incur-0-4-20.md
+++ b/.changeset/incur-0-4-20.md
@@ -1,0 +1,5 @@
+---
+'frog': patch
+---
+
+Updated `incur` to 0.4.20, which stopped `skills add` deleting a skill it had just installed when an agent's skills directory is a symlink to the canonical one.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,8 +25,8 @@ catalogs:
       specifier: latest
       version: 4.1.10
     incur:
-      specifier: 0.4.19
-      version: 0.4.19
+      specifier: 0.4.20
+      version: 0.4.20
     octokit:
       specifier: ^5.0.5
       version: 5.0.5
@@ -61,7 +61,7 @@ importers:
         version: 22.0.1
       incur:
         specifier: 'catalog:'
-        version: 0.4.19
+        version: 0.4.20
       yaml:
         specifier: 'catalog:'
         version: 2.9.0
@@ -1930,8 +1930,8 @@ packages:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
 
-  incur@0.4.19:
-    resolution: {integrity: sha512-xSH6Y79oIeLwwiOp51MjXTyBzcNmP/gOQN+pCrjqG04UdAawZkKoqs6lpTto5c8ht1fGnGz8PADRJqdpf8mD2A==}
+  incur@0.4.20:
+    resolution: {integrity: sha512-TPiYXQkV4Tt2A8ubCOO1fkFMKpvrApCMJuy7Yvlg9onCc52W5per1d8nXf4MVEWLFCaFqlI2ziDSzYmK3peOTQ==}
     engines: {node: '>=22'}
     hasBin: true
 
@@ -3990,7 +3990,7 @@ snapshots:
 
   ignore@5.3.2: {}
 
-  incur@0.4.19:
+  incur@0.4.20:
     dependencies:
       '@cfworker/json-schema': 4.1.1
       '@modelcontextprotocol/server': 2.0.0-alpha.4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,7 +9,7 @@ catalog:
   '@octokit/rest': ^22.0.1
   '@types/node': latest
   '@vitest/coverage-v8': latest
-  incur: 0.4.19
+  incur: 0.4.20
   octokit: ^5.0.5
   tsx: ^4.23.1
   typescript: latest
@@ -21,3 +21,6 @@ catalog:
 allowBuilds:
   esbuild: true
   workerd: true
+
+minimumReleaseAgeExclude:
+  - incur@0.4.20


### PR DESCRIPTION
The `incur` bump merged in #26 without its changeset, so the fix would not reach npm. Adds it.