### PR TITLE
feat(init): guide project setup

### DIFF
--- a/.changeset/init-agent-followup.md
+++ b/.changeset/init-agent-followup.md
@@ -1,0 +1,5 @@
+---
+'frog': patch
+---
+
+Directed agents to install the GitHub App and update `AGENTS.md` after `init`.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ health endpoint hit a config loader that turns a missing environment variable in
 Prompt your agent:
 
 ```txt
-Run `npx frog init` and `npx frog skills add`, then log friction as you hit it from now on.
+Run `npx frog init`, and set up Frog in this project.
 ```
 
 ## Install

--- a/src/cli/commands/init.test.ts
+++ b/src/cli/commands/init.test.ts
@@ -19,11 +19,27 @@ test('behavior: scaffolds the directory', async () => {
     }
   `)
 
-  // Nothing is filed until the App is installed, and the failure is silent, so the one place a user
-  // is certain to look has to say so.
+  // Nothing is filed until the App is installed, and agents need the rule to log future friction.
   const { envelope } = await cli.run(['init', '--cwd', await helpers.repo()])
-  const cta = envelope.meta?.['cta'] as { description?: string } | undefined
-  expect(cta?.description).toContain('https://github.com/apps/frog-fm/installations/new')
+  const cta = envelope.meta?.['cta'] as
+    | {
+        commands?: { command?: string; description?: string }[]
+        description?: string
+      }
+    | undefined
+  expect(cta?.description).toMatchInlineSnapshot(`
+    "Install the GitHub App at https://github.com/apps/frog-fm/installations/new and add this to \`AGENTS.md\` under the appropriate section:
+
+    - Log papercuts and friction (tooling, docs, APIs, tests, conventions) as you hit them with \`frog log\`.
+    - Do not add global, system, or internal friction.
+    - Run \`frog list\` first to see what is already known.
+
+    Then:"
+  `)
+  expect(cta?.commands?.[0]).toEqual({
+    command: 'frog log',
+    description: 'Write the first entry',
+  })
 
   // The scaffolded config must validate against the schema it advertises.
   expect(await Config.resolve({ root: cwd })).toEqual(Config.from({}))

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -7,10 +7,11 @@ import * as IssueForm from '../../IssueForm.js'
 import * as Store from '../../Store.js'
 import * as context from '../internal/context.js'
 
-/** The rule to paste into `AGENTS.md`. */
-export const rule =
-  'Log papercuts and friction (tooling, docs, APIs, tests, conventions) as you hit them with ' +
-  '`frog log`. Run `frog list` first to see what is already known.'
+/** The rules to paste into `AGENTS.md`. */
+export const rules =
+  '- Log papercuts and friction (tooling, docs, APIs, tests, conventions) as you hit them with ' +
+  '`frog log`.\n- Do not add global, system, or internal friction.\n' +
+  '- Run `frog list` first to see what is already known.'
 
 /** Where to install the GitHub App, which is what makes filing and reconciling automatic. */
 const install = 'https://github.com/apps/frog-fm/installations/new'
@@ -50,9 +51,9 @@ write-up. The next reader runs the reproduction instead of rebuilding it.
 
 ## For Agents
 
-Add this to \`AGENTS.md\`:
+Add this to \`AGENTS.md\` under the appropriate section:
 
-> ${rule}
+${rules}
 
 Managed by [Frog](https://github.com/wevm/frog).
 `
@@ -145,11 +146,10 @@ export const init = Cli.create('init', {
       { created, existing },
       {
         cta: {
-          commands: [
-            { command: 'log', description: 'Write the first entry' },
-            { command: 'skills add', description: 'Install the skill that says when to log' },
-          ],
-          description: `Install the GitHub App at ${install} to file and reconcile automatically, then:`,
+          commands: [{ command: 'log', description: 'Write the first entry' }],
+          description:
+            `Install the GitHub App at ${install} and add this to \`AGENTS.md\` under the appropriate section:\n\n` +
+            `${rules}\n\nThen:`,
         },
       },
     )


### PR DESCRIPTION
Updates `frog init` to guide agents through GitHub App installation and repository-scoped `AGENTS.md` rules. Simplifies the quick prompt so one command covers complete project setup.