### PR TITLE
docs: move setup before workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 </p>
 
 <p align="center">
-  <a href="#problem">Problem</a> · <a href="#solution">Solution</a> · <a href="#workflow">Workflow</a> · <a href="#quick-prompt">Quick Prompt</a> · <a href="#install">Install</a> · <a href="#usage">Usage</a> · <a href="#action-only-mode">Action-only Mode</a> · <a href="#license">License</a>
+  <a href="#problem">Problem</a> · <a href="#solution">Solution</a> · <a href="#quick-prompt">Quick Prompt</a> · <a href="#install">Install</a> · <a href="#workflow">Workflow</a> · <a href="#usage">Usage</a> · <a href="#action-only-mode">Action-only Mode</a> · <a href="#license">License</a>
 </p>
 
 ## Problem
@@ -49,22 +49,6 @@ agent reads them before it starts guessing.
 Each entry is then reported as an issue, so somebody owns it, and deleted once that issue closes, so the log
 only ever holds what is still unresolved. Friction in a dependency can be reported to that project instead,
 if it has opted in.
-
-## Workflow
-
-See a demonstration in [wevm/frog-demo](https://github.com/wevm/frog-demo), where an agent adding a
-health endpoint hit a config loader that turns a missing environment variable into the string
-`"undefined"`, and logged it on the way past.
-
-| Step | What happens                                                                    | Example                                                       |
-| ---- | ------------------------------------------------------------------------------- | ------------------------------------------------------------- |
-| 1    | Agent hits friction while working and runs `frog log`                           | —                                                             |
-| 2    | The entry commits alongside the change that provoked it                         | [`0de4ab6`](https://github.com/wevm/frog-demo/commit/0de4ab6) |
-| 3    | Frog comments on the pull request, naming what it found                         | [#1](https://github.com/wevm/frog-demo/pull/1)                |
-| 4    | Frog reports the entry as an issue and writes the `issue:` link onto the branch | [#2](https://github.com/wevm/frog-demo/issues/2)              |
-| 5    | You fix the friction and close the issue                                        | [#3](https://github.com/wevm/frog-demo/pull/3)                |
-| 6    | Frog opens a pull request deleting the resolved entry                           | [#4](https://github.com/wevm/frog-demo/pull/4)                |
-| 7    | Merging leaves the log holding only what is still unresolved                    | [`e4ac13d`](https://github.com/wevm/frog-demo/commit/e4ac13d) |
 
 ## Quick Prompt
 
@@ -101,6 +85,22 @@ frog init
 > - Install the [Frog GitHub App](https://github.com/apps/frog-fm/installations/new) for pull-request
 >   comments, forks, and cross-repository reporting.
 > - Use the Action-only workflow below for same-repository automation without an external App write grant.
+
+## Workflow
+
+See a demonstration in [wevm/frog-demo](https://github.com/wevm/frog-demo), where an agent adding a
+health endpoint hit a config loader that turns a missing environment variable into the string
+`"undefined"`, and logged it on the way past.
+
+| Step | What happens                                                                    | Example                                                       |
+| ---- | ------------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| 1    | Agent hits friction while working and runs `frog log`                           | —                                                             |
+| 2    | The entry commits alongside the change that provoked it                         | [`0de4ab6`](https://github.com/wevm/frog-demo/commit/0de4ab6) |
+| 3    | Frog comments on the pull request, naming what it found                         | [#1](https://github.com/wevm/frog-demo/pull/1)                |
+| 4    | Frog reports the entry as an issue and writes the `issue:` link onto the branch | [#2](https://github.com/wevm/frog-demo/issues/2)              |
+| 5    | You fix the friction and close the issue                                        | [#3](https://github.com/wevm/frog-demo/pull/3)                |
+| 6    | Frog opens a pull request deleting the resolved entry                           | [#4](https://github.com/wevm/frog-demo/pull/4)                |
+| 7    | Merging leaves the log holding only what is still unresolved                    | [`e4ac13d`](https://github.com/wevm/frog-demo/commit/e4ac13d) |
 
 ## Usage
 


### PR DESCRIPTION
Moves the quick prompt and installation instructions ahead of the workflow walkthrough so readers can start using Frog before reading the end-to-end example.