### PR TITLE
feat: scaffold friction issue form

### DIFF
--- a/.changeset/init-friction-template.md
+++ b/.changeset/init-friction-template.md
@@ -1,0 +1,5 @@
+---
+'frog': patch
+---
+
+Added a default friction issue form to every `frog init` scaffold.

--- a/README.md
+++ b/README.md
@@ -161,8 +161,8 @@ frog log --target viem
 
 ### Accept Inbound Logs
 
-Marks this repository as accepting friction from the projects that depend on it, and publishes
-`.github/ISSUE_TEMPLATE/friction.yml` so a consumer's report arrives in the shape this project wants.
+Every `frog init` adds `.github/ISSUE_TEMPLATE/friction.yml`, keeping human issues and Frog entries in
+the same shape. Add `--library` to accept reports from projects that depend on this one.
 
 ```sh
 frog init --library
@@ -176,7 +176,7 @@ frog — Automated friction logging for agents.
 Usage: frog <command>
 
 Commands:
-  init     Create `.agents/friction-log` and its config.
+  init     Create the friction log, config, and issue form.
   list     List entries with their state.
   log      Write a friction entry.
   publish  Report pending entries as GitHub issues.

--- a/src/Entry.ts
+++ b/src/Entry.ts
@@ -210,8 +210,8 @@ export type Section = {
  * Nothing enforces these. Expected and current behavior are separate prompts because friction is the
  * gap between the two.
  *
- * Held as data because two things render from it: the markdown scaffold below, and the issue form
- * `init --library` publishes so a consumer's agent finds the same questions.
+ * Held as data because the entry scaffold and the issue form `frog init` publishes must ask the same
+ * questions.
  */
 export const sections: readonly Section[] = [
   {

--- a/src/cli/commands/init.test.ts
+++ b/src/cli/commands/init.test.ts
@@ -5,6 +5,7 @@ import * as helpers from '../../../test/helpers.js'
 import * as Config from '../../Config.js'
 import * as Entry from '../../Entry.js'
 import * as IssueForm from '../../IssueForm.js'
+import * as Store from '../../Store.js'
 
 test('behavior: scaffolds the directory', async () => {
   const cwd = await helpers.repo()
@@ -14,6 +15,7 @@ test('behavior: scaffolds the directory', async () => {
       "created": [
         ".agents/friction-log/README.md",
         ".agents/friction-log/config.json",
+        ".github/ISSUE_TEMPLATE/friction.yml",
       ],
       "existing": [],
     }
@@ -43,19 +45,40 @@ test('behavior: scaffolds the directory', async () => {
     description: 'Write the first entry',
   })
   const readme = await fs.readFile(path.join(cwd, path.dirname(Config.file), 'README.md'), 'utf8')
-  expect(readme).toContain('## Choose Automation')
+  expect(readme).not.toContain('## Choose Automation')
   expect(readme).toContain('Prompt the user to choose one automation method')
   expect(readme).toContain('Choose one method per repository')
   expect(readme).toContain('| Scope | Cross-repository reporting')
   expect(readme).toContain('Choose **Action-only**')
-  expect(readme).toContain('### GitHub App')
-  expect(readme).toContain('### Action-only')
+  expect(readme).toContain('## GitHub App')
+  expect(readme).toContain('## Action-only')
   expect(readme).toContain('Create `.github/workflows/frog.yml`')
   expect(readme).toContain('uses: wevm/frog/action@v1')
 
   // The scaffolded config must validate against the schema it advertises.
   expect(await Config.resolve({ root: cwd })).toEqual(Config.from({}))
+
+  // The form and the entry scaffold are rendered from one list of sections.
+  const contents = await fs.readFile(path.join(cwd, IssueForm.dir, IssueForm.filename), 'utf8')
+  const form = IssueForm.parse(contents)
+  expect(form?.fields.map((field) => field.label)).toEqual(
+    Entry.sections.map((section) => section.label),
+  )
+
   await expect(fs.readFile(path.join(cwd, '.github/workflows/frog.yml'))).rejects.toThrow()
+})
+
+test('behavior: the issue form scaffolds local entries', async () => {
+  const cwd = await helpers.repo()
+  await cli.data(['init', '--cwd', cwd])
+
+  const contents = await fs.readFile(path.join(cwd, IssueForm.dir, IssueForm.filename), 'utf8')
+  const form = IssueForm.parse(contents)
+  if (!form) throw new Error('Expected a valid friction issue form.')
+
+  const { id } = await cli.data<{ id: string }>(['log', 'A papercut', '--cwd', cwd])
+
+  expect((await Store.get(id, { root: cwd })).body).toBe(IssueForm.scaffold(form).trim())
 })
 
 test('behavior: re-running never clobbers local edits', async () => {
@@ -65,7 +88,11 @@ test('behavior: re-running never clobbers local edits', async () => {
 
   expect(await cli.data(['init', '--cwd', cwd])).toMatchObject({
     created: [],
-    existing: ['.agents/friction-log/README.md', '.agents/friction-log/config.json'],
+    existing: [
+      '.agents/friction-log/README.md',
+      '.agents/friction-log/config.json',
+      '.github/ISSUE_TEMPLATE/friction.yml',
+    ],
   })
   expect((await Config.resolve({ root: cwd })).maxPerRun).toBe(3)
 })
@@ -81,27 +108,30 @@ test('behavior: leaves the automation choice alone', async () => {
   expect(await fs.readFile(workflow, 'utf8')).toBe('custom\n')
 })
 
+test('behavior: never clobbers an existing friction issue form', async () => {
+  const cwd = await helpers.repo()
+  const file = path.join(cwd, IssueForm.dir, IssueForm.filename)
+  await fs.mkdir(path.dirname(file), { recursive: true })
+  await fs.writeFile(file, 'custom\n', 'utf8')
+
+  const result = await cli.data<{ existing: string[] }>(['init', '--cwd', cwd])
+
+  expect(result.existing).toContain('.github/ISSUE_TEMPLATE/friction.yml')
+  expect(await fs.readFile(file, 'utf8')).toBe('custom\n')
+})
+
 describe('--library', () => {
-  test('behavior: publishes an issue form a consumer can author against', async () => {
+  test('behavior: accepts friction reported by consumers', async () => {
     const cwd = await helpers.repo()
 
-    const result = await cli.data<{ created: string[] }>(['init', '--library', '--cwd', cwd])
+    await cli.data(['init', '--library', '--cwd', cwd])
 
-    expect(result.created).toContain('.github/ISSUE_TEMPLATE/friction.yml')
-
-    // The form and the entry scaffold are rendered from one list of sections, so the questions a
-    // consumer is asked are the questions this project asks itself.
-    const contents = await fs.readFile(path.join(cwd, IssueForm.dir, IssueForm.filename), 'utf8')
-    const form = IssueForm.parse(contents)
-    expect(form?.fields.map((field) => field.label)).toEqual(
-      Entry.sections.map((section) => section.label),
+    expect(await Config.resolve({ root: cwd })).toEqual(
+      Config.from({
+        inbound: {
+          enabled: true,
+        },
+      }),
     )
-  })
-
-  test('behavior: plain init leaves the repository issue templates alone', async () => {
-    const cwd = await helpers.repo()
-    await cli.data(['init', '--cwd', cwd])
-
-    await expect(fs.readdir(path.join(cwd, IssueForm.dir))).rejects.toThrow()
   })
 })

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -49,19 +49,17 @@ outstanding, including friction in dependencies.
 
 Do not maintain an index here. This directory is the index.
 
-## Choose Automation
-
 Prompt the user to choose one automation method. Do not install the App or add a workflow before they
 answer.
 
 ${automationComparison}
 
-### GitHub App
+## GitHub App
 
 Install the [Frog GitHub App](${install}) and entries are reported, linked, and removed as their issues
 close, without anyone running anything.
 
-### Action-only
+## Action-only
 
 Create \`.github/workflows/frog.yml\`:
 
@@ -149,11 +147,9 @@ const libraryConfig = `{
 `
 
 /**
- * The issue form a project serves so consumers report friction the way it wants.
+ * The issue form a project serves so Frog and humans report friction with the same questions.
  *
- * Rendered from the same sections as the entry scaffold, so the two cannot drift. A consumer's Frog finds
- * it by convention and writes its entry against it. A human filing through the issue page gets the same
- * questions.
+ * Rendered from the same sections as the entry scaffold, so the two cannot drift.
  */
 const form = `name: Friction
 description: Something about this project cost you time.
@@ -174,7 +170,7 @@ ${Entry.sections
 `
 
 export const init = Cli.create('init', {
-  description: 'Create `.agents/friction-log` and its config.',
+  description: 'Create the friction log, config, and issue form.',
   options: z.object({
     cwd: context.cwdOption,
     library: z
@@ -196,12 +192,11 @@ export const init = Cli.create('init', {
     const files = [
       [`${Store.dir}/README.md`, readme()],
       [Config.file, c.options.library ? libraryConfig : config],
-      // Only for a project accepting reports: a consumer's Frog writes its entry against it.
-      ...(c.options.library ? ([[`${IssueForm.dir}/${IssueForm.filename}`, form]] as const) : []),
+      [`${IssueForm.dir}/${IssueForm.filename}`, form],
     ] as const
 
     await fs.mkdir(path.join(root, Store.dir), { recursive: true })
-    if (c.options.library) await fs.mkdir(path.join(root, IssueForm.dir), { recursive: true })
+    await fs.mkdir(path.join(root, IssueForm.dir), { recursive: true })
 
     const created: string[] = []
     const existing: string[] = []


### PR DESCRIPTION
Scaffolds `.github/ISSUE_TEMPLATE/friction.yml` during every `frog init`, so newly logged reports and human-filed issues share one question set. Removes the redundant automation heading.