### PR TITLE
docs(init): trim friction readme

### DIFF
--- a/.changeset/tidy-friction-readme.md
+++ b/.changeset/tidy-friction-readme.md
@@ -1,0 +1,5 @@
+---
+'frog': patch
+---
+
+Removed automation setup guidance from generated friction log READMEs.

--- a/src/cli/commands/init.test.ts
+++ b/src/cli/commands/init.test.ts
@@ -30,7 +30,7 @@ test('behavior: scaffolds the directory', async () => {
       }
     | undefined
   expect(cta?.description).toMatchInlineSnapshot(`
-    "Prompt the user to choose the GitHub App or Action-only setup described in \`.agents/friction-log/README.md\`. Do not install the App or add a workflow before they answer.
+    "Prompt the user to choose the GitHub App or Action-only setup described at https://github.com/wevm/frog#install. Do not install the App or add a workflow before they answer.
 
     Add this to \`AGENTS.md\` under the appropriate section:
 
@@ -45,15 +45,16 @@ test('behavior: scaffolds the directory', async () => {
     description: 'Write the first entry',
   })
   const readme = await fs.readFile(path.join(cwd, path.dirname(Config.file), 'README.md'), 'utf8')
+  expect(readme).not.toContain('Prompt the user to choose')
   expect(readme).not.toContain('## Choose Automation')
-  expect(readme).toContain('Prompt the user to choose one automation method')
-  expect(readme).toContain('Choose one method per repository')
-  expect(readme).toContain('| Scope | Cross-repository reporting')
-  expect(readme).toContain('Choose **Action-only**')
-  expect(readme).toContain('## GitHub App')
-  expect(readme).toContain('## Action-only')
-  expect(readme).toContain('Create `.github/workflows/frog.yml`')
-  expect(readme).toContain('uses: wevm/frog/action@v1')
+  expect(readme).not.toContain('## GitHub App')
+  expect(readme).not.toContain('## Action-only')
+  expect(readme).not.toContain('| Area | GitHub App | Action-only |')
+  expect(readme).not.toContain('github.com/apps/frog-fm')
+  expect(readme).not.toContain('Create `.github/workflows/frog.yml`')
+  expect(readme).not.toContain('uses: wevm/frog/action@v1')
+  expect(readme).toContain('## Logging Friction')
+  expect(readme).toContain('## For Agents')
 
   // The scaffolded config must validate against the schema it advertises.
   expect(await Config.resolve({ root: cwd })).toEqual(Config.from({}))

--- a/src/cli/commands/init.test.ts
+++ b/src/cli/commands/init.test.ts
@@ -30,7 +30,7 @@ test('behavior: scaffolds the directory', async () => {
       }
     | undefined
   expect(cta?.description).toMatchInlineSnapshot(`
-    "Prompt the user to choose the GitHub App or Action-only setup described at https://github.com/wevm/frog#install. Do not install the App or add a workflow before they answer.
+    "Prompt the user to choose the GitHub App or Action-only setup described in \`.agents/friction-log/README.md\`. Do not install the App or add a workflow before they answer.
 
     Add this to \`AGENTS.md\` under the appropriate section:
 

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -13,25 +13,6 @@ export const rules =
   '`frog log`.\n- Do not add global, system, or internal friction.\n' +
   '- Run `frog list` first to see what is already known.'
 
-/** Where to install the GitHub App, which is what makes filing and reconciling automatic. */
-const install = 'https://github.com/apps/frog-fm/installations/new'
-
-const automationComparison = `Choose the **GitHub App** for pull-request feedback, forks, cross-repository reporting, or durable event
-processing. Choose **Action-only** when same-repository automation and avoiding an external write grant
-matter most. Choose one method per repository; concurrent App and Action-only runs can create duplicate
-issues.
-
-| Area | GitHub App | Action-only |
-| --- | --- | --- |
-| Trust | Grants the Frog App access to selected repositories. | Uses this repository's \`GITHUB_TOKEN\`; no third-party App installation. |
-| Scope | Cross-repository reporting and reconciliation where installed and allowed. | Same repository only; \`target:\` entries stay deferred. |
-| Pull requests | Reports during the pull request and posts or updates one comment. | Reports after merge, without commenting on the author's pull request. |
-| Forks | Installation credentials work independently of the fork token. | Cannot safely report from fork pull requests. |
-| Reconciliation | Webhooks react immediately, with durable retries and serialization. | Workflows plus a daily sweep; issue edits wait for the next run. |
-| Delivery | Commits through GitHub's API, directly or through an accumulating pull request. | Commits locally, then pushes directly or updates \`frog/sync\`. |
-| Setup | Needs the App installed with its requested repository permissions. | Needs workflow write permissions and Actions-created pull requests enabled. |
-| Operations | Requires the Worker, queues, secrets, and App installation. | Uses Actions minutes and installs Frog from npm; no service to run. |`
-
 function readme(): string {
   return `# Friction log
 
@@ -48,28 +29,6 @@ to it. The whole directory is deleted once the friction is resolved. Every entry
 outstanding, including friction in dependencies.
 
 Do not maintain an index here. This directory is the index.
-
-Prompt the user to choose one automation method. Do not install the App or add a workflow before they
-answer.
-
-${automationComparison}
-
-## GitHub App
-
-Install the [Frog GitHub App](${install}) and entries are reported, linked, and removed as their issues
-close, without anyone running anything.
-
-## Action-only
-
-Create \`.github/workflows/frog.yml\`:
-
-\`\`\`yaml
-${workflow}\`\`\`
-
-The workflow uses this repository's \`GITHUB_TOKEN\` and handles same-repository friction only. Before
-the first run, enable "Allow GitHub Actions to create and approve pull requests" under Settings >
-Actions > General. Pull-request checks need a write user to approve each action-created run. Push-only
-workflows do not run; pass a personal access token or App token as \`token\` when they are required.
 
 ## Logging Friction
 
@@ -93,42 +52,6 @@ ${rules}
 Managed by [Frog](https://github.com/wevm/frog).
 `
 }
-
-const workflow = `name: Frog
-on:
-  push:
-  issues:
-    types: [closed, reopened]
-  workflow_dispatch:
-  schedule:
-    - cron: '0 0 * * *'
-
-concurrency:
-  group: frog
-  cancel-in-progress: false
-
-permissions: {}
-
-jobs:
-  frog:
-    name: Frog
-    if: github.event_name != 'push' || github.ref_name == github.event.repository.default_branch
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      issues: write
-      pull-requests: write
-
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-          ref: \${{ github.event.repository.default_branch }}
-
-      - name: Report and reconcile friction
-        uses: wevm/frog/action@v1
-`
 
 const schema = 'https://unpkg.com/frog/schema.json'
 
@@ -217,7 +140,8 @@ export const init = Cli.create('init', {
         cta: {
           commands: [{ command: 'log', description: 'Write the first entry' }],
           description:
-            `Prompt the user to choose the GitHub App or Action-only setup described in \`${Store.dir}/README.md\`. ` +
+            'Prompt the user to choose the GitHub App or Action-only setup described at ' +
+            'https://github.com/wevm/frog#install. ' +
             `Do not install the App or add a workflow before they answer.\n\n` +
             `Add this to \`AGENTS.md\` under the appropriate section:\n\n${rules}\n\nThen:`,
         },

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -140,8 +140,7 @@ export const init = Cli.create('init', {
         cta: {
           commands: [{ command: 'log', description: 'Write the first entry' }],
           description:
-            'Prompt the user to choose the GitHub App or Action-only setup described at ' +
-            'https://github.com/wevm/frog#install. ' +
+            `Prompt the user to choose the GitHub App or Action-only setup described in \`${Store.dir}/README.md\`. ` +
             `Do not install the App or add a workflow before they answer.\n\n` +
             `Add this to \`AGENTS.md\` under the appropriate section:\n\n${rules}\n\nThen:`,
         },


### PR DESCRIPTION
Removes duplicated automation setup from generated friction-log READMEs and points the `frog init` prompt to the root install documentation instead.