### PR TITLE
feat(init): accept inbound logs by default

### DIFF
--- a/.changeset/default-inbound-logs.md
+++ b/.changeset/default-inbound-logs.md
@@ -1,0 +1,5 @@
+---
+'frog': patch
+---
+
+Enabled inbound logs by default in `frog init`, replacing `--library` with `--no-inbound` for opting out.

--- a/README.md
+++ b/README.md
@@ -181,12 +181,19 @@ frog log --target viem
 
 ### Accept Inbound Logs
 
-Every `frog init` adds `.github/ISSUE_TEMPLATE/friction.yml`, keeping human issues and Frog entries in
-the same shape. Add `--library` to accept reports from projects that depend on this one.
+Accept friction reported by other repositories with `.agents/friction-log/config.json`:
 
-```sh
-frog init --library
+```json
+{
+  "$schema": "https://unpkg.com/frog/schema.json",
+  "inbound": {
+    "enabled": true
+  }
+}
 ```
+
+`frog init` enables inbound reports by default. Run `frog init --no-inbound` to initialize without
+accepting inbound reports.
 
 ## CLI Reference
 

--- a/src/cli/commands/init.test.ts
+++ b/src/cli/commands/init.test.ts
@@ -62,7 +62,13 @@ test('behavior: scaffolds the directory', async () => {
   expect(readme).toContain('## For Agents')
 
   // The scaffolded config must validate against the schema it advertises.
-  expect(await Config.resolve({ root: cwd })).toEqual(Config.from({}))
+  expect(await Config.resolve({ root: cwd })).toEqual(
+    Config.from({
+      inbound: {
+        enabled: true,
+      },
+    }),
+  )
 
   // The form and the entry scaffold are rendered from one list of sections.
   const contents = await fs.readFile(path.join(cwd, IssueForm.dir, IssueForm.filename), 'utf8')
@@ -126,18 +132,12 @@ test('behavior: never clobbers an existing friction issue form', async () => {
   expect(await fs.readFile(file, 'utf8')).toBe('custom\n')
 })
 
-describe('--library', () => {
-  test('behavior: accepts friction reported by consumers', async () => {
+describe('--no-inbound', () => {
+  test('behavior: disables friction reported by other repositories', async () => {
     const cwd = await helpers.repo()
 
-    await cli.data(['init', '--library', '--cwd', cwd])
+    await cli.data(['init', '--no-inbound', '--cwd', cwd])
 
-    expect(await Config.resolve({ root: cwd })).toEqual(
-      Config.from({
-        inbound: {
-          enabled: true,
-        },
-      }),
-    )
+    expect((await Config.resolve({ root: cwd })).inbound.enabled).toBe(false)
   })
 })

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -55,13 +55,14 @@ Managed by [Frog](https://github.com/wevm/frog).
 
 const schema = 'https://unpkg.com/frog/schema.json'
 
-const config = `{
+/** Config for a project that does not accept friction reported by others. */
+const noInboundConfig = `{
   "$schema": "${schema}"
 }
 `
 
 /** Config for a project that accepts friction reported by others. */
-const libraryConfig = `{
+const config = `{
   "$schema": "${schema}",
   "inbound": {
     "enabled": true
@@ -96,15 +97,15 @@ export const init = Cli.create('init', {
   description: 'Create the friction log, config, and issue form.',
   options: z.object({
     cwd: context.cwdOption,
-    library: z
+    inbound: z
       .boolean()
+      .default(true)
       .optional()
-      .describe('Also accept friction reported by consumers of this project.'),
+      .describe(
+        'Accept friction reported by other repositories. Pass `--no-inbound` to disable during setup.',
+      ),
   }),
-  examples: [
-    { description: 'Set up Frog' },
-    { description: 'Become a friction target', options: { library: true } },
-  ],
+  examples: [{ description: 'Set up Frog' }],
   output: z.object({
     created: z.array(z.string()).describe('Files written.'),
     existing: z.array(z.string()).describe('Files left alone.'),
@@ -114,7 +115,7 @@ export const init = Cli.create('init', {
 
     const files = [
       [`${Store.dir}/README.md`, readme()],
-      [Config.file, c.options.library ? libraryConfig : config],
+      [Config.file, c.options.inbound !== false ? config : noInboundConfig],
       [`${IssueForm.dir}/${IssueForm.filename}`, form],
     ] as const
 


### PR DESCRIPTION
`frog init` now enables inbound reporting in generated configs and exposes `--no-inbound` as the opt-out, making repositories available as friction targets without an extra initialization flag.