### PR TITLE
fix: repair app reconciliation

### DIFF
--- a/.changeset/fix-demo-reconciliation.md
+++ b/.changeset/fix-demo-reconciliation.md
@@ -1,0 +1,5 @@
+---
+'frog': patch
+---
+
+Fixed App reconciliation and pull-request comments, and moved major Action tags with compatible releases.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,7 @@ jobs:
         uses: ./.github/actions/install-dependencies
 
       - name: PR or publish
+        id: changesets
         uses: changesets/action@v1
         with:
           commit: 'chore: version packages'
@@ -43,6 +44,14 @@ jobs:
           version: pnpm changeset:version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update Action tag
+        if: steps.changesets.outputs.published == 'true'
+        run: |
+          major="$(node -p "require('./package.json').version.split('.')[0]")"
+          tag="v$major"
+          git tag --annotate --force "$tag" "$GITHUB_SHA" --message "$tag"
+          git push --force origin "refs/tags/$tag"
 
   deploy:
     name: Deploy

--- a/README.md
+++ b/README.md
@@ -287,14 +287,12 @@ permissions: {}
 jobs:
   friction-log:
     name: Friction Log
-    # Only the Frog-owned control issue can wake reconciliation through a comment.
+    # The Action validates the exact Frog-owned control issue and comment.
     if: >-
-      github.ref_name == github.event.repository.default_branch &&
+      (github.event_name != 'push' ||
+      github.ref_name == github.event.repository.default_branch) &&
       (github.event_name != 'issue_comment' ||
-      (github.event.issue.user.login == 'frog-fm[bot]' &&
-      github.event.issue.title == 'Frog reconciliation' &&
-      contains(github.event.issue.body, '<!-- frog:reconcile-issue:v1 -->') &&
-      github.event.comment.user.login == 'frog-fm[bot]'))
+      github.actor_id == '309546769')
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/app/src/App.ts
+++ b/app/src/App.ts
@@ -1,6 +1,7 @@
 import { App, type Octokit } from 'octokit'
 import { issues } from './handlers/issues.js'
 import { pullRequest } from './handlers/pullRequest.js'
+import * as client from './internal/client.js'
 import * as serialization from './internal/serialize.js'
 
 /**
@@ -51,13 +52,21 @@ export function runtime(options: create.Options): Runtime {
   app.webhooks.on(
     ['pull_request.opened', 'pull_request.reopened', 'pull_request.synchronize'],
     async ({ id, octokit, payload }) => {
-      const author = payload.pull_request.user?.login
+      const actor = payload.pull_request.user?.login
+      const base = payload.repository.full_name
+      const installationId = payload.installation?.id
+      if (!installationId) throw new Error('Pull request delivery has no installation.')
       await pullRequest({
         app: await self(),
-        ...(author ? { actor: `@${author}` } : {}),
-        base: payload.repository.full_name,
+        ...(actor ? { actor: `@${actor}` } : {}),
+        base,
         baseRef: payload.pull_request.base.ref,
         client: octokit,
+        comments: () =>
+          client.comments(app, {
+            installation: installationId,
+            repo: base,
+          }),
         head: payload.pull_request.head.sha,
         installation,
         pr: payload.number,

--- a/app/src/handlers/pullRequest.test.ts
+++ b/app/src/handlers/pullRequest.test.ts
@@ -31,6 +31,7 @@ function entry(title: string, frontmatter: Record<string, string> = {}): string 
 async function run(
   url: string,
   options: {
+    comments?: (() => Promise<Octokit>) | undefined
     installed?: Record<string, Octokit> | undefined
     serialize?: Serialize | undefined
   } = {},
@@ -42,6 +43,7 @@ async function run(
     base,
     baseRef: 'main',
     client: octokit,
+    comments: options.comments ?? (async () => octokit),
     head: 'head',
     installation: async (repo) => options.installed?.[repo],
     pr: 42,
@@ -79,6 +81,20 @@ test('behavior: files pending entries and comments once', async () => {
   expect(instance.issues.get(base)?.[0]?.title).toBe('Filters ignored')
   expect(instance.comments(base, 42)).toHaveLength(1)
   expect(instance.comments(base, 42)[0]).toContain(`${base}#1`)
+})
+
+test('security: uses the dedicated client for the pull request comment', async () => {
+  const instance = await github(
+    {},
+    { head: { [base]: { [`${dir}/a/friction.md`]: entry('Filters ignored') } } },
+  )
+  const comments = await github()
+
+  await run(instance.url, { comments: async () => client(comments.url) })
+
+  expect(instance.issues.get(base)).toHaveLength(1)
+  expect(instance.comments(base, 42)).toEqual([])
+  expect(comments.comments(base, 42)).toHaveLength(1)
 })
 
 test('behavior: records the pull request and the reporter on the issue', async () => {
@@ -124,12 +140,14 @@ test('behavior: a pull request that changes no entry says nothing', async () => 
       head: { [base]: { 'src/index.ts': 'export {}\n' } },
     },
   )
+  const comments = vi.fn(async () => client(instance.url))
 
-  const report = await run(instance.url)
+  const report = await run(instance.url, { comments })
 
   expect(report).toEqual({ commented: [], created: [], deferred: [], linked: [], malformed: [] })
   expect(instance.issues.get(base)).toBeUndefined()
   expect(instance.comments(base, 42)).toEqual([])
+  expect(comments).not.toHaveBeenCalled()
 })
 
 // Every push to the branch re-runs this, and each one is a separate delivery.

--- a/app/src/handlers/pullRequest.ts
+++ b/app/src/handlers/pullRequest.ts
@@ -63,10 +63,12 @@ export async function pullRequest(options: pullRequest.Options): Promise<comment
   }
 
   const body = comment.render(report)
-  if (body)
+  if (body) {
+    const comments = await options.comments()
     await serialize(base, () =>
-      comment.upsert(client, { author: options.app, body, pr, repo: base }),
+      comment.upsert(comments, { author: options.app, body, pr, repo: base }),
     )
+  }
 
   return report
 }
@@ -100,6 +102,8 @@ export declare namespace pullRequest {
     baseRef: string
     /** Installation client for the base repository. */
     client: Octokit
+    /** Lazily resolves an Issues-scoped client for pull-request comments. */
+    comments: () => Promise<Octokit>
     /** Head commit sha, reachable from the base repository even for a fork. */
     head: string
     /**

--- a/app/src/internal/body.test.ts
+++ b/app/src/internal/body.test.ts
@@ -1,0 +1,64 @@
+import * as body from './body.js'
+
+describe('empty', () => {
+  test('behavior: a missing body is empty', async () => {
+    await expect(body.empty(null)).resolves.toBe(true)
+  })
+
+  test.each(['', new Uint8Array()])(
+    'behavior: a zero-byte request body is empty',
+    async (value) => {
+      const request = new Request('https://frog.wevm.dev/github/reconcile', {
+        body: value,
+        method: 'POST',
+      })
+
+      expect(request.body).not.toBeNull()
+      await expect(body.empty(request.body)).resolves.toBe(true)
+    },
+  )
+
+  test('behavior: one byte is not empty', async () => {
+    const request = new Request('https://frog.wevm.dev/github/reconcile', {
+      body: new Uint8Array([0]),
+      method: 'POST',
+    })
+
+    await expect(body.empty(request.body)).resolves.toBe(false)
+  })
+
+  test('security: probing a body reads one byte and cancels the remainder', async () => {
+    const cancel = vi.fn()
+    const stream = new ReadableStream<Uint8Array>({
+      cancel,
+      pull(controller) {
+        controller.enqueue(new Uint8Array([1]))
+      },
+      type: 'bytes',
+    })
+
+    await expect(body.empty(stream)).resolves.toBe(false)
+    expect(cancel).toHaveBeenCalledOnce()
+  })
+
+  test('security: an unreadable body fails closed', async () => {
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.error(new Error('unreadable'))
+      },
+      type: 'bytes',
+    })
+
+    await expect(body.empty(stream)).resolves.toBe(false)
+  })
+
+  test('security: a non-byte stream fails closed', async () => {
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.close()
+      },
+    })
+
+    await expect(body.empty(stream)).resolves.toBe(false)
+  })
+})

--- a/app/src/internal/body.ts
+++ b/app/src/internal/body.ts
@@ -1,0 +1,18 @@
+/**
+ * Checks whether a request body contains no bytes.
+ *
+ * Cloudflare may expose a non-null stream for a zero-byte POST. A one-byte BYOB read avoids buffering
+ * an attacker-controlled body, and any stream error fails closed.
+ */
+export async function empty(body: ReadableStream<Uint8Array> | null): Promise<boolean> {
+  if (!body) return true
+
+  try {
+    const reader = body.getReader({ mode: 'byob' })
+    const result = await reader.read(new Uint8Array(1))
+    if (!result.done) await reader.cancel()
+    return result.done
+  } catch {
+    return false
+  }
+}

--- a/app/src/internal/client.test.ts
+++ b/app/src/internal/client.test.ts
@@ -1,0 +1,23 @@
+import { App, Octokit } from 'octokit'
+import * as client from './client.js'
+
+describe('comments', () => {
+  test('security: grants one repository only Issues write access', async () => {
+    const auth = vi.fn(async () => ({ token: 'installation-token' }))
+    const app = { octokit: { auth } } as unknown as Pick<App, 'octokit'>
+
+    const comments = await client.comments(app, {
+      installation: 42,
+      repo: 'wevm/frog',
+    })
+
+    expect(auth).toHaveBeenCalledWith({
+      installationId: 42,
+      permissions: { issues: 'write' },
+      repositoryNames: ['frog'],
+      type: 'installation',
+    })
+    expect(comments).toBeInstanceOf(Octokit)
+    await expect(comments.auth()).resolves.toMatchObject({ token: 'installation-token' })
+  })
+})

--- a/app/src/internal/client.ts
+++ b/app/src/internal/client.ts
@@ -1,0 +1,32 @@
+import { Github } from 'frog'
+import { type App, Octokit } from 'octokit'
+
+type Authentication = { token: string }
+
+/**
+ * Creates a client for pull-request comments without merge-capable Pull Requests write access.
+ *
+ * The token is limited to one repository and GitHub's documented Issues write alternative.
+ */
+export async function comments(
+  app: Pick<App, 'octokit'>,
+  options: comments.Options,
+): Promise<Octokit> {
+  const authentication = (await app.octokit.auth({
+    installationId: options.installation,
+    permissions: { issues: 'write' },
+    repositoryNames: [Github.split(options.repo).repo],
+    type: 'installation',
+  })) as Authentication
+  return new Octokit({ auth: authentication.token })
+}
+
+export declare namespace comments {
+  /** Repository installation used for the scoped comment client. */
+  type Options = {
+    /** GitHub App installation id. */
+    installation: number
+    /** Repository receiving the comment, as `owner/name`. */
+    repo: string
+  }
+}

--- a/app/src/internal/failure.test.ts
+++ b/app/src/internal/failure.test.ts
@@ -1,0 +1,81 @@
+import * as failure from './failure.js'
+
+describe('from', () => {
+  test('behavior: preserves safe error details', () => {
+    const error = Object.assign(new Error('Resource not accessible by integration'), {
+      name: 'RequestError',
+      status: 403,
+    })
+
+    expect(failure.from(error)).toEqual({
+      message: 'Resource not accessible by integration',
+      name: 'RequestError',
+      status: 403,
+    })
+  })
+
+  test('behavior: exposes nested webhook failures', () => {
+    const error = Object.assign(new Error('Validation failed'), {
+      name: 'RequestError',
+      status: 422,
+    })
+
+    expect(failure.from(new AggregateError([error], error.message))).toEqual({
+      errors: [
+        {
+          message: 'Validation failed',
+          name: 'RequestError',
+          status: 422,
+        },
+      ],
+      name: 'AggregateError',
+    })
+  })
+
+  test('security: ignores arbitrary properties and messages on unknown failures', () => {
+    expect(
+      failure.from({
+        headers: { authorization: 'Bearer secret' },
+        message: 'Bearer secret',
+        name: 'RequestError',
+        request: { token: 'secret' },
+        status: 500,
+      }),
+    ).toEqual({
+      name: 'RequestError',
+      status: 500,
+    })
+  })
+
+  test('security: bounds and redacts request failures', () => {
+    const errors = Array.from({ length: 10 }, () =>
+      Object.assign(new Error('Bearer secret ghs_stateless.token'), {
+        name: 'RequestError',
+        status: 403,
+      }),
+    )
+
+    const summarized = failure.from(new AggregateError(errors))
+
+    expect(summarized.errors).toHaveLength(5)
+    expect(summarized.errors?.[0]).toEqual({
+      message: 'Bearer [REDACTED] [REDACTED]',
+      name: 'RequestError',
+      status: 403,
+    })
+  })
+
+  test('security: handles circular aggregate errors', () => {
+    const error = new AggregateError([])
+    error.errors.push(error)
+
+    expect(failure.from(error)).toEqual({
+      errors: [{ name: 'AggregateError' }],
+      name: 'AggregateError',
+    })
+  })
+
+  test.each([null, undefined, 'failed', 42])('behavior: summarizes primitive failures', (error) => {
+    expect(failure.from(error)).toEqual({ name: 'UnknownError' })
+  })
+})

--- a/app/src/internal/failure.ts
+++ b/app/src/internal/failure.ts
@@ -1,0 +1,67 @@
+/** Safe error fields emitted to Worker logs. */
+export type Failure = {
+  /** Nested failures carried by an aggregate error. */
+  errors?: readonly Failure[] | undefined
+  /** Error message, which must not contain request credentials. */
+  message?: string | undefined
+  /** Error class name. */
+  name: string
+  /** HTTP status exposed by request errors. */
+  status?: number | undefined
+}
+
+const maximumDepth = 3
+const maximumErrors = 5
+const maximumMessage = 500
+
+/** Reduces an error to diagnostic fields without logging requests, responses, or credentials. */
+export function from(error: unknown): Failure {
+  return summarize(error, { depth: 0, seen: new Set() })
+}
+
+function summarize(error: unknown, options: { depth: number; seen: Set<object> }): Failure {
+  const value =
+    error && (typeof error === 'object' || typeof error === 'function')
+      ? (error as { message?: unknown; name?: unknown; status?: unknown })
+      : {}
+  if (error && typeof error === 'object') {
+    if (options.seen.has(error)) return { name: name(value.name) }
+    options.seen.add(error)
+  }
+
+  const errors =
+    error instanceof AggregateError && Array.isArray(error.errors) && options.depth < maximumDepth
+      ? error.errors
+          .slice(0, maximumErrors)
+          .map((nested) => summarize(nested, { depth: options.depth + 1, seen: options.seen }))
+      : undefined
+  const message =
+    error instanceof Error && typeof value.status === 'number' && typeof value.message === 'string'
+      ? redact(value.message)
+      : undefined
+
+  return {
+    name: name(value.name),
+    ...(message ? { message } : {}),
+    ...(typeof value.status === 'number' ? { status: value.status } : {}),
+    ...(errors?.length ? { errors } : {}),
+  }
+}
+
+function name(value: unknown): string {
+  return typeof value === 'string' ? value : 'UnknownError'
+}
+
+function redact(value: string): string {
+  return value
+    .slice(0, maximumMessage * 4)
+    .replace(
+      /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?(?:-----END [A-Z ]*PRIVATE KEY-----|$)/g,
+      '[REDACTED]',
+    )
+    .replace(/([?&](?:access_token|api_key|key|secret|token)=)[^&\s]+/gi, '$1[REDACTED]')
+    .replace(/\b(?:gh[pousr]|github_pat)_[A-Za-z0-9_.-]+\b/g, '[REDACTED]')
+    .replace(/\b(Bearer|Basic|token)\s+\S+/gi, '$1 [REDACTED]')
+    .replace(/\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b/g, '[REDACTED]')
+    .slice(0, maximumMessage)
+}

--- a/app/src/worker.ts
+++ b/app/src/worker.ts
@@ -3,7 +3,9 @@ import { runtime, type Runtime } from './App.js'
 import * as Delivery from './Delivery.js'
 import * as Reconcile from './Reconcile.js'
 import { WebhookCoordinator } from './WebhookCoordinator.js'
+import * as body from './internal/body.js'
 import * as dispatch from './internal/dispatch.js'
+import * as failure from './internal/failure.js'
 import * as oidc from './internal/oidc.js'
 import * as deliveryQueue from './internal/queue.js'
 import * as serialization from './internal/serialize.js'
@@ -12,14 +14,6 @@ import * as webhook from './internal/webhook.js'
 const reconcilePath = '/github/reconcile'
 const reconcileAudience = 'https://frog.wevm.dev/github/reconcile'
 const webhookPath = '/github'
-
-function failure(error: unknown): { name: string; status?: number | undefined } {
-  const value = error as { name?: unknown; status?: unknown }
-  return {
-    name: typeof value.name === 'string' ? value.name : 'UnknownError',
-    ...(typeof value.status === 'number' ? { status: value.status } : {}),
-  }
-}
 
 /** Bindings the Worker needs, set as secrets. */
 export type Env = {
@@ -95,7 +89,7 @@ async function reconcile(request: Request, env: Env): Promise<Response> {
       headers: { allow: 'POST', 'cache-control': 'no-store' },
       status: 405,
     })
-  if (request.body !== null)
+  if (!(await body.empty(request.body)))
     return new Response('Bad Request', {
       headers: { 'cache-control': 'no-store' },
       status: 400,
@@ -153,7 +147,7 @@ async function reconcile(request: Request, env: Env): Promise<Response> {
   } catch (error) {
     if (error instanceof ForbiddenError || error instanceof oidc.InvalidError) return forbidden()
     if (error instanceof StaleError) return conflict()
-    console.error('Reconciliation failed.', failure(error))
+    console.error('Reconciliation failed.', failure.from(error))
     return new Response('Service Unavailable', {
       headers: { 'cache-control': 'no-store' },
       status: 503,
@@ -211,11 +205,11 @@ const worker = {
       return await webhook.receive(request, {
         enqueue: (delivery) => env.WEBHOOKS.send(delivery, { contentType: 'json' }),
         error: (error, context) =>
-          console.error('Webhook enqueue failed.', context, failure(error)),
+          console.error('Webhook enqueue failed.', context, failure.from(error)),
         verify: (body, signature) => app(env).app.webhooks.verify(body, signature),
       })
     } catch (error) {
-      console.error('Webhook ingress failed.', { delivery: id, event: name }, failure(error))
+      console.error('Webhook ingress failed.', { delivery: id, event: name }, failure.from(error))
       return new Response('Service Unavailable', { status: 503 })
     }
   },
@@ -223,7 +217,7 @@ const worker = {
   async queue(batch: MessageBatch<Delivery.Delivery>, env: Env): Promise<void> {
     await deliveryQueue.consume(batch.messages, {
       error: (error, context) =>
-        console.error('Webhook processing failed.', context, failure(error)),
+        console.error('Webhook processing failed.', context, failure.from(error)),
       process: (delivery) => processQueued(env, delivery),
     })
   },


### PR DESCRIPTION
Accepts Cloudflare’s zero-byte reconciliation requests, posts pull-request feedback through repository-scoped Issues tokens, and exposes redacted nested failures. 