### PR TITLE
docs: simplify init prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,7 @@ if it has opted in.
 Prompt your agent:
 
 ```txt
-Run `npx frog init`, prompt me to choose between the GitHub App and Action-only automation, then set up
-Frog in this project.
+Run `npx frog init`, then set up Frog in my project.
 ```
 
 ## Install


### PR DESCRIPTION
Simplifies the Quick Prompt to ask agents to run `npx frog init` and finish project setup, leaving the command to present the available automation choices itself.