### PR TITLE
feat(targets): include transitive dependencies

### DIFF
--- a/.changeset/transitive-targets.md
+++ b/.changeset/transitive-targets.md
@@ -1,0 +1,5 @@
+---
+'frog': patch
+---
+
+Added transitive dependencies to `frog targets` and package-name target resolution.

--- a/README.md
+++ b/README.md
@@ -164,7 +164,11 @@ frog mcp add
 ### Logging Upstream
 
 Reports friction to another project instead of your own. A target is an npm package or an `owner/repo`,
-and it has to have opted in: `targets` lists the ones your dependencies declare.
+and it has to have opted in: `targets` lists accepting packages across the installed dependency tree,
+including transitive dependencies.
+
+Large dependency trees may exceed GitHub's anonymous API limit. Authenticate `gh` or set
+`GITHUB_TOKEN` so `targets` can check every distinct repository.
 
 A package names its repository through the standard `repository` field, and consent is then read from that
 repository's own default branch. So nothing a package says can send a report somewhere that has not itself

--- a/src/cli/commands/log.test.ts
+++ b/src/cli/commands/log.test.ts
@@ -158,6 +158,24 @@ describe('--target', () => {
     }
   }
 
+  async function installDeep(cwd: string) {
+    await helpers.writeFile(
+      'package.json',
+      JSON.stringify({ dependencies: { parent: '^1.0.0' }, name: 'app' }),
+      cwd,
+    )
+    await helpers.writeFile(
+      'node_modules/parent/package.json',
+      JSON.stringify({ dependencies: { viem: '^2.0.0' }, name: 'parent' }),
+      cwd,
+    )
+    await helpers.writeFile(
+      'node_modules/parent/node_modules/viem/package.json',
+      JSON.stringify({ name: 'viem', repository: `https://github.com/${upstream}` }),
+      cwd,
+    )
+  }
+
   test('behavior: scaffolds the entry from the target form', async () => {
     const cwd = await consumer()
     const instance = await github({}, accepting({ '.github/ISSUE_TEMPLATE/bug_report.yml': form }))
@@ -175,6 +193,110 @@ describe('--target', () => {
 
       ### Current Behavior"
     `)
+  })
+
+  test('behavior: scaffolds from a transitive package target', async () => {
+    const cwd = await consumer()
+    await installDeep(cwd)
+    const instance = await github({}, accepting({ '.github/ISSUE_TEMPLATE/bug_report.yml': form }))
+
+    const { id } = await cli.data<Logged>(['log', title, '--target', 'viem', '--cwd', cwd], {
+      GITHUB_API_URL: instance.url,
+      GITHUB_TOKEN: 'test-token',
+    })
+
+    expect((await Store.get(id, { root: cwd })).body).toContain('### Viem Version')
+  })
+
+  test('behavior: scaffolds from the canonical name of an aliased package', async () => {
+    const cwd = await consumer()
+    await helpers.writeFile(
+      'package.json',
+      JSON.stringify({ dependencies: { legacy: 'npm:viem@^2.0.0' }, name: 'app' }),
+      cwd,
+    )
+    await helpers.writeFile(
+      'node_modules/legacy/package.json',
+      JSON.stringify({ name: 'viem', repository: `https://github.com/${upstream}` }),
+      cwd,
+    )
+    const instance = await github({}, accepting({ '.github/ISSUE_TEMPLATE/bug_report.yml': form }))
+
+    const { id } = await cli.data<Logged>(['log', title, '--target', 'viem', '--cwd', cwd], {
+      GITHUB_API_URL: instance.url,
+      GITHUB_TOKEN: 'test-token',
+    })
+
+    expect((await Store.get(id, { root: cwd })).body).toContain('### Viem Version')
+  })
+
+  test('behavior: a canonical transitive target wins over a colliding dependency alias', async () => {
+    const cwd = await consumer()
+    await helpers.writeFile(
+      'package.json',
+      JSON.stringify({
+        dependencies: { legacy: 'npm:actual@^1.0.0', parent: '^1.0.0' },
+        name: 'app',
+      }),
+      cwd,
+    )
+    await helpers.writeFile(
+      'node_modules/legacy/package.json',
+      JSON.stringify({ name: 'actual', repository: 'https://github.com/acme/actual' }),
+      cwd,
+    )
+    await helpers.writeFile(
+      'node_modules/parent/package.json',
+      JSON.stringify({ dependencies: { legacy: '^2.0.0' }, name: 'parent' }),
+      cwd,
+    )
+    await helpers.writeFile(
+      'node_modules/parent/node_modules/legacy/package.json',
+      JSON.stringify({ name: 'legacy', repository: `https://github.com/${upstream}` }),
+      cwd,
+    )
+    const instance = await github({}, accepting({ '.github/ISSUE_TEMPLATE/bug_report.yml': form }))
+
+    const { id } = await cli.data<Logged>(['log', title, '--target', 'legacy', '--cwd', cwd], {
+      GITHUB_API_URL: instance.url,
+      GITHUB_TOKEN: 'test-token',
+    })
+
+    expect((await Store.get(id, { root: cwd })).body).toContain('### Viem Version')
+    expect(instance.requests.some((request) => request.path.includes('acme/actual'))).toBe(false)
+  })
+
+  test('behavior: resolves a listed package when another installed copy has no repository', async () => {
+    const cwd = await consumer()
+    await helpers.writeFile(
+      'package.json',
+      JSON.stringify({ dependencies: { one: '^1.0.0', two: '^1.0.0' }, name: 'app' }),
+      cwd,
+    )
+    await helpers.writeFile(
+      'node_modules/one/package.json',
+      JSON.stringify({ dependencies: { viem: '^1.0.0' }, name: 'one' }),
+      cwd,
+    )
+    await helpers.writeFile(
+      'node_modules/two/package.json',
+      JSON.stringify({ dependencies: { viem: '^2.0.0' }, name: 'two' }),
+      cwd,
+    )
+    await helpers.writeFile('node_modules/viem/package.json', JSON.stringify({ name: 'viem' }), cwd)
+    await helpers.writeFile(
+      'node_modules/two/node_modules/viem/package.json',
+      JSON.stringify({ name: 'viem', repository: `https://github.com/${upstream}` }),
+      cwd,
+    )
+    const instance = await github({}, accepting({ '.github/ISSUE_TEMPLATE/bug_report.yml': form }))
+
+    const { id } = await cli.data<Logged>(['log', title, '--target', 'viem', '--cwd', cwd], {
+      GITHUB_API_URL: instance.url,
+      GITHUB_TOKEN: 'test-token',
+    })
+
+    expect((await Store.get(id, { root: cwd })).body).toContain('### Viem Version')
   })
 
   test('behavior: a template named in the target config wins', async () => {

--- a/src/cli/commands/publish.test.ts
+++ b/src/cli/commands/publish.test.ts
@@ -376,6 +376,25 @@ describe('cross-repo', () => {
     )
   }
 
+  /** Installs a package beneath another installed dependency. */
+  async function installDeep(cwd: string, name: string, repo: string): Promise<void> {
+    await helpers.writeFile(
+      'package.json',
+      JSON.stringify({ dependencies: { parent: '^1.0.0' }, name: 'app' }),
+      cwd,
+    )
+    await helpers.writeFile(
+      'node_modules/parent/package.json',
+      JSON.stringify({ dependencies: { [name]: '^1.0.0' }, name: 'parent' }),
+      cwd,
+    )
+    await helpers.writeFile(
+      `node_modules/parent/node_modules/${name}/package.json`,
+      JSON.stringify({ name, repository: `https://github.com/${repo}` }),
+      cwd,
+    )
+  }
+
   /** The upstream repository, with its inbound policy committed where consent is now read from. */
   function accepts(
     inbound: unknown = { enabled: true },
@@ -404,6 +423,22 @@ describe('cross-repo', () => {
     expect(instance.issues.get(upstream)?.[0]?.title).toBe('Upstream friction')
     // The consumer's repository gets nothing.
     expect(instance.issues.get(repo)).toBeUndefined()
+  })
+
+  test('behavior: files on a target named by a transitive package', async () => {
+    const cwd = await helpers.repo({ remote })
+    const instance = await github({}, accepts())
+    await installDeep(cwd, 'viem', upstream)
+    await Store.write(
+      { body, severity: 'major', target: 'viem', title: 'Upstream friction' },
+      { id: 'a', root: cwd },
+    )
+
+    const result = await cli.data<Outcome>(['publish', '--cwd', cwd], env(instance.url))
+
+    expect(result.created).toEqual([
+      { id: 'a', issue: `${upstream}#1`, title: 'Upstream friction' },
+    ])
   })
 
   test('behavior: applies the labels the receiver asked for', async () => {

--- a/src/cli/commands/targets.test.ts
+++ b/src/cli/commands/targets.test.ts
@@ -1,3 +1,5 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
 import * as cli from '../../../test/cli.js'
 import { github } from '../../../test/github.js'
 import * as helpers from '../../../test/helpers.js'
@@ -9,13 +11,21 @@ type Listed = { targets: { name: string; repo: string }[] }
 async function install(
   cwd: string,
   name: string,
-  options: { bugs?: string; homepage?: string; repository?: string } = {},
+  options: {
+    bugs?: string
+    dependencies?: Record<string, string>
+    directory?: string
+    homepage?: string
+    packageName?: string
+    repository?: string
+  } = {},
 ): Promise<void> {
   await helpers.writeFile(
-    `node_modules/${name}/package.json`,
+    `${options.directory ?? 'node_modules'}/${name}/package.json`,
     JSON.stringify({
-      name,
+      name: options.packageName ?? name,
       ...(options.bugs ? { bugs: { url: options.bugs } } : {}),
+      ...(options.dependencies ? { dependencies: options.dependencies } : {}),
       ...(options.homepage ? { homepage: options.homepage } : {}),
       ...(options.repository ? { repository: { type: 'git', url: options.repository } } : {}),
     }),
@@ -91,6 +101,198 @@ test('behavior: includes optional dependencies', async () => {
   )
 
   expect(result.targets).toEqual([{ name: 'viem', repo: 'wevm/viem' }])
+})
+
+test('behavior: includes nested transitive dependencies', async () => {
+  const cwd = await helpers.repo()
+  await declare(cwd, { parent: '^1.0.0' })
+  await install(cwd, 'parent', { dependencies: { deep: '^1.0.0' } })
+  await install(cwd, 'deep', {
+    directory: 'node_modules/parent/node_modules',
+    repository: 'https://github.com/acme/deep',
+  })
+
+  const instance = await github({}, { files: { 'acme/deep': { [Config.file]: config(true) } } })
+  const result = await cli.data<Listed>(
+    ['targets', '--cwd', cwd],
+    env(instance.url, await helpers.tmpdir()),
+  )
+
+  expect(result.targets).toEqual([{ name: 'deep', repo: 'acme/deep' }])
+})
+
+test('behavior: includes transitive dependencies in a pnpm virtual store', async () => {
+  const cwd = await helpers.repo()
+  const parentStore = 'node_modules/.pnpm/parent@1.0.0/node_modules'
+  const deepStore = 'node_modules/.pnpm/deep@1.0.0/node_modules'
+  await declare(cwd, { parent: '^1.0.0' })
+  await install(cwd, 'parent', {
+    dependencies: { deep: '^1.0.0' },
+    directory: parentStore,
+  })
+  await install(cwd, 'deep', {
+    directory: deepStore,
+    repository: 'https://github.com/acme/deep',
+  })
+  await fs.symlink('.pnpm/parent@1.0.0/node_modules/parent', path.join(cwd, 'node_modules/parent'))
+  await fs.symlink('../../deep@1.0.0/node_modules/deep', path.join(cwd, parentStore, 'deep'))
+
+  const instance = await github({}, { files: { 'acme/deep': { [Config.file]: config(true) } } })
+  const result = await cli.data<Listed>(
+    ['targets', '--cwd', cwd],
+    env(instance.url, await helpers.tmpdir()),
+  )
+
+  expect(result.targets).toEqual([{ name: 'deep', repo: 'acme/deep' }])
+})
+
+test('behavior: lists an aliased dependency by its canonical package name', async () => {
+  const cwd = await helpers.repo()
+  await declare(cwd, { legacy: 'npm:actual@^1.0.0' })
+  await install(cwd, 'legacy', {
+    packageName: 'actual',
+    repository: 'https://github.com/acme/actual',
+  })
+
+  const instance = await github({}, { files: { 'acme/actual': { [Config.file]: config(true) } } })
+  const result = await cli.data<Listed>(
+    ['targets', '--cwd', cwd],
+    env(instance.url, await helpers.tmpdir()),
+  )
+
+  expect(result.targets).toEqual([{ name: 'actual', repo: 'acme/actual' }])
+})
+
+test('behavior: an exact direct package wins over an alias with the same canonical name', async () => {
+  const cwd = await helpers.repo()
+  await declare(cwd, { actual: '^2.0.0', legacy: 'npm:actual@^1.0.0' })
+  await install(cwd, 'actual', { repository: 'https://github.com/acme/new' })
+  await install(cwd, 'legacy', {
+    packageName: 'actual',
+    repository: 'https://github.com/acme/old',
+  })
+
+  const instance = await github(
+    {},
+    {
+      files: {
+        'acme/new': { [Config.file]: config(true) },
+        'acme/old': { [Config.file]: config(true) },
+      },
+    },
+  )
+  const result = await cli.data<Listed>(
+    ['targets', '--cwd', cwd],
+    env(instance.url, await helpers.tmpdir()),
+  )
+
+  expect(result.targets).toEqual([{ name: 'actual', repo: 'acme/new' }])
+  expect(instance.requests.some((request) => request.path.includes('acme/old'))).toBe(false)
+})
+
+test('behavior: a canonical transitive package wins over a colliding dependency alias', async () => {
+  const cwd = await helpers.repo()
+  await declare(cwd, { legacy: 'npm:actual@^1.0.0', parent: '^1.0.0' })
+  await install(cwd, 'legacy', {
+    packageName: 'actual',
+    repository: 'https://github.com/acme/actual',
+  })
+  await install(cwd, 'parent', { dependencies: { legacy: '^2.0.0' } })
+  await install(cwd, 'legacy', {
+    directory: 'node_modules/parent/node_modules',
+    repository: 'https://github.com/acme/legacy',
+  })
+
+  const instance = await github(
+    {},
+    {
+      files: {
+        'acme/actual': { [Config.file]: config(true) },
+        'acme/legacy': { [Config.file]: config(true) },
+      },
+    },
+  )
+  const result = await cli.data<Listed>(
+    ['targets', '--cwd', cwd],
+    env(instance.url, await helpers.tmpdir()),
+  )
+
+  expect(result.targets).toEqual([
+    { name: 'actual', repo: 'acme/actual' },
+    { name: 'legacy', repo: 'acme/legacy' },
+  ])
+})
+
+test('behavior: omits a transitive package whose installed copies name different repositories', async () => {
+  const cwd = await helpers.repo()
+  await declare(cwd, { one: '^1.0.0', two: '^1.0.0' })
+  await install(cwd, 'one', { dependencies: { shared: '^1.0.0' } })
+  await install(cwd, 'two', { dependencies: { shared: '^2.0.0' } })
+  await install(cwd, 'shared', {
+    directory: 'node_modules/one/node_modules',
+    repository: 'https://github.com/acme/one',
+  })
+  await install(cwd, 'shared', {
+    directory: 'node_modules/two/node_modules',
+    repository: 'https://github.com/acme/two',
+  })
+
+  const instance = await github()
+  const result = await cli.data<Listed>(
+    ['targets', '--cwd', cwd],
+    env(instance.url, await helpers.tmpdir()),
+  )
+
+  expect(result.targets).toEqual([])
+  expect(instance.requests).toEqual([])
+})
+
+test('behavior: includes a transitive package when only one installed copy names a repository', async () => {
+  const cwd = await helpers.repo()
+  await declare(cwd, { one: '^1.0.0', two: '^1.0.0' })
+  await install(cwd, 'one', { dependencies: { shared: '^1.0.0' } })
+  await install(cwd, 'two', { dependencies: { shared: '^2.0.0' } })
+  await install(cwd, 'shared')
+  await install(cwd, 'shared', {
+    directory: 'node_modules/two/node_modules',
+    repository: 'https://github.com/acme/shared',
+  })
+
+  const instance = await github({}, { files: { 'acme/shared': { [Config.file]: config(true) } } })
+  const result = await cli.data<Listed>(
+    ['targets', '--cwd', cwd],
+    env(instance.url, await helpers.tmpdir()),
+  )
+
+  expect(result.targets).toEqual([{ name: 'shared', repo: 'acme/shared' }])
+})
+
+test('behavior: a root package wins over a conflicting transitive copy', async () => {
+  const cwd = await helpers.repo()
+  await declare(cwd, { parent: '^1.0.0', shared: '^1.0.0' })
+  await install(cwd, 'parent', { dependencies: { shared: '^2.0.0' } })
+  await install(cwd, 'shared', { repository: 'https://github.com/acme/root' })
+  await install(cwd, 'shared', {
+    directory: 'node_modules/parent/node_modules',
+    repository: 'https://github.com/acme/nested',
+  })
+
+  const instance = await github(
+    {},
+    {
+      files: {
+        'acme/nested': { [Config.file]: config(true) },
+        'acme/root': { [Config.file]: config(true) },
+      },
+    },
+  )
+  const result = await cli.data<Listed>(
+    ['targets', '--cwd', cwd],
+    env(instance.url, await helpers.tmpdir()),
+  )
+
+  expect(result.targets).toEqual([{ name: 'shared', repo: 'acme/root' }])
+  expect(instance.requests.some((request) => request.path.includes('acme/nested'))).toBe(false)
 })
 
 test('behavior: applies each receiver allowFrom policy', async () => {

--- a/src/cli/commands/targets.ts
+++ b/src/cli/commands/targets.ts
@@ -33,8 +33,8 @@ export const targets = Cli.create('targets', {
   async run(c) {
     const { repo, root } = await context.resolve({ cwd: c.options.cwd })
 
-    // Consent lives on the target repository, so this needs a client. Works unauthenticated at 60
-    // requests an hour. The day-long cache keeps runs within that limit.
+    // Consent lives on the target repository, costing one request per distinct repository. Use any
+    // available token for GitHub's authenticated limit; the day-long cache makes later runs cheap.
     const token = await octokit.token({
       env: c.env,
       ...(c.options.token ? { token: c.options.token } : {}),

--- a/src/cli/internal/target.ts
+++ b/src/cli/internal/target.ts
@@ -17,11 +17,31 @@ const concurrency = 8
  */
 export function resolvers(options: resolvers.Options): Target.resolve.Options {
   const { outbound, client, root, self, store } = options
+  let declared: Promise<ReadonlySet<string>> | undefined
+  let indexed: Promise<Inventory> | undefined
+  const direct = () => (declared ??= rootDependencies(root))
+  const inventory = () => (indexed ??= installed(root))
 
   return {
     outbound,
     readConfig: reader({ client, ...(store ? { store } : {}) }),
-    readRepo: (name) => repoOf(name, root),
+    async readRepo(name) {
+      if ((await direct()).has(name)) {
+        const declared = await installedPackage(name, root)
+        if (!declared) return undefined
+        if (declared.name === name) return declared.repo
+      }
+
+      const indexed = await inventory()
+      const canonical = indexed.canonical.repositories.get(name)
+      if (canonical || indexed.canonical.names.has(name)) return canonical
+
+      const alias = indexed.aliases.repositories.get(name)
+      if (alias || indexed.aliases.names.has(name)) return alias
+
+      // Preserve support for manually installed root packages that the project does not declare.
+      return (await installedPackage(name, root))?.repo
+    },
     self,
   }
 }
@@ -98,35 +118,13 @@ export type Accepting = {
 /**
  * Dependencies that accept friction reports.
  *
- * Scans the declared dependencies rather than walking `node_modules`, which keeps the disk half of this a
- * handful of reads instead of thousands. Consent then costs one API call per distinct repository, cached
- * for a day.
+ * Walks the installed dependency graph so nested packages and pnpm's virtual store are both covered.
+ * Consent costs one API call per distinct repository, cached for a day.
  */
 export async function accepting(options: accepting.Options): Promise<readonly Accepting[]> {
   const { client, root, self, store } = options
 
-  const own = await fs
-    .readFile(path.join(root, 'package.json'), 'utf8')
-    .then((contents) => JSON.parse(contents) as Dependencies)
-    .catch(() => undefined)
-
-  const names = [
-    ...new Set([
-      ...Object.keys(own?.dependencies ?? {}),
-      ...Object.keys(own?.devDependencies ?? {}),
-      ...Object.keys(own?.optionalDependencies ?? {}),
-      ...Object.keys(own?.peerDependencies ?? {}),
-    ]),
-  ].sort()
-
-  const resolved = (
-    await Promise.all(
-      names.map(async (name) => {
-        const repo = await repoOf(name, root)
-        return repo ? { name, repo } : undefined
-      }),
-    )
-  ).filter((entry): entry is Accepting => entry !== undefined)
+  const resolved = (await installed(root)).targets
 
   // Several packages of one monorepo share a repository, and asking about it once is enough.
   const repos = [...new Set(resolved.map((entry) => entry.repo))]
@@ -164,32 +162,216 @@ type Dependencies = {
   dependencies?: Record<string, string> | undefined
   devDependencies?: Record<string, string> | undefined
   homepage?: string | undefined
+  name?: string | undefined
   optionalDependencies?: Record<string, string> | undefined
   peerDependencies?: Record<string, string> | undefined
   repository?: { url?: string | undefined } | string | undefined
 }
 
-/**
- * Repository an installed package declares.
- *
- * `repository` is the field npm defines for this, and it resolves 98.5% of what is actually installed
- * here. `homepage` and `bugs` are tried after it for the handful that omit it.
- */
-async function repoOf(name: string, root: string): Promise<string | undefined> {
-  const contents = await fs
-    .readFile(path.join(root, 'node_modules', name, 'package.json'), 'utf8')
-    .catch(() => undefined)
-  if (!contents) return undefined
+type Candidate = {
+  direct: boolean
+  directRepos: Set<string>
+  exactDirect: boolean
+  exactDirectRepo?: string | undefined
+  repos: Set<string>
+}
 
-  const declared = (() => {
-    try {
-      return JSON.parse(contents) as Dependencies
-    } catch {
-      return undefined
+type Index = {
+  names: ReadonlySet<string>
+  repositories: ReadonlyMap<string, string>
+}
+
+type Inventory = {
+  aliases: Index
+  canonical: Index
+  targets: readonly Accepting[]
+}
+
+type Pending = {
+  direct: boolean
+  from: string
+  name: string
+}
+
+/** Every installed package name that resolves to one unambiguous GitHub repository. */
+async function installed(root: string): Promise<Inventory> {
+  const own = await readPackage(path.join(root, 'package.json'))
+  if (!own)
+    return {
+      aliases: { names: new Set(), repositories: new Map() },
+      canonical: { names: new Set(), repositories: new Map() },
+      targets: [],
     }
-  })()
+
+  const pending: Pending[] = dependencies(own, true).map((name) => ({
+    direct: true,
+    from: root,
+    name,
+  }))
+  const aliases = new Map<string, Candidate>()
+  const canonical = new Map<string, Candidate>()
+  const listed = new Set<string>()
+  const seen = new Set<string>()
+
+  for (let index = 0; index < pending.length; index++) {
+    const next = pending[index]!
+    const file = await resolvePackage(next.name, next.from)
+    if (!file) continue
+
+    const declared = await readPackage(file)
+    const repo = declared ? repositoryOf(declared) : undefined
+    const canonicalName = declared?.name && packageParts(declared.name) ? declared.name : next.name
+    listed.add(canonicalName)
+
+    addCandidate(canonical, canonicalName, {
+      direct: next.direct,
+      exactDirect: next.direct && canonicalName === next.name,
+      repo,
+    })
+    if (canonicalName !== next.name)
+      addCandidate(aliases, next.name, {
+        direct: next.direct,
+        exactDirect: next.direct,
+        repo,
+      })
+
+    if (!declared || seen.has(file)) continue
+    seen.add(file)
+    for (const name of dependencies(declared, false))
+      pending.push({ direct: false, from: path.dirname(file), name })
+  }
+
+  const canonicalRepositories = repositories(canonical)
+
+  return {
+    aliases: { names: new Set(aliases.keys()), repositories: repositories(aliases) },
+    canonical: { names: new Set(canonical.keys()), repositories: canonicalRepositories },
+    targets: [...listed].sort().flatMap((name) => {
+      const repo = canonicalRepositories.get(name)
+      return repo ? [{ name, repo }] : []
+    }),
+  }
+}
+
+function addCandidate(
+  candidates: Map<string, Candidate>,
+  name: string,
+  options: { direct: boolean; exactDirect: boolean; repo: string | undefined },
+): void {
+  const { direct, exactDirect, repo } = options
+  const candidate = candidates.get(name) ?? {
+    direct: false,
+    directRepos: new Set<string>(),
+    exactDirect: false,
+    repos: new Set<string>(),
+  }
+  candidate.direct ||= direct
+  if (direct && repo) candidate.directRepos.add(repo)
+  if (exactDirect) {
+    candidate.exactDirect = true
+    candidate.exactDirectRepo = repo
+  }
+  if (repo) candidate.repos.add(repo)
+  candidates.set(name, candidate)
+}
+
+function repositories(candidates: ReadonlyMap<string, Candidate>): ReadonlyMap<string, string> {
+  const resolved = new Map<string, string>()
+  for (const [name, candidate] of [...candidates].sort(([a], [b]) => a.localeCompare(b))) {
+    const repo = candidate.exactDirect
+      ? candidate.exactDirectRepo
+      : candidate.direct
+        ? candidate.directRepos.size === 1
+          ? candidate.directRepos.values().next().value
+          : undefined
+        : candidate.repos.size === 1
+          ? candidate.repos.values().next().value
+          : undefined
+    if (repo) resolved.set(name, repo)
+  }
+  return resolved
+}
+
+async function rootDependencies(root: string): Promise<ReadonlySet<string>> {
+  const own = await readPackage(path.join(root, 'package.json'))
+  return new Set(own ? dependencies(own, true) : [])
+}
+
+/** Dependency names installed for a project or package. */
+function dependencies(declared: Dependencies, root: boolean): string[] {
+  return [
+    ...new Set([
+      ...Object.keys(declared.dependencies ?? {}),
+      ...(root ? Object.keys(declared.devDependencies ?? {}) : []),
+      ...Object.keys(declared.optionalDependencies ?? {}),
+      ...Object.keys(declared.peerDependencies ?? {}),
+    ]),
+  ].sort()
+}
+
+/** Resolves a dependency using Node's ancestor `node_modules` lookup from a real package path. */
+async function resolvePackage(name: string, from: string): Promise<string | undefined> {
+  const parts = packageParts(name)
+  if (!parts) return undefined
+
+  let directory = from
+  while (true) {
+    const candidate = path.join(directory, 'node_modules', ...parts, 'package.json')
+    const file = await fs.realpath(candidate).catch(() => undefined)
+    if (file) return file
+
+    const parent = path.dirname(directory)
+    if (parent === directory) return undefined
+    directory = parent
+  }
+}
+
+/** Reads an installed package's canonical name and repository. */
+async function installedPackage(
+  name: string,
+  root: string,
+): Promise<{ name: string; repo?: string | undefined } | undefined> {
+  const file = await resolvePackage(name, root)
+  if (!file) return undefined
+  const declared = await readPackage(file)
   if (!declared) return undefined
 
+  const canonical = declared.name && packageParts(declared.name) ? declared.name : name
+  const repo = repositoryOf(declared)
+  return { name: canonical, ...(repo ? { repo } : {}) }
+}
+
+/** Splits an npm package name without allowing it to escape `node_modules`. */
+function packageParts(name: string): string[] | undefined {
+  if (!name || name.includes('\\')) return undefined
+  const parts = name.split('/')
+  if (parts.some((part) => !part || part === '.' || part === '..')) return undefined
+  if (name.startsWith('@')) return parts.length === 2 ? parts : undefined
+  return parts.length === 1 ? parts : undefined
+}
+
+async function readPackage(file: string): Promise<Dependencies | undefined> {
+  const contents = await fs.readFile(file, 'utf8').catch(() => undefined)
+  return contents === undefined ? undefined : parsePackage(contents)
+}
+
+function parsePackage(contents: string): Dependencies | undefined {
+  try {
+    const value = JSON.parse(contents) as unknown
+    return typeof value === 'object' && value !== null && !Array.isArray(value)
+      ? (value as Dependencies)
+      : undefined
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Repository a package declares.
+ *
+ * `repository` is npm's standard field. `homepage` and `bugs` cover packages that omit it.
+ */
+function repositoryOf(declared: Dependencies): string | undefined {
   const { bugs, homepage, repository } = declared
   const candidates = [
     typeof repository === 'string' ? repository : repository?.url,


### PR DESCRIPTION
`frog targets` now discovers accepting packages throughout installed npm and pnpm dependency graphs. `frog log --target` and `frog publish` can resolve those transitive package names safely.