### PR TITLE
fix: repair private repository automation

### DIFF
--- a/app/app.yml
+++ b/app/app.yml
@@ -19,5 +19,5 @@ default_permissions:
   issues: write
   # Reads repository metadata, including the default branch.
   metadata: read
-  # Receives pull request events. Comments use the Issues permission.
+  # Receives pull request events and reads comments before updating them.
   pull_requests: read

--- a/app/src/handlers/pullRequest.ts
+++ b/app/src/handlers/pullRequest.ts
@@ -102,7 +102,7 @@ export declare namespace pullRequest {
     baseRef: string
     /** Installation client for the base repository. */
     client: Octokit
-    /** Lazily resolves an Issues-scoped client for pull-request comments. */
+    /** Lazily resolves a repository-scoped client for pull-request comments. */
     comments: () => Promise<Octokit>
     /** Head commit sha, reachable from the base repository even for a fork. */
     head: string

--- a/app/src/internal/client.test.ts
+++ b/app/src/internal/client.test.ts
@@ -2,7 +2,7 @@ import { App, Octokit } from 'octokit'
 import * as client from './client.js'
 
 describe('comments', () => {
-  test('security: grants one repository only Issues write access', async () => {
+  test('security: grants one repository no merge-capable access', async () => {
     const auth = vi.fn(async () => ({ token: 'installation-token' }))
     const app = { octokit: { auth } } as unknown as Pick<App, 'octokit'>
 
@@ -13,7 +13,10 @@ describe('comments', () => {
 
     expect(auth).toHaveBeenCalledWith({
       installationId: 42,
-      permissions: { issues: 'write' },
+      permissions: {
+        issues: 'write',
+        pull_requests: 'read',
+      },
       repositoryNames: ['frog'],
       type: 'installation',
     })

--- a/app/src/internal/client.ts
+++ b/app/src/internal/client.ts
@@ -6,7 +6,7 @@ type Authentication = { token: string }
 /**
  * Creates a client for pull-request comments without merge-capable Pull Requests write access.
  *
- * The token is limited to one repository and GitHub's documented Issues write alternative.
+ * The token can read pull requests and write issue comments in one repository.
  */
 export async function comments(
   app: Pick<App, 'octokit'>,
@@ -14,7 +14,10 @@ export async function comments(
 ): Promise<Octokit> {
   const authentication = (await app.octokit.auth({
     installationId: options.installation,
-    permissions: { issues: 'write' },
+    permissions: {
+      issues: 'write',
+      pull_requests: 'read',
+    },
     repositoryNames: [Github.split(options.repo).repo],
     type: 'installation',
   })) as Authentication

--- a/app/src/internal/oidc.test.ts
+++ b/app/src/internal/oidc.test.ts
@@ -115,9 +115,18 @@ test('behavior: verifies a token signed by GitHub for the trusted workflow', asy
     'https://token.actions.githubusercontent.com/.well-known/jwks',
     expect.objectContaining({
       headers: { accept: 'application/json' },
-      redirect: 'error',
+      redirect: 'manual',
     }),
   )
+})
+
+test('security: rejects redirected signing-key responses', async () => {
+  const fetch = vi.fn(async () => Response.redirect('https://attacker.test/keys', 302))
+
+  await expect(Oidc.verify(await token(), options({ fetch }))).rejects.toThrowError(
+    'Invalid GitHub Actions identity.',
+  )
+  expect(fetch).toHaveBeenCalledOnce()
 })
 
 test('security: caches the bounded GitHub signing-key set', async () => {

--- a/app/src/internal/oidc.ts
+++ b/app/src/internal/oidc.ts
@@ -259,7 +259,8 @@ async function fetchKeys(
 ): Promise<ReadonlyMap<string, JsonWebKey>> {
   const response = await fetch_(jwksUrl, {
     headers: { accept: 'application/json' },
-    redirect: 'error',
+    // Workers rejects `error`; manual returns redirects for the status guard below.
+    redirect: 'manual',
     signal: AbortSignal.timeout(5_000),
   })
   if (!response.ok) throw new Error()


### PR DESCRIPTION
Allows scoped App tokens to read private pull-request comments and uses Workers-compatible manual JWKS redirects. This repairs Frog comments and Action reconciliation in private repositories without granting merge access.