### PR TITLE
fix: grant pull request write access

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,16 +236,16 @@ Choose the **GitHub App** for pull-request feedback, forks, cross-repository rep
 processing. Choose **Action-only** when same-repository automation and avoiding a third-party App grant
 matter most. Choose one method per repository; running both can create duplicate issues.
 
-| Area           | GitHub App                                                                                              | Action-only                                                               |
-| -------------- | ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
-| Trust          | The App reads contents and pull requests and writes issues; the repository workflow owns source writes. | Uses this repository's `GITHUB_TOKEN`; no third-party App installation.   |
-| Scope          | Cross-repository reporting and reconciliation where installed and allowed.                              | Same repository only; `target:` entries stay deferred.                    |
-| Pull requests  | Reports during the pull request and posts or updates one comment.                                       | Reports after merge, without commenting on the author's pull request.     |
-| Forks          | Installation credentials work independently of the fork token.                                          | Cannot safely report from fork pull requests.                             |
-| Reconciliation | App webhooks signal the repository workflow, with durable retries and a daily sweep.                    | Repository issue events trigger the workflow, with a daily sweep.         |
-| Delivery       | The App returns issue state through OIDC; the repository workflow updates `frog/sync`.                  | The repository workflow reports issues and updates `frog/sync`.           |
-| Setup          | Needs the App, the App workflow, and Actions-created pull requests enabled.                             | Needs the Action-only workflow and Actions-created pull requests enabled. |
-| Operations     | Uses the App service and Actions minutes.                                                               | Uses Actions minutes; no service to run.                                  |
+| Area           | GitHub App                                                                             | Action-only                                                               |
+| -------------- | -------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| Trust          | Contents read; issues and pull requests write. The workflow owns source writes.        | Uses this repository's `GITHUB_TOKEN`; no third-party App installation.   |
+| Scope          | Cross-repository reporting and reconciliation where installed and allowed.             | Same repository only; `target:` entries stay deferred.                    |
+| Pull requests  | Reports during the pull request and posts or updates one comment.                      | Reports after merge, without commenting on the author's pull request.     |
+| Forks          | Installation credentials work independently of the fork token.                         | Cannot safely report from fork pull requests.                             |
+| Reconciliation | App webhooks signal the repository workflow, with durable retries and a daily sweep.   | Repository issue events trigger the workflow, with a daily sweep.         |
+| Delivery       | The App returns issue state through OIDC; the repository workflow updates `frog/sync`. | The repository workflow reports issues and updates `frog/sync`.           |
+| Setup          | Needs the App, the App workflow, and Actions-created pull requests enabled.            | Needs the Action-only workflow and Actions-created pull requests enabled. |
+| Operations     | Uses the App service and Actions minutes.                                              | Uses Actions minutes; no service to run.                                  |
 
 Before using either method, enable **Allow GitHub Actions to create and approve pull
 requests** under **Settings > Actions > General**. Pull-request checks created by `GITHUB_TOKEN` wait
@@ -310,11 +310,12 @@ jobs:
         uses: wevm/frog/reconcile@v1
 ```
 
-The App can read repository contents and pull requests and write issues, but it cannot write source.
-The workflow authenticates to the App with GitHub OIDC. The App returns issue state only; the Action
-derives every change from the checked-out reports and writes it with this repository's `GITHUB_TOKEN`.
-GitHub's Contents permission covers the whole selected repository, not only the friction log. Choose
-Action-only if you do not want to grant that read access.
+The App has read access to repository contents and write access to issues and pull requests, but it
+cannot write source. Its pull-request comment token is scoped to one repository and has no Contents
+access. The workflow authenticates to the App with GitHub OIDC. The App returns issue state only; the
+Action derives every change from the checked-out reports and writes it with this repository's
+`GITHUB_TOKEN`. GitHub's Contents permission covers the whole selected repository, not only the
+friction log. Choose Action-only if you do not want to grant that read access.
 
 ### Action-only Mode
 

--- a/app/README.md
+++ b/app/README.md
@@ -8,15 +8,18 @@ writes repository contents: each repository owns those writes through its Frog w
 
 The App requests only these repository permissions:
 
-| Permission    | Access | Purpose                                       |
-| ------------- | ------ | --------------------------------------------- |
-| Contents      | Read   | Read config and friction reports              |
-| Issues        | Write  | Report friction and post coordination signals |
-| Metadata      | Read   | Resolve repositories and default branches     |
-| Pull requests | Read   | Inspect pull-request reports                  |
+| Permission    | Access | Purpose                                              |
+| ------------- | ------ | ---------------------------------------------------- |
+| Contents      | Read   | Read config and friction reports                     |
+| Issues        | Write  | Report friction and post coordination signals        |
+| Metadata      | Read   | Resolve repositories and default branches            |
+| Pull requests | Write  | Inspect reports and post or update the App's comment |
 
 GitHub's Contents permission covers each selected repository, not only `.agents/friction-log`. Use
 Action-only when that repository-wide read grant is not acceptable.
+
+Pull requests write also permits pull-request metadata changes and reviews. Frog scopes its comment
+token to one repository and requests Pull requests write without Contents access.
 
 Source reconciliation runs in `.github/workflows/friction-log.yml`. The workflow grants
 `contents: write`, `pull-requests: write`, and `id-token: write` to
@@ -98,8 +101,8 @@ The `Main` workflow creates the queues, deploys the Worker, and syncs its secret
 1. **Create the App** from [`app.yml`](./app.yml) at `https://github.com/settings/apps/new`, or an
    organization's equivalent. Generate a webhook secret and private key.
 
-   Updating this manifest does not change an existing App. In its GitHub settings, set Contents and
-   Pull requests to read, Issues to write, Metadata to read, subscribe to Pull request and Issues
+   Updating this manifest does not change an existing App. In its GitHub settings, set Contents to
+   read, Pull requests and Issues to write, Metadata to read, subscribe to Pull request and Issues
    events, and remove the Push event.
 
 2. **Add the repository secrets** used by the deployment workflow:

--- a/app/app.yml
+++ b/app/app.yml
@@ -19,5 +19,5 @@ default_permissions:
   issues: write
   # Reads repository metadata, including the default branch.
   metadata: read
-  # Receives pull request events and reads comments before updating them.
-  pull_requests: read
+  # Reads pull request metadata and posts or updates the App-owned comment.
+  pull_requests: write

--- a/app/src/internal/client.test.ts
+++ b/app/src/internal/client.test.ts
@@ -2,7 +2,7 @@ import { App, Octokit } from 'octokit'
 import * as client from './client.js'
 
 describe('comments', () => {
-  test('security: grants one repository no merge-capable access', async () => {
+  test('security: scopes pull-request write to one repository', async () => {
     const auth = vi.fn(async () => ({ token: 'installation-token' }))
     const app = { octokit: { auth } } as unknown as Pick<App, 'octokit'>
 
@@ -14,8 +14,7 @@ describe('comments', () => {
     expect(auth).toHaveBeenCalledWith({
       installationId: 42,
       permissions: {
-        issues: 'write',
-        pull_requests: 'read',
+        pull_requests: 'write',
       },
       repositoryNames: ['frog'],
       type: 'installation',

--- a/app/src/internal/client.ts
+++ b/app/src/internal/client.ts
@@ -4,9 +4,9 @@ import { type App, Octokit } from 'octokit'
 type Authentication = { token: string }
 
 /**
- * Creates a client for pull-request comments without merge-capable Pull Requests write access.
+ * Creates a repository-scoped client for pull-request comments.
  *
- * The token can read pull requests and write issue comments in one repository.
+ * The token requests Pull Requests write without Contents access.
  */
 export async function comments(
   app: Pick<App, 'octokit'>,
@@ -15,8 +15,7 @@ export async function comments(
   const authentication = (await app.octokit.auth({
     installationId: options.installation,
     permissions: {
-      issues: 'write',
-      pull_requests: 'read',
+      pull_requests: 'write',
     },
     repositoryNames: [Github.split(options.repo).repo],
     type: 'installation',


### PR DESCRIPTION
Grant the GitHub App Pull requests write and scope comment tokens to one repository without Contents access. This lets Frog post and update its pull-request comment.