### PR TITLE
feat: install frog globally on init

### DIFF
--- a/.changeset/global-init-install.md
+++ b/.changeset/global-init-install.md
@@ -2,4 +2,4 @@
 'frog': patch
 ---
 
-Globally installed Frog during `frog init`, with package-manager detection and a `--no-global` opt-out.
+Added global installation to `npx frog init`, with package-manager detection and a `--no-global` opt-out.

--- a/.changeset/global-init-install.md
+++ b/.changeset/global-init-install.md
@@ -1,0 +1,5 @@
+---
+'frog': patch
+---
+
+Globally installed Frog during `frog init`, with package-manager detection and a `--no-global` opt-out.

--- a/README.md
+++ b/README.md
@@ -66,9 +66,7 @@ Run once per repository:
 npx frog init
 ```
 
-Frog detects the repository's package manager and installs itself globally with npm, pnpm, Yarn Classic,
-or Bun before scaffolding the friction log. Yarn Modern falls back to npm because it no longer supports
-global installs.
+Frog detects the repository's package manager and installs itself globally.
 
 Use `--no-global` only when `frog` is already available another way:
 
@@ -200,7 +198,7 @@ frog — Automated friction logging for agents.
 Usage: frog <command>
 
 Commands:
-  init     Create the friction log, config, and issue form.
+  init     Initializes Frog in a project.
   list     List entries with their state.
   log      Write a friction entry.
   publish  Report pending entries as GitHub issues.

--- a/README.md
+++ b/README.md
@@ -60,22 +60,20 @@ Run `npx frog init`, then set up Frog in my project.
 
 ## Install
 
+Run once per repository:
+
 ```bash
-npm i -D frog
+npx frog init
 ```
 
-```bash
-pnpm i -D frog
-```
+Frog detects the repository's package manager and installs itself globally with npm, pnpm, Yarn Classic,
+or Bun before scaffolding the friction log. Yarn Modern falls back to npm because it no longer supports
+global installs.
+
+Use `--no-global` only when `frog` is already available another way:
 
 ```bash
-bun i -D frog
-```
-
-Then, once per repository:
-
-```bash
-frog init
+npx frog init --no-global
 ```
 
 Frog supports two automation methods. If an agent is doing the setup, it should prompt the user before

--- a/src/cli/commands/init.test.ts
+++ b/src/cli/commands/init.test.ts
@@ -10,7 +10,7 @@ import * as Store from '../../Store.js'
 test('behavior: scaffolds the directory', async () => {
   const cwd = await helpers.repo()
 
-  expect(await cli.data(['init', '--cwd', cwd])).toMatchInlineSnapshot(`
+  expect(await cli.data(['init', '--no-global', '--cwd', cwd])).toMatchInlineSnapshot(`
     {
       "created": [
         ".agents/friction-log/README.md",
@@ -22,7 +22,7 @@ test('behavior: scaffolds the directory', async () => {
   `)
 
   // Automation changes repository access or workflows, so init leaves that choice to the user.
-  const { envelope } = await cli.run(['init', '--cwd', await helpers.repo()])
+  const { envelope } = await cli.run(['init', '--no-global', '--cwd', await helpers.repo()])
   const cta = envelope.meta?.['cta'] as
     | {
         commands?: { command?: string; description?: string }[]
@@ -82,7 +82,7 @@ test('behavior: scaffolds the directory', async () => {
 
 test('behavior: the issue form scaffolds local entries', async () => {
   const cwd = await helpers.repo()
-  await cli.data(['init', '--cwd', cwd])
+  await cli.data(['init', '--no-global', '--cwd', cwd])
 
   const contents = await fs.readFile(path.join(cwd, IssueForm.dir, IssueForm.filename), 'utf8')
   const form = IssueForm.parse(contents)
@@ -95,10 +95,10 @@ test('behavior: the issue form scaffolds local entries', async () => {
 
 test('behavior: re-running never clobbers local edits', async () => {
   const cwd = await helpers.repo()
-  await cli.data(['init', '--cwd', cwd])
+  await cli.data(['init', '--no-global', '--cwd', cwd])
   await fs.writeFile(path.join(cwd, Config.file), '{ "maxPerRun": 3 }', 'utf8')
 
-  expect(await cli.data(['init', '--cwd', cwd])).toMatchObject({
+  expect(await cli.data(['init', '--no-global', '--cwd', cwd])).toMatchObject({
     created: [],
     existing: [
       '.agents/friction-log/README.md',
@@ -115,7 +115,7 @@ test('behavior: leaves the automation choice alone', async () => {
   await fs.mkdir(path.dirname(workflow), { recursive: true })
   await fs.writeFile(workflow, 'custom\n', 'utf8')
 
-  await cli.data(['init', '--cwd', cwd])
+  await cli.data(['init', '--no-global', '--cwd', cwd])
 
   expect(await fs.readFile(workflow, 'utf8')).toBe('custom\n')
 })
@@ -126,7 +126,7 @@ test('behavior: never clobbers an existing friction issue form', async () => {
   await fs.mkdir(path.dirname(file), { recursive: true })
   await fs.writeFile(file, 'custom\n', 'utf8')
 
-  const result = await cli.data<{ existing: string[] }>(['init', '--cwd', cwd])
+  const result = await cli.data<{ existing: string[] }>(['init', '--no-global', '--cwd', cwd])
 
   expect(result.existing).toContain('.github/ISSUE_TEMPLATE/friction.yml')
   expect(await fs.readFile(file, 'utf8')).toBe('custom\n')
@@ -136,8 +136,84 @@ describe('--no-inbound', () => {
   test('behavior: disables friction reported by other repositories', async () => {
     const cwd = await helpers.repo()
 
-    await cli.data(['init', '--no-inbound', '--cwd', cwd])
+    await cli.data(['init', '--no-global', '--no-inbound', '--cwd', cwd])
 
     expect((await Config.resolve({ root: cwd })).inbound.enabled).toBe(false)
+  })
+})
+
+describe('global installation', () => {
+  test.each([
+    ['npm@11.0.0', 'npm', ['install', '--global', 'frog']],
+    ['pnpm@11.0.0', 'pnpm', ['add', '--global', 'frog']],
+    ['bun@1.2.0', 'bun', ['add', '--global', 'frog']],
+    ['yarn@1.22.22', 'yarn', ['global', 'add', 'frog']],
+    ['yarn@4.9.2', 'npm', ['install', '--global', 'frog']],
+  ])('behavior: installs with %s before scaffolding', async (value, executable, args) => {
+    const cwd = await helpers.repo()
+    const command = await helpers.fakeCommand(executable)
+    const manifest = `${JSON.stringify({ packageManager: value }, null, 2)}\n`
+    await helpers.writeFile('package.json', manifest, cwd)
+
+    await cli.data(['init', '--cwd', cwd], { PATH: command.bin })
+
+    expect(await command.calls()).toEqual([{ args, cwd }])
+    expect(await fs.readFile(path.join(cwd, 'package.json'), 'utf8')).toBe(manifest)
+    await expect(fs.stat(path.join(cwd, 'node_modules'))).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
+  test('behavior: resolves package-manager metadata from the repository root', async () => {
+    const cwd = await helpers.repo()
+    const nested = path.join(cwd, 'packages/app')
+    const command = await helpers.fakeCommand('pnpm')
+    await helpers.writeFile('package.json', '{"packageManager":"pnpm@11.0.0"}\n', cwd)
+    await fs.mkdir(nested, { recursive: true })
+
+    await cli.data(['init', '--cwd', nested], { PATH: command.bin })
+
+    expect(await command.calls()).toEqual([{ args: ['add', '--global', 'frog'], cwd }])
+  })
+
+  test('behavior: falls back to the invoking package manager', async () => {
+    const cwd = await helpers.repo()
+    const command = await helpers.fakeCommand('pnpm')
+
+    await cli.data(['init', '--cwd', cwd], {
+      PATH: command.bin,
+      npm_config_user_agent: 'pnpm/11.0.0 npm/? node/v24',
+    })
+
+    expect(await command.calls()).toEqual([{ args: ['add', '--global', 'frog'], cwd }])
+  })
+
+  test('behavior: --no-global skips package-manager resolution and installation', async () => {
+    const cwd = await helpers.repo()
+    const bin = await helpers.tmpdir()
+    await helpers.writeFile('package.json', '{"packageManager":"pnpm@11.0.0"}\n', cwd)
+
+    expect(await cli.data(['init', '--no-global', '--cwd', cwd], { PATH: bin })).toMatchObject({
+      created: expect.any(Array),
+      existing: [],
+    })
+  })
+
+  test('behavior: an install failure leaves the repository untouched', async () => {
+    const cwd = await helpers.repo()
+    const command = await helpers.fakeCommand('npm', { exitCode: 17 })
+
+    expect(
+      await cli.error(['init', '--cwd', cwd], {
+        PATH: command.bin,
+        npm_config_user_agent: 'npm/11.0.0 node/v24',
+      }),
+    ).toEqual({
+      code: 'INSTALL_FAILED',
+      message:
+        'Failed to install Frog globally: `npm install --global frog` exited with code 17. ' +
+        'Run the command directly for details, or rerun `npx frog init --no-global` to skip installation.',
+    })
+    expect(await command.calls()).toEqual([{ args: ['install', '--global', 'frog'], cwd }])
+    await expect(fs.stat(path.join(cwd, Store.dir))).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(fs.stat(path.join(cwd, IssueForm.dir))).rejects.toMatchObject({ code: 'ENOENT' })
   })
 })

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -5,7 +5,9 @@ import * as Config from '../../Config.js'
 import * as Entry from '../../Entry.js'
 import * as IssueForm from '../../IssueForm.js'
 import * as Store from '../../Store.js'
+import { attempt } from '../internal/attempt.js'
 import * as context from '../internal/context.js'
+import * as packageManager from '../internal/packageManager.js'
 
 /** The rules to paste into `AGENTS.md`. */
 export const rules =
@@ -95,8 +97,22 @@ ${Entry.sections
 
 export const init = Cli.create('init', {
   description: 'Create the friction log, config, and issue form.',
+  env: z.object({
+    PATH: z.string().optional().describe('Executable search path used for global installation.'),
+    npm_config_user_agent: z
+      .string()
+      .optional()
+      .describe(
+        'Invoking package manager, used when the repository has no package-manager metadata.',
+      ),
+  }),
   options: z.object({
     cwd: context.cwdOption,
+    global: z
+      .boolean()
+      .default(true)
+      .optional()
+      .describe('Install Frog globally. Pass `--no-global` to skip during setup.'),
     inbound: z
       .boolean()
       .default(true)
@@ -112,6 +128,16 @@ export const init = Cli.create('init', {
   }),
   async run(c) {
     const { root } = await context.resolve({ cwd: c.options.cwd })
+
+    if (c.options.global !== false) {
+      const command = await packageManager.resolve({ env: c.env, root })
+      const installed = await attempt(packageManager.install(command, { cwd: root, env: c.env }))
+      if (!installed.ok)
+        return c.error({
+          code: installed.code,
+          message: installed.message,
+        })
+    }
 
     const files = [
       [`${Store.dir}/README.md`, readme()],

--- a/src/cli/internal/packageManager.test.ts
+++ b/src/cli/internal/packageManager.test.ts
@@ -1,0 +1,80 @@
+import * as helpers from '../../../test/helpers.js'
+import * as packageManager from './packageManager.js'
+
+describe('resolve', () => {
+  test.each([
+    ['npm@11.0.0', 'npm install --global frog'],
+    ['pnpm@11.0.0', 'pnpm add --global frog'],
+    ['bun@1.2.0', 'bun add --global frog'],
+    ['yarn@1.22.22', 'yarn global add frog'],
+    ['yarn@4.9.2', 'npm install --global frog'],
+  ])('behavior: resolves %s from package.json', async (value, expected) => {
+    const root = await helpers.tmpdir()
+    await helpers.writeFile('package.json', JSON.stringify({ packageManager: value }), root)
+
+    expect(packageManager.format(await packageManager.resolve({ root }))).toBe(expected)
+  })
+
+  test.each([
+    ['package-lock.json', '', 'npm install --global frog'],
+    ['npm-shrinkwrap.json', '', 'npm install --global frog'],
+    ['pnpm-lock.yaml', '', 'pnpm add --global frog'],
+    ['pnpm-workspace.yaml', '', 'pnpm add --global frog'],
+    ['bun.lock', '', 'bun add --global frog'],
+    ['bun.lockb', '', 'bun add --global frog'],
+    ['yarn.lock', '# yarn lockfile v1\n', 'yarn global add frog'],
+    ['yarn.lock', '__metadata:\n  version: 8\n', 'npm install --global frog'],
+    ['.yarnrc.yml', 'nodeLinker: node-modules\n', 'npm install --global frog'],
+  ])('behavior: resolves %s from repository markers', async (file, contents, expected) => {
+    const root = await helpers.tmpdir()
+    await helpers.writeFile(file, contents, root)
+
+    expect(packageManager.format(await packageManager.resolve({ root }))).toBe(expected)
+  })
+
+  test('behavior: packageManager takes precedence over conflicting lockfiles', async () => {
+    const root = await helpers.tmpdir()
+    await helpers.writeFile('package.json', JSON.stringify({ packageManager: 'pnpm@11.0.0' }), root)
+    await helpers.writeFile('package-lock.json', '', root)
+    await helpers.writeFile('bun.lock', '', root)
+
+    expect(packageManager.format(await packageManager.resolve({ root }))).toBe(
+      'pnpm add --global frog',
+    )
+  })
+
+  test('behavior: conflicting repository markers fall back to npm', async () => {
+    const root = await helpers.tmpdir()
+    await helpers.writeFile('pnpm-lock.yaml', '', root)
+    await helpers.writeFile('bun.lock', '', root)
+
+    expect(packageManager.format(await packageManager.resolve({ root }))).toBe(
+      'npm install --global frog',
+    )
+  })
+
+  test.each([
+    ['npm/11.0.0 node/v24', 'npm install --global frog'],
+    ['pnpm/11.0.0 npm/? node/v24', 'pnpm add --global frog'],
+    ['bun/1.2.0 npm/? node/v24', 'bun add --global frog'],
+    ['yarn/1.22.22 npm/? node/v24', 'yarn global add frog'],
+    ['yarn/4.9.2 npm/? node/v24', 'npm install --global frog'],
+  ])('behavior: resolves the invoking user agent %s as a fallback', async (value, expected) => {
+    const root = await helpers.tmpdir()
+
+    expect(
+      packageManager.format(
+        await packageManager.resolve({
+          env: { npm_config_user_agent: value },
+          root,
+        }),
+      ),
+    ).toBe(expected)
+  })
+
+  test('behavior: missing metadata falls back to npm', async () => {
+    expect(
+      packageManager.format(await packageManager.resolve({ root: await helpers.tmpdir() })),
+    ).toBe('npm install --global frog')
+  })
+})

--- a/src/cli/internal/packageManager.ts
+++ b/src/cli/internal/packageManager.ts
@@ -1,0 +1,151 @@
+import { spawn } from 'node:child_process'
+import fs from 'node:fs/promises'
+import path from 'node:path'
+
+export type Command = {
+  args: readonly string[]
+  executable: 'bun' | 'npm' | 'pnpm' | 'yarn'
+}
+
+type Manager = 'bun' | 'npm' | 'pnpm' | 'yarnClassic' | 'yarnModern'
+
+const commands = {
+  bun: { args: ['add', '--global', 'frog'], executable: 'bun' },
+  npm: { args: ['install', '--global', 'frog'], executable: 'npm' },
+  pnpm: { args: ['add', '--global', 'frog'], executable: 'pnpm' },
+  yarnClassic: { args: ['global', 'add', 'frog'], executable: 'yarn' },
+  // Yarn Modern removed global installs. `npx frog init` guarantees npm is available as a fallback.
+  yarnModern: { args: ['install', '--global', 'frog'], executable: 'npm' },
+} as const satisfies Record<Manager, Command>
+
+/** Formats a package-manager command for display. */
+export function format(command: Command): string {
+  return [command.executable, ...command.args].join(' ')
+}
+
+/** Installs Frog globally with the resolved package manager. */
+export async function install(command: Command, options: install.Options): Promise<void> {
+  const env = { ...process.env }
+  for (const [name, value] of Object.entries(options.env ?? {}))
+    if (value !== undefined) env[name] = value
+  // Windows package-manager shims are `.cmd` files, so invoke cmd.exe without deprecated shell
+  // argument concatenation.
+  const executable =
+    process.platform === 'win32' ? (env['ComSpec'] ?? 'cmd.exe') : command.executable
+  const args =
+    process.platform === 'win32' ? ['/d', '/s', '/c', format(command)] : [...command.args]
+
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(executable, args, {
+      cwd: options.cwd,
+      env,
+      stdio: 'ignore',
+      windowsHide: true,
+    })
+
+    child.once('error', () => reject(new InstallError(command, 'could not be started')))
+    child.once('close', (code, signal) => {
+      if (code === 0) return resolve()
+      const detail = signal
+        ? `was terminated by ${signal}`
+        : `exited with code ${code ?? 'unknown'}`
+      reject(new InstallError(command, detail))
+    })
+  })
+}
+
+export declare namespace install {
+  type Options = {
+    cwd: string
+    env?: Record<string, string | undefined> | undefined
+  }
+}
+
+/** Resolves the global-install command from repository metadata and the invoking package manager. */
+export async function resolve(options: resolve.Options): Promise<Command> {
+  const declared = await fromManifest(options.root)
+  if (declared) return commands[declared]
+
+  const marked = await fromMarkers(options.root)
+  if (marked) return commands[marked]
+
+  return commands[fromUserAgent(options.env?.npm_config_user_agent) ?? 'npm']
+}
+
+export declare namespace resolve {
+  type Options = {
+    env?: {
+      npm_config_user_agent?: string | undefined
+    }
+    root: string
+  }
+}
+
+async function exists(file: string): Promise<boolean> {
+  return fs.stat(file).then(
+    () => true,
+    () => false,
+  )
+}
+
+async function fromManifest(root: string): Promise<Manager | undefined> {
+  const value = await fs
+    .readFile(path.join(root, 'package.json'), 'utf8')
+    .then((contents) => (JSON.parse(contents) as { packageManager?: unknown }).packageManager)
+    .catch(() => undefined)
+  if (typeof value !== 'string') return undefined
+
+  const match = /^(bun|npm|pnpm|yarn)@([^+]+)/.exec(value)
+  if (!match) return undefined
+  const [, name, version] = match
+  if (name !== 'yarn') return name as Exclude<Manager, 'yarnClassic' | 'yarnModern'>
+  return version?.startsWith('1.') ? 'yarnClassic' : 'yarnModern'
+}
+
+async function fromMarkers(root: string): Promise<Manager | undefined> {
+  const markers = {
+    bun: ['bun.lock', 'bun.lockb'],
+    npm: ['package-lock.json', 'npm-shrinkwrap.json'],
+    pnpm: ['pnpm-lock.yaml', 'pnpm-workspace.yaml'],
+    yarn: ['yarn.lock', '.yarnrc.yml'],
+  } as const
+  const found = (
+    await Promise.all(
+      Object.entries(markers).map(async ([manager, files]) => ({
+        found: (await Promise.all(files.map((file) => exists(path.join(root, file))))).some(
+          Boolean,
+        ),
+        manager,
+      })),
+    )
+  ).filter((entry) => entry.found)
+
+  if (found.length !== 1) return undefined
+  const manager = found[0]?.manager
+  if (manager !== 'yarn') return manager as Exclude<Manager, 'yarnClassic' | 'yarnModern'>
+  if (await exists(path.join(root, '.yarnrc.yml'))) return 'yarnModern'
+
+  const lock = await fs.readFile(path.join(root, 'yarn.lock'), 'utf8').catch(() => '')
+  if (lock.includes('# yarn lockfile v1')) return 'yarnClassic'
+  return 'yarnModern'
+}
+
+function fromUserAgent(value: string | undefined): Manager | undefined {
+  const match = /^(bun|npm|pnpm|yarn)\/([^\s]+)/.exec(value ?? '')
+  if (!match) return undefined
+  const [, name, version] = match
+  if (name !== 'yarn') return name as Exclude<Manager, 'yarnClassic' | 'yarnModern'>
+  return version?.startsWith('1.') ? 'yarnClassic' : 'yarnModern'
+}
+
+class InstallError extends Error {
+  readonly code = 'INSTALL_FAILED'
+
+  constructor(command: Command, detail: string) {
+    super(
+      `Failed to install Frog globally: \`${format(command)}\` ${detail}. ` +
+        'Run the command directly for details, or rerun `npx frog init --no-global` to skip installation.',
+    )
+    this.name = 'PackageManager.InstallError'
+  }
+}

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -18,6 +18,62 @@ export async function tmpdir(): Promise<string> {
   return dir
 }
 
+/** Creates an executable that records its working directory and arguments. */
+export async function fakeCommand(
+  name: string,
+  options: fakeCommand.Options = {},
+): Promise<fakeCommand.Result> {
+  const bin = await tmpdir()
+  const file = path.join(bin, process.platform === 'win32' ? `${name}.cjs` : name)
+  const log = path.join(bin, 'calls.jsonl')
+  const script = `#!${process.execPath}
+const fs = require('node:fs')
+fs.appendFileSync(${JSON.stringify(log)}, JSON.stringify({
+  args: process.argv.slice(2),
+  cwd: process.cwd(),
+}) + '\\n')
+process.stdout.write('fake stdout\\n')
+process.stderr.write('fake stderr\\n')
+process.exit(${options.exitCode ?? 0})
+`
+  await fs.writeFile(file, script, { mode: 0o755 })
+
+  if (process.platform === 'win32')
+    await fs.writeFile(
+      path.join(bin, `${name}.cmd`),
+      `@echo off\r\n"${process.execPath}" "${file}" %*\r\n`,
+      'utf8',
+    )
+
+  return {
+    bin,
+    async calls() {
+      const contents = await fs.readFile(log, 'utf8').catch(() => '')
+      return contents
+        .trim()
+        .split('\n')
+        .filter(Boolean)
+        .map((line) => JSON.parse(line) as fakeCommand.Call)
+    },
+  }
+}
+
+export declare namespace fakeCommand {
+  type Call = {
+    args: string[]
+    cwd: string
+  }
+
+  type Options = {
+    exitCode?: number | undefined
+  }
+
+  type Result = {
+    bin: string
+    calls(): Promise<Call[]>
+  }
+}
+
 /** Runs git in `cwd`, returning trimmed stdout. */
 export async function git(args: readonly string[], cwd: string): Promise<string> {
   const { stdout } = await exec('git', [...args], { cwd })


### PR DESCRIPTION
Globally installs Frog during `frog init` using the repository's package manager, with npm fallback for ambiguous metadata and Yarn Modern. Adds `--no-global` for callers that manage availability themselves.