### PR TITLE
fix: update reports in place

### DIFF
--- a/.changeset/steady-reports-update.md
+++ b/.changeset/steady-reports-update.md
@@ -1,0 +1,5 @@
+---
+'frog': patch
+---
+
+Updated existing reports in place and reserved recurrence comments for new friction entries.

--- a/app/src/handlers/pullRequest.test.ts
+++ b/app/src/handlers/pullRequest.test.ts
@@ -247,52 +247,10 @@ test('behavior: a severity-only edit updates the original issue', async () => {
       ],
     },
     {
-      files: { [base]: { [path]: entry(previous.title) } },
-      head: { [base]: { [path]: entry(previous.title, { severity: 'major' }) } },
-    },
-  )
-
-  const report = await run(instance.url)
-
-  expect(report.created).toEqual([{ id: 'a', issue: `${base}#1` }])
-  expect(Github.parseMarker(instance.issues.get(base)?.[0]?.body)?.severity).toBe('major')
-  expect(instance.comments(base, 1)).toEqual([])
-})
-
-test('behavior: renaming a report frees its old title for a new entry', async () => {
-  const path = `${dir}/a/friction.md`
-  const previous = {
-    body: 'The filter was swallowed.',
-    id: 'a',
-    severity: 'minor',
-    title: 'Filters ignored',
-  } as const
-  const instance = await github(
-    {
-      [base]: [
-        {
-          body: Github.renderBody({
-            body: previous.body,
-            marker: {
-              hash: Github.hash(previous.title),
-              origin: base,
-              path,
-              severity: previous.severity,
-            },
-            occurrence: Github.occurrence({ entry: previous, origin: base }),
-            report: Github.report({ entry: previous, origin: base }),
-            revision: Github.revision({ entry: previous, origin: base }),
-          }),
-          title: previous.title,
-        },
-      ],
-    },
-    {
-      files: { [base]: { [path]: entry(previous.title) } },
+      files: { [base]: { [path]: entry(previous.title, { issue: `${base}#1` }) } },
       head: {
         [base]: {
-          [path]: entry('Filters renamed'),
-          [`${dir}/b/friction.md`]: entry(previous.title),
+          [path]: entry(previous.title, { issue: `${base}#1`, severity: 'major' }),
         },
       },
     },
@@ -300,16 +258,69 @@ test('behavior: renaming a report frees its old title for a new entry', async ()
 
   const report = await run(instance.url)
 
-  expect(report.created).toEqual([
-    { id: 'a', issue: `${base}#1` },
-    { id: 'b', issue: `${base}#2` },
-  ])
-  expect(instance.issues.get(base)?.map((issue) => issue.title)).toEqual([
-    'Filters renamed',
-    'Filters ignored',
-  ])
+  expect(report.created).toEqual([{ id: 'a', issue: `${base}#1` }])
+  expect(report.linked).toEqual([])
+  expect(Github.parseMarker(instance.issues.get(base)?.[0]?.body)?.severity).toBe('major')
   expect(instance.comments(base, 1)).toEqual([])
 })
+
+test.each([
+  ['pending', {}],
+  ['linked', { issue: `${base}#1` }],
+] as const)(
+  'behavior: renaming a %s report frees its old title for a new entry',
+  async (_, link) => {
+    const path = `${dir}/a/friction.md`
+    const previous = {
+      body: 'The filter was swallowed.',
+      id: 'a',
+      severity: 'minor',
+      title: 'Filters ignored',
+    } as const
+    const instance = await github(
+      {
+        [base]: [
+          {
+            body: Github.renderBody({
+              body: previous.body,
+              marker: {
+                hash: Github.hash(previous.title),
+                origin: base,
+                path,
+                severity: previous.severity,
+              },
+              occurrence: Github.occurrence({ entry: previous, origin: base }),
+              report: Github.report({ entry: previous, origin: base }),
+              revision: Github.revision({ entry: previous, origin: base }),
+            }),
+            title: previous.title,
+          },
+        ],
+      },
+      {
+        files: { [base]: { [path]: entry(previous.title, link) } },
+        head: {
+          [base]: {
+            [path]: entry('Filters renamed', link),
+            [`${dir}/b/friction.md`]: entry(previous.title),
+          },
+        },
+      },
+    )
+
+    const report = await run(instance.url)
+
+    expect(report.created).toEqual([
+      { id: 'a', issue: `${base}#1` },
+      { id: 'b', issue: `${base}#2` },
+    ])
+    expect(instance.issues.get(base)?.map((issue) => issue.title)).toEqual([
+      'Filters renamed',
+      'Filters ignored',
+    ])
+    expect(instance.comments(base, 1)).toEqual([])
+  },
+)
 
 test('behavior: an edited entry updates once', async () => {
   const instance = await github(
@@ -388,6 +399,36 @@ test('behavior: an already-linked entry is listed, not filed again', async () =>
     linked: [{ id: 'a', issue: `${base}#1` }],
   })
   expect(instance.issues.get(base)).toHaveLength(1)
+})
+
+test('security: a linked edit does not replace a missing issue', async () => {
+  const path = `${dir}/a/friction.md`
+  const issue = `${base}#99`
+  const instance = await github(
+    {},
+    {
+      files: { [base]: { [path]: entry('Filters ignored', { issue }) } },
+      head: {
+        [base]: { [path]: entry('Filters ignored', { issue, severity: 'major' }) },
+      },
+    },
+  )
+
+  const report = await run(instance.url)
+
+  expect(report).toMatchObject({
+    commented: [],
+    created: [],
+    deferred: [
+      {
+        code: 'LINK_INVALID',
+        id: 'a',
+        reason: `The linked issue \`${issue}\` is missing or does not carry this Frog report.`,
+      },
+    ],
+    linked: [],
+  })
+  expect(instance.issues.get(base)).toBeUndefined()
 })
 
 test('behavior: a malformed entry is reported without stopping the rest', async () => {
@@ -503,6 +544,74 @@ describe('cross-repo', () => {
     expect(Github.parseMarker(instance.issues.get(upstream)?.[0]?.body)).toMatchObject({
       origin: base,
     })
+  })
+
+  test('behavior: linked edits keep their established destination', async () => {
+    const alternate = 'wevm/ox'
+    const path = `${dir}/a/friction.md`
+    const previous = {
+      body: 'The filter was swallowed.',
+      id: 'a',
+      issue: `${upstream}#1`,
+      severity: 'minor',
+      target: 'viem',
+      title: 'Upstream friction',
+    } as const
+    const instance = await github(
+      {
+        [upstream]: [
+          {
+            body: Github.renderBody({
+              body: previous.body,
+              marker: {
+                hash: Github.hash(previous.title),
+                origin: base,
+                path,
+                severity: previous.severity,
+              },
+              occurrence: Github.occurrence({ entry: previous, origin: base }),
+              report: Github.report({ entry: previous, origin: base }),
+              revision: Github.revision({ entry: previous, origin: base }),
+            }),
+            title: previous.title,
+          },
+        ],
+      },
+      {
+        files: {
+          [base]: {
+            [path]: entry(previous.title, { issue: previous.issue, target: previous.target }),
+          },
+          [alternate]: {
+            [`${dir}/config.json`]: JSON.stringify({ inbound: { enabled: true } }),
+          },
+          [upstream]: {
+            [`${dir}/config.json`]: JSON.stringify({ inbound: { enabled: true } }),
+          },
+        },
+        head: {
+          [base]: {
+            [path]: entry(previous.title, {
+              issue: previous.issue,
+              severity: 'major',
+              target: 'ox',
+            }),
+          },
+        },
+        packages: { ox: alternate, viem: upstream },
+      },
+    )
+
+    const report = await run(instance.url, {
+      installed: {
+        [alternate]: client(instance.url),
+        [upstream]: client(instance.url),
+      },
+    })
+
+    expect(report.created).toEqual([{ id: 'a', issue: `${upstream}#1` }])
+    expect(Github.parseMarker(instance.issues.get(upstream)?.[0]?.body)?.severity).toBe('major')
+    expect(instance.issues.get(alternate)).toBeUndefined()
   })
 
   // No installation on the receiver means no token, so GitHub itself prevents the filing.

--- a/app/src/handlers/pullRequest.test.ts
+++ b/app/src/handlers/pullRequest.test.ts
@@ -197,7 +197,7 @@ test('behavior: a title edit reuses the issue carrying the occurrence', async ()
   expect(instance.comments(base, 1)).toHaveLength(0)
 })
 
-test('behavior: a title edit reuses an occurrence carried by a comment', async () => {
+test('behavior: title and body edits keep updating the original issue', async () => {
   const instance = await github(
     {},
     { head: { [base]: { [`${dir}/a/friction.md`]: entry('Filters ignored') } } },
@@ -210,13 +210,14 @@ test('behavior: a title edit reuses an occurrence carried by a comment', async (
   instance.write(base, `${dir}/a/friction.md`, changed.replace('ignored', 'renamed'), 'head')
   const third = await run(instance.url)
 
-  expect(third.commented).toEqual([{ id: 'a', issue: `${base}#1` }])
+  expect(third.created).toEqual([{ id: 'a', issue: `${base}#1` }])
   expect(instance.issues.get(base)).toHaveLength(1)
-  expect(instance.comments(base, 1)).toHaveLength(1)
+  expect(instance.issues.get(base)?.[0]?.title).toBe('Filters renamed')
+  expect(Github.parseBody(instance.issues.get(base)?.[0]?.body)).toBe('The filter was dropped.')
+  expect(instance.comments(base, 1)).toHaveLength(0)
 })
 
-// The one repeat worth having: the entry changed, so the issue should hear about it.
-test('behavior: an edited entry comments once', async () => {
+test('behavior: an edited entry updates once', async () => {
   const instance = await github(
     {},
     { head: { [base]: { [`${dir}/a/friction.md`]: entry('Filters ignored') } } },
@@ -233,12 +234,11 @@ test('behavior: an edited entry comments once', async () => {
   await run(instance.url)
 
   expect(instance.issues.get(base)).toHaveLength(1)
-  expect(instance.comments(base, 1)).toHaveLength(1)
+  expect(Github.parseBody(instance.issues.get(base)?.[0]?.body)).toBe('The filter was dropped.')
+  expect(instance.comments(base, 1)).toHaveLength(0)
 })
 
-// The edit that a title-shaped hash would have thrown away: punctuation and case only. Adding the `--`
-// a command was missing changes what the report means, so the issue has to hear about it.
-test('behavior: an edit of only punctuation still comments', async () => {
+test('behavior: an edit of only punctuation still updates', async () => {
   const instance = await github(
     {},
     { head: { [base]: { [`${dir}/a/friction.md`]: entry('Filters ignored') } } },
@@ -256,7 +256,10 @@ test('behavior: an edit of only punctuation still comments', async () => {
   instance.write(base, `${dir}/a/friction.md`, after, 'head')
   await run(instance.url)
 
-  expect(instance.comments(base, 1)).toHaveLength(1)
+  expect(Github.parseBody(instance.issues.get(base)?.[0]?.body)).toBe(
+    'Run `pnpm test -- src/foo.test.ts`.',
+  )
+  expect(instance.comments(base, 1)).toHaveLength(0)
 })
 
 test('behavior: concurrent deliveries with the same title open one issue', async () => {

--- a/app/src/handlers/pullRequest.test.ts
+++ b/app/src/handlers/pullRequest.test.ts
@@ -217,6 +217,100 @@ test('behavior: title and body edits keep updating the original issue', async ()
   expect(instance.comments(base, 1)).toHaveLength(0)
 })
 
+test('behavior: a severity-only edit updates the original issue', async () => {
+  const path = `${dir}/a/friction.md`
+  const previous = {
+    body: 'The filter was swallowed.',
+    id: 'a',
+    severity: 'minor',
+    title: 'Filters ignored',
+  } as const
+  const marker = {
+    hash: Github.hash(previous.title),
+    origin: base,
+    path,
+    severity: previous.severity,
+  }
+  const instance = await github(
+    {
+      [base]: [
+        {
+          body: Github.renderBody({
+            body: previous.body,
+            marker,
+            occurrence: Github.occurrence({ entry: previous, origin: base }),
+            report: Github.report({ entry: previous, origin: base }),
+            revision: Github.revision({ entry: previous, origin: base }),
+          }),
+          title: previous.title,
+        },
+      ],
+    },
+    {
+      files: { [base]: { [path]: entry(previous.title) } },
+      head: { [base]: { [path]: entry(previous.title, { severity: 'major' }) } },
+    },
+  )
+
+  const report = await run(instance.url)
+
+  expect(report.created).toEqual([{ id: 'a', issue: `${base}#1` }])
+  expect(Github.parseMarker(instance.issues.get(base)?.[0]?.body)?.severity).toBe('major')
+  expect(instance.comments(base, 1)).toEqual([])
+})
+
+test('behavior: renaming a report frees its old title for a new entry', async () => {
+  const path = `${dir}/a/friction.md`
+  const previous = {
+    body: 'The filter was swallowed.',
+    id: 'a',
+    severity: 'minor',
+    title: 'Filters ignored',
+  } as const
+  const instance = await github(
+    {
+      [base]: [
+        {
+          body: Github.renderBody({
+            body: previous.body,
+            marker: {
+              hash: Github.hash(previous.title),
+              origin: base,
+              path,
+              severity: previous.severity,
+            },
+            occurrence: Github.occurrence({ entry: previous, origin: base }),
+            report: Github.report({ entry: previous, origin: base }),
+            revision: Github.revision({ entry: previous, origin: base }),
+          }),
+          title: previous.title,
+        },
+      ],
+    },
+    {
+      files: { [base]: { [path]: entry(previous.title) } },
+      head: {
+        [base]: {
+          [path]: entry('Filters renamed'),
+          [`${dir}/b/friction.md`]: entry(previous.title),
+        },
+      },
+    },
+  )
+
+  const report = await run(instance.url)
+
+  expect(report.created).toEqual([
+    { id: 'a', issue: `${base}#1` },
+    { id: 'b', issue: `${base}#2` },
+  ])
+  expect(instance.issues.get(base)?.map((issue) => issue.title)).toEqual([
+    'Filters renamed',
+    'Filters ignored',
+  ])
+  expect(instance.comments(base, 1)).toEqual([])
+})
+
 test('behavior: an edited entry updates once', async () => {
   const instance = await github(
     {},

--- a/app/src/handlers/pullRequest.ts
+++ b/app/src/handlers/pullRequest.ts
@@ -81,7 +81,12 @@ function introduced(
   const existing = new Map(base.map((entry) => [entry.id, entry]))
   return head.filter((entry) => {
     const previous = existing.get(entry.id)
-    return !previous || previous.body !== entry.body || previous.title !== entry.title
+    return (
+      !previous ||
+      previous.body !== entry.body ||
+      previous.severity !== entry.severity ||
+      previous.title !== entry.title
+    )
   })
 }
 

--- a/app/src/handlers/pullRequest.ts
+++ b/app/src/handlers/pullRequest.ts
@@ -37,15 +37,21 @@ export async function pullRequest(options: pullRequest.Options): Promise<comment
   // request.
   const before = await Repository.read(client, { ref: baseRef, repo: base })
   const changed = introduced(contents.entries, before.entries)
+  const existing = new Map(before.entries.map((entry) => [entry.id, entry]))
+  const updates = new Set(
+    changed
+      .filter((entry) => entry.issue && existing.get(entry.id)?.issue === entry.issue)
+      .map((entry) => entry.id),
+  )
 
   const malformed = contents.malformed
-  const { linked, pending } = filing.partition(changed)
+  const { linked } = filing.partition(changed)
 
   const filed = await filing.file({
     app: options.app,
     client,
     config: settings,
-    entries: pending,
+    entries: changed.filter((entry) => !entry.issue || updates.has(entry.id)),
     installation,
     origin: base,
     pr: `${base}#${pr}`,
@@ -58,7 +64,7 @@ export async function pullRequest(options: pullRequest.Options): Promise<comment
     commented: filed.commented,
     created: filed.created,
     deferred: filed.deferred,
-    linked,
+    linked: linked.filter((entry) => !updates.has(entry.id)),
     malformed,
   }
 

--- a/app/src/internal/file.ts
+++ b/app/src/internal/file.ts
@@ -62,13 +62,16 @@ export async function file(options: file.Options): Promise<Filing> {
   }[] = []
 
   for (const entry of entries) {
-    const resolution = await Target.resolve(entry.target, stack).catch((error: unknown) => {
-      if (error instanceof resolvers.InstallationMissingError) {
-        deferred.push({ code: error.code, id: entry.id, reason: error.message })
-        return undefined
-      }
-      throw error
-    })
+    const link = entry.issue ? Github.parseLink(entry.issue) : undefined
+    const resolution = await Target.resolve(link?.repo ?? entry.target, stack).catch(
+      (error: unknown) => {
+        if (error instanceof resolvers.InstallationMissingError) {
+          deferred.push({ code: error.code, id: entry.id, reason: error.message })
+          return undefined
+        }
+        throw error
+      },
+    )
     if (!resolution) continue
     if (!resolution.ok) {
       deferred.push({ code: resolution.code, id: entry.id, reason: resolution.message })
@@ -135,8 +138,34 @@ export async function file(options: file.Options): Promise<Filing> {
           path: Store.toPath(entry.id),
           severity: entry.severity,
         }
-        const existing =
-          (await matcher.match(entry.title, { marker, occurrence, report })) ?? seen.get(hash)
+        const link = entry.issue ? Github.parseLink(entry.issue) : undefined
+        let existing: Github.Issue | undefined
+        if (link) {
+          existing = await Github.get(target.rest, { issue: link.issue, repo: link.repo })
+          const location =
+            existing?.author === app
+              ? await Github.findReport(target.rest, {
+                  existing,
+                  expectedAuthor: app,
+                  marker,
+                  occurrence,
+                  repo: destination,
+                  report,
+                })
+              : undefined
+          if (!location) {
+            deferred.push({
+              code: 'LINK_INVALID',
+              id: entry.id,
+              reason: `The linked issue \`${entry.issue}\` is missing or does not carry this Frog report.`,
+            })
+            continue
+          }
+          if (location === 'created')
+            await matcher.match(entry.title, { marker, occurrence, report })
+        } else
+          existing =
+            (await matcher.match(entry.title, { marker, occurrence, report })) ?? seen.get(hash)
         const result = await (async () => {
           if (mutated < config.maxPerRun)
             return Github.publish(target.rest, {
@@ -205,7 +234,7 @@ export declare namespace file {
     client: Octokit
     /** Normalized config, read from the default branch. */
     config: Config.Config
-    /** Entries to resolve and file. Already free of linked ones. */
+    /** Entries to resolve and file. Linked entries update their established Frog issues. */
     entries: readonly Entry.Entry[]
     /** Resolves an installation client for another repository. */
     installation: (repo: string) => Promise<Octokit | undefined>

--- a/app/src/internal/file.ts
+++ b/app/src/internal/file.ts
@@ -126,8 +126,11 @@ export async function file(options: file.Options): Promise<Filing> {
 
       for (const entry of group.entries) {
         const hash = Github.hash(entry.title)
+        const report = Github.report({ entry, origin })
         const occurrence = Github.occurrence({ entry, origin })
-        const existing = (await matcher.match(entry.title, { occurrence })) ?? seen.get(hash)
+        const revision = Github.revision({ entry, origin })
+        const existing =
+          (await matcher.match(entry.title, { occurrence, report })) ?? seen.get(hash)
         const result = await (async () => {
           if (mutated < config.maxPerRun)
             return Github.publish(target.rest, {
@@ -142,15 +145,17 @@ export async function file(options: file.Options): Promise<Filing> {
               occurrence,
               provenance: { ...(actor ? { author: actor } : {}), ...(pr ? { pr } : {}) },
               repo: destination,
+              report,
+              revision,
               ...(existing ? { existing } : {}),
             })
 
           const status = existing
-            ? await Github.findOccurrence(target.rest, {
+            ? await Github.findRevision(target.rest, {
                 existing,
                 expectedAuthor: app,
-                occurrence,
                 repo: destination,
+                revision,
               })
             : undefined
           if (status && existing) return { issue: existing.number, mutated: false, status }

--- a/app/src/internal/file.ts
+++ b/app/src/internal/file.ts
@@ -129,8 +129,14 @@ export async function file(options: file.Options): Promise<Filing> {
         const report = Github.report({ entry, origin })
         const occurrence = Github.occurrence({ entry, origin })
         const revision = Github.revision({ entry, origin })
+        const marker = {
+          hash,
+          origin,
+          path: Store.toPath(entry.id),
+          severity: entry.severity,
+        }
         const existing =
-          (await matcher.match(entry.title, { occurrence, report })) ?? seen.get(hash)
+          (await matcher.match(entry.title, { marker, occurrence, report })) ?? seen.get(hash)
         const result = await (async () => {
           if (mutated < config.maxPerRun)
             return Github.publish(target.rest, {
@@ -141,7 +147,7 @@ export async function file(options: file.Options): Promise<Filing> {
                 labels: applied,
               }),
               // `origin` is where the entry file lives, not the destination when reporting upstream.
-              marker: { hash, origin, path: Store.toPath(entry.id), severity: entry.severity },
+              marker,
               occurrence,
               provenance: { ...(actor ? { author: actor } : {}), ...(pr ? { pr } : {}) },
               repo: destination,

--- a/src/Github.test.ts
+++ b/src/Github.test.ts
@@ -65,21 +65,84 @@ describe('hash', () => {
   })
 })
 
-describe('occurrence', () => {
-  // Pinned deliberately. The App and CLI hash this exact value, so changing its bytes would make a
-  // repository running both modes report the same entry twice.
+describe('report', () => {
+  // Pinned deliberately. The App and CLI share this identity across automation modes.
   test('behavior: is stable', () => {
+    const value = Github.report({
+      entry: {
+        body: 'Body:\n\nunchanged.',
+        id: 'entry-a',
+        severity: 'minor',
+        title: 'A friction',
+      },
+      origin: 'acme/app',
+    })
+
+    expect(value).toBe('acme/app:entry-a')
     expect(
-      Github.occurrence({
+      Github.report({
+        entry: {
+          body: 'Edited.',
+          id: 'entry-a',
+          severity: 'major',
+          title: 'Renamed friction',
+        },
+        origin: 'acme/app',
+      }),
+    ).toBe(value)
+    expect(
+      Github.report({
         entry: {
           body: 'Body:\n\nunchanged.',
-          id: 'entry-a',
+          id: 'entry-b',
           severity: 'minor',
           title: 'A friction',
         },
         origin: 'acme/app',
       }),
-    ).toBe('acme/app:entry-a:Body:\n\nunchanged.')
+    ).not.toBe(value)
+  })
+})
+
+describe('occurrence', () => {
+  test('behavior: preserves the v1 compatibility key', () => {
+    const value = {
+      body: 'Body.',
+      id: 'entry-a',
+      severity: 'minor',
+      title: 'A friction',
+    } as const
+    const occurrence = Github.occurrence({ entry: value, origin: 'acme/app' })
+
+    expect(occurrence).toBe('acme/app:entry-a:Body.')
+    expect(Github.occurrence({ entry: { ...value, title: 'Renamed' }, origin: 'acme/app' })).toBe(
+      occurrence,
+    )
+    expect(Github.occurrence({ entry: { ...value, severity: 'major' }, origin: 'acme/app' })).toBe(
+      occurrence,
+    )
+  })
+})
+
+describe('revision', () => {
+  test('behavior: changes with report content', () => {
+    const value = {
+      body: 'Body.',
+      id: 'entry-a',
+      severity: 'minor',
+      title: 'A friction',
+    } as const
+    const revision = Github.revision({ entry: value, origin: 'acme/app' })
+
+    expect(Github.revision({ entry: { ...value, body: 'Edited.' }, origin: 'acme/app' })).not.toBe(
+      revision,
+    )
+    expect(Github.revision({ entry: { ...value, title: 'Renamed' }, origin: 'acme/app' })).not.toBe(
+      revision,
+    )
+    expect(
+      Github.revision({ entry: { ...value, severity: 'major' }, origin: 'acme/app' }),
+    ).not.toBe(revision)
   })
 })
 
@@ -566,8 +629,8 @@ describe('index', () => {
 })
 
 describe('matcher', () => {
-  test('behavior: matches an occurrence before a changed title', async () => {
-    const occurrence = 'delivery-1:entry-a'
+  test('behavior: matches a report before a changed title', async () => {
+    const report = 'acme/app:entry-a'
     const instance = await github(
       {
         [repo]: [
@@ -575,7 +638,7 @@ describe('matcher', () => {
             body: Github.renderBody({
               body: 'Legitimate friction.',
               marker: { hash: Github.hash(title) },
-              occurrence,
+              report,
             }),
             title,
           },
@@ -590,11 +653,11 @@ describe('matcher', () => {
       repo,
     })
 
-    expect(await matcher.match('Renamed friction', { occurrence })).toMatchObject({ number: 1 })
+    expect(await matcher.match('Renamed friction', { report })).toMatchObject({ number: 1 })
   })
 
-  test('behavior: paginates and caches occurrences carried by comments', async () => {
-    const occurrence = 'delivery-2:entry-a'
+  test('behavior: paginates and caches reports carried by comments', async () => {
+    const report = 'acme/app:entry-a'
     const instance = await github(
       {
         [repo]: [
@@ -617,7 +680,7 @@ describe('matcher', () => {
       Github.renderBody({
         body: 'Legitimate friction changed.',
         marker: { hash: Github.hash(title) },
-        occurrence,
+        report,
       }),
       'frog-fm[bot]',
     )
@@ -630,8 +693,8 @@ describe('matcher', () => {
       repo,
     })
 
-    expect(await matcher.match('Renamed friction', { occurrence })).toMatchObject({ number: 1 })
-    await matcher.match('Another friction', { occurrence: 'missing' })
+    expect(await matcher.match('Renamed friction', { report })).toMatchObject({ number: 1 })
+    await matcher.match('Another friction', { report: 'missing' })
     expect(
       instance.requests.filter((request) => request.path === `/repos/${repo}/issues/comments`),
     ).toHaveLength(2)
@@ -830,8 +893,8 @@ describe('publish', () => {
     const result = await Github.publish(octokit, {
       entry,
       labels: ['friction'],
-      marker: { hash: Github.hash(title) },
-      provenance: { author: 'Test User', pr: 'acme/app#42' },
+      marker: { hash: Github.hash(title), origin: 'acme/app' },
+      provenance: { author: '@jxom', pr: 'acme/app#42' },
       repo,
       ...(existing ? { existing } : {}),
     })
@@ -840,11 +903,16 @@ describe('publish', () => {
     expect(instance.issues.get(repo)).toHaveLength(1)
     expect(instance.comments(repo, 1)).toMatchInlineSnapshot(`
       [
-        "Hit again by Test User via acme/app#42.
+        "Hit again by [**@jxom**](https://github.com/jxom) in acme/app via [#42](https://github.com/acme/app/pull/42).
+
+      <details>
+      <summary>Details</summary>
 
       ## Description
 
       The filter was swallowed.
+
+      </details>
       ",
       ]
     `)
@@ -941,33 +1009,133 @@ describe('publish', () => {
     expect(instance.issues.get(repo)).toHaveLength(1)
   })
 
-  test('behavior: replay after issue creation does not add a hit-again comment', async () => {
+  test('behavior: an edited report updates its issue in place', async () => {
     const instance = await github({}, { pushAccess: [] })
     const octokit = client(instance.url)
-    const occurrence = 'delivery-1:entry-a'
+    const report = 'report-a'
 
     const first = await Github.publish(octokit, {
       entry,
       labels: ['friction'],
       marker: { hash: Github.hash(title) },
-      occurrence,
+      occurrence: 'occurrence-a',
       repo,
+      report,
+      revision: 'revision-1',
     })
     const matcher = await Github.matcher(octokit, { label: 'friction', repo })
-    const existing = await matcher.match(title)
-    const replayed = await Github.publish(octokit, {
-      entry,
+    const changed = { body: 'Updated details.', title: 'Updated title' }
+    const existing = await matcher.match(changed.title, { report })
+    const updated = await Github.publish(octokit, {
+      entry: changed,
       labels: ['friction'],
-      marker: { hash: Github.hash(title) },
-      occurrence,
+      marker: { hash: Github.hash(changed.title) },
+      occurrence: 'occurrence-a',
       repo,
+      report,
+      revision: 'revision-2',
       ...(existing ? { existing } : {}),
+    })
+    const current = await Github.get(octokit, { issue: 1, repo })
+    if (!current) throw new Error('Expected updated issue.')
+    const replayed = await Github.publish(octokit, {
+      entry: changed,
+      existing: current,
+      labels: ['friction'],
+      marker: { hash: Github.hash(changed.title) },
+      occurrence: 'occurrence-a',
+      repo,
+      report,
+      revision: 'revision-2',
     })
 
     expect(first).toEqual({ issue: 1, mutated: true, status: 'created' })
+    expect(updated).toEqual({ issue: 1, mutated: true, status: 'created' })
     expect(replayed).toEqual({ issue: 1, mutated: false, status: 'created' })
     expect(instance.issues.get(repo)).toHaveLength(1)
+    expect(instance.issues.get(repo)?.[0]?.title).toBe(changed.title)
+    expect(Github.parseBody(instance.issues.get(repo)?.[0]?.body)).toBe(changed.body)
     expect(instance.comments(repo, 1)).toEqual([])
+  })
+
+  test('behavior: migrates a v1 issue without adding a recurrence', async () => {
+    const occurrence = 'acme/app:entry-a:Body.'
+    const report = 'acme/app:entry-a'
+    const marker = { hash: Github.hash(title), origin: 'acme/app', path: 'entry-a/friction.md' }
+    const legacyBody = `${Github.renderBody({ body: 'Body.', marker, occurrence }).trimEnd()}\n\nMaintainer note.\n`
+    const instance = await github({
+      [repo]: [{ body: legacyBody, title }],
+    })
+    const octokit = client(instance.url)
+    const matcher = await Github.matcher(octokit, { label: 'friction', repo })
+    const existing = await matcher.match(title, { occurrence, report })
+    if (!existing) throw new Error('Expected v1 issue.')
+
+    const migrated = await Github.publish(octokit, {
+      entry: { body: 'Body.', title },
+      existing,
+      labels: ['friction'],
+      marker,
+      occurrence,
+      repo,
+      report,
+      revision: 'revision-a',
+    })
+
+    expect(migrated).toEqual({ issue: 1, mutated: true, status: 'created' })
+    expect(instance.comments(repo, 1)).toEqual([])
+    expect(instance.issues.get(repo)?.[0]?.body).toContain('Maintainer note.')
+
+    const current = await Github.get(octokit, { issue: 1, repo })
+    if (!current) throw new Error('Expected migrated issue.')
+    await expect(
+      Github.publish(octokit, {
+        entry: { body: 'Body.', title },
+        existing: current,
+        labels: ['friction'],
+        marker,
+        occurrence,
+        repo,
+        report,
+        revision: 'revision-a',
+      }),
+    ).resolves.toEqual({ issue: 1, mutated: false, status: 'created' })
+  })
+
+  test('behavior: migrates an edited v1 recurrence comment in place', async () => {
+    const report = 'acme/app:entry-b'
+    const occurrence = `${report}:Updated body.`
+    const legacy = Github.renderBody({
+      body: 'Old body.',
+      marker: { hash: Github.hash(title) },
+      occurrence: `${report}:Old body.`,
+    })
+    const marker = legacy.match(/<!-- frog:occurrence:v1 [0-9a-f]{64} -->/)?.[0]
+    if (!marker) throw new Error('Expected v1 occurrence marker.')
+    const instance = await github({
+      [repo]: [{ body: Github.renderMarker({ hash: Github.hash(title) }), title }],
+    })
+    instance.addComment(repo, 1, `Hit again in \`acme/app\`.\n\nOld body.\n\n${marker}\n`)
+    const octokit = client(instance.url)
+    const matcher = await Github.matcher(octokit, { label: 'friction', repo })
+    const existing = await matcher.match(title, { occurrence, report })
+    if (!existing) throw new Error('Expected v1 recurrence.')
+
+    const migrated = await Github.publish(octokit, {
+      entry: { body: 'Updated body.', title },
+      existing,
+      labels: ['friction'],
+      marker: { hash: Github.hash(title), origin: 'acme/app' },
+      occurrence,
+      repo,
+      report,
+      revision: 'revision-b',
+    })
+
+    expect(migrated).toEqual({ issue: 1, mutated: true, status: 'commented' })
+    expect(instance.comments(repo, 1)).toHaveLength(1)
+    expect(instance.comments(repo, 1)[0]).toContain('Updated body.')
+    expect(instance.comments(repo, 1)[0]).toContain('<summary>Details</summary>')
   })
 
   // An entry left in the log after its issue was closed is re-filed on every push. Reopening there
@@ -1033,7 +1201,7 @@ describe('publish', () => {
     expect(instance.comments(repo, 1)).toHaveLength(1)
   })
 
-  test('behavior: replay after commenting does not add the comment twice', async () => {
+  test('behavior: an edited recurrence updates its comment in place', async () => {
     const instance = await github({
       [repo]: [{ body: Github.renderMarker({ hash: Github.hash(title) }), title }],
     })
@@ -1050,29 +1218,39 @@ describe('publish', () => {
         issue_number: existing.number,
       })
 
-    const publish = (occurrence: string) =>
+    const publish = (report: string, revision: string, body = entry.body) =>
       Github.publish(octokit, {
-        entry,
+        entry: { ...entry, body },
         existing,
         labels: ['friction'],
         marker: { hash: Github.hash(title) },
-        occurrence,
+        occurrence: `${report}:${body}`,
         repo,
+        report,
+        revision,
       })
 
-    await expect(publish('delivery-1:entry-a')).resolves.toEqual({
+    await expect(publish('report-a', 'revision-1')).resolves.toEqual({
       issue: 1,
       mutated: true,
       status: 'commented',
     })
-    await expect(publish('delivery-1:entry-a')).resolves.toEqual({
+    await expect(publish('report-a', 'revision-1')).resolves.toEqual({
       issue: 1,
       mutated: false,
       status: 'commented',
     })
     expect(instance.comments(repo, 1)).toHaveLength(101)
 
-    await publish('delivery-2:entry-a')
+    await expect(publish('report-a', 'revision-2', 'Updated details.')).resolves.toEqual({
+      issue: 1,
+      mutated: true,
+      status: 'commented',
+    })
+    expect(instance.comments(repo, 1)).toHaveLength(101)
+    expect(instance.comments(repo, 1).at(-1)).toContain('Updated details.')
+
+    await publish('report-b', 'revision-1')
     expect(instance.comments(repo, 1)).toHaveLength(102)
   })
 })

--- a/src/Github.test.ts
+++ b/src/Github.test.ts
@@ -656,6 +656,40 @@ describe('matcher', () => {
     expect(await matcher.match('Renamed friction', { report })).toMatchObject({ number: 1 })
   })
 
+  test('behavior: matches a legacy mirror after its title and body change', async () => {
+    const report = 'acme/app:entry-a'
+    const path = '.agents/friction-log/entry-a/friction.md'
+    const instance = await github(
+      {
+        [repo]: [
+          {
+            body: Github.renderBody({
+              body: 'Old body.',
+              marker: { hash: Github.hash(title), origin: 'acme/app', path },
+              occurrence: `${report}:Old body.`,
+            }),
+            title,
+          },
+        ],
+      },
+      { author: 'frog-fm[bot]', pushAccess: [] },
+    )
+
+    const matcher = await Github.matcher(client(instance.url), {
+      expectedAuthor: 'frog-fm[bot]',
+      label: 'friction',
+      repo,
+    })
+
+    expect(
+      await matcher.match('Renamed friction', {
+        marker: { hash: Github.hash('Renamed friction'), origin: 'acme/app', path },
+        occurrence: `${report}:Edited body.`,
+        report,
+      }),
+    ).toMatchObject({ number: 1 })
+  })
+
   test('behavior: paginates and caches reports carried by comments', async () => {
     const report = 'acme/app:entry-a'
     const instance = await github(
@@ -1100,11 +1134,72 @@ describe('publish', () => {
         revision: 'revision-a',
       }),
     ).resolves.toEqual({ issue: 1, mutated: false, status: 'created' })
+
+    const edited = await Github.get(octokit, { issue: 1, repo })
+    if (!edited) throw new Error('Expected migrated issue.')
+    await expect(
+      Github.publish(octokit, {
+        entry: { body: 'Edited body.', title },
+        existing: edited,
+        labels: ['friction'],
+        marker,
+        occurrence: `${report}:Edited body.`,
+        repo,
+        report,
+        revision: 'revision-b',
+      }),
+    ).resolves.toEqual({ issue: 1, mutated: true, status: 'created' })
+
+    const body = instance.issues.get(repo)?.[0]?.body ?? ''
+    expect(Github.parseBody(body)).toBe('Edited body.')
+    expect(body).toContain('Maintainer note.')
+    expect(body.match(/<!-- frog:report:v1 /g)).toHaveLength(1)
+    expect(body.match(/<!-- frog:revision:v1 /g)).toHaveLength(1)
+    expect(instance.comments(repo, 1)).toEqual([])
+  })
+
+  test('behavior: a v1 migration updates the exact issue title', async () => {
+    const before = 'BUILD-cache misses!'
+    const after = 'Build cache misses'
+    const occurrence = 'acme/app:entry-a:Body.'
+    const report = 'acme/app:entry-a'
+    const marker = {
+      hash: Github.hash(after),
+      origin: 'acme/app',
+      path: 'entry-a/friction.md',
+    }
+    const instance = await github({
+      [repo]: [
+        {
+          body: Github.renderBody({ body: 'Body.', marker, occurrence }),
+          title: before,
+        },
+      ],
+    })
+    const octokit = client(instance.url)
+    const matcher = await Github.matcher(octokit, { label: 'friction', repo })
+    const existing = await matcher.match(after, { occurrence, report })
+    if (!existing) throw new Error('Expected v1 issue.')
+
+    await Github.publish(octokit, {
+      entry: { body: 'Body.', title: after },
+      existing,
+      labels: ['friction'],
+      marker,
+      occurrence,
+      repo,
+      report,
+      revision: 'revision-a',
+    })
+
+    expect(instance.issues.get(repo)?.[0]?.title).toBe(after)
+    expect(instance.comments(repo, 1)).toEqual([])
   })
 
   test('behavior: migrates an edited v1 recurrence comment in place', async () => {
     const report = 'acme/app:entry-b'
     const occurrence = `${report}:Updated body.`
+    const changedTitle = 'Renamed friction'
     const legacy = Github.renderBody({
       body: 'Old body.',
       marker: { hash: Github.hash(title) },
@@ -1118,14 +1213,14 @@ describe('publish', () => {
     instance.addComment(repo, 1, `Hit again in \`acme/app\`.\n\nOld body.\n\n${marker}\n`)
     const octokit = client(instance.url)
     const matcher = await Github.matcher(octokit, { label: 'friction', repo })
-    const existing = await matcher.match(title, { occurrence, report })
+    const existing = await matcher.match(changedTitle, { occurrence, report })
     if (!existing) throw new Error('Expected v1 recurrence.')
 
     const migrated = await Github.publish(octokit, {
-      entry: { body: 'Updated body.', title },
+      entry: { body: 'Updated body.', title: changedTitle },
       existing,
       labels: ['friction'],
-      marker: { hash: Github.hash(title), origin: 'acme/app' },
+      marker: { hash: Github.hash(changedTitle), origin: 'acme/app' },
       occurrence,
       repo,
       report,
@@ -1136,6 +1231,7 @@ describe('publish', () => {
     expect(instance.comments(repo, 1)).toHaveLength(1)
     expect(instance.comments(repo, 1)[0]).toContain('Updated body.')
     expect(instance.comments(repo, 1)[0]).toContain('<summary>Details</summary>')
+    expect(instance.issues.get(repo)).toHaveLength(1)
   })
 
   // An entry left in the log after its issue was closed is re-filed on every push. Reopening there

--- a/src/Github.test.ts
+++ b/src/Github.test.ts
@@ -726,6 +726,9 @@ describe('matcher', () => {
         report,
       }),
     ).toMatchObject({ number: 1 })
+    expect(
+      instance.requests.filter((request) => request.path === `/repos/${repo}/issues/comments`),
+    ).toEqual([])
   })
 
   test('behavior: paginates and caches reports carried by comments', async () => {
@@ -1091,6 +1094,7 @@ describe('publish', () => {
       labels: ['friction'],
       marker: { hash: Github.hash(title) },
       occurrence: 'occurrence-a',
+      provenance: { author: '@original', pr: 'acme/app#1' },
       repo,
       report,
       revision: 'revision-1',
@@ -1103,6 +1107,7 @@ describe('publish', () => {
       labels: ['friction'],
       marker: { hash: Github.hash(changed.title) },
       occurrence: 'occurrence-a',
+      provenance: { author: '@editor', pr: 'acme/app#2' },
       repo,
       report,
       revision: 'revision-2',
@@ -1116,6 +1121,7 @@ describe('publish', () => {
       labels: ['friction'],
       marker: { hash: Github.hash(changed.title) },
       occurrence: 'occurrence-a',
+      provenance: { author: '@editor', pr: 'acme/app#2' },
       repo,
       report,
       revision: 'revision-2',
@@ -1127,6 +1133,8 @@ describe('publish', () => {
     expect(instance.issues.get(repo)).toHaveLength(1)
     expect(instance.issues.get(repo)?.[0]?.title).toBe(changed.title)
     expect(Github.parseBody(instance.issues.get(repo)?.[0]?.body)).toBe(changed.body)
+    expect(instance.issues.get(repo)?.[0]?.body).toContain('Logged by @original via acme/app#1')
+    expect(instance.issues.get(repo)?.[0]?.body).not.toContain('@editor')
     expect(instance.comments(repo, 1)).toEqual([])
   })
 

--- a/src/Github.test.ts
+++ b/src/Github.test.ts
@@ -656,6 +656,44 @@ describe('matcher', () => {
     expect(await matcher.match('Renamed friction', { report })).toMatchObject({ number: 1 })
   })
 
+  test('behavior: retains earlier title changes while reindexing later reports', async () => {
+    const instance = await github(
+      {
+        [repo]: [
+          {
+            body: Github.renderBody({
+              body: 'First body.',
+              marker: { hash: Github.hash('First old title') },
+              report: 'acme/app:entry-a',
+            }),
+            title: 'First old title',
+          },
+          {
+            body: Github.renderBody({
+              body: 'Second body.',
+              marker: { hash: Github.hash('Second old title') },
+              report: 'acme/app:entry-b',
+            }),
+            title: 'Second old title',
+          },
+        ],
+      },
+      { pushAccess: [] },
+    )
+    const matcher = await Github.matcher(client(instance.url), { label: 'friction', repo })
+
+    await expect(
+      matcher.match('First new title', { report: 'acme/app:entry-a' }),
+    ).resolves.toMatchObject({ number: 1 })
+    await expect(
+      matcher.match('Second new title', { report: 'acme/app:entry-b' }),
+    ).resolves.toMatchObject({ number: 2 })
+    await expect(
+      matcher.match('First old title', { report: 'acme/app:entry-c' }),
+    ).resolves.toBeUndefined()
+    await expect(matcher.match('First new title')).resolves.toMatchObject({ number: 1 })
+  })
+
   test('behavior: matches a legacy mirror after its title and body change', async () => {
     const report = 'acme/app:entry-a'
     const path = '.agents/friction-log/entry-a/friction.md'
@@ -1294,6 +1332,91 @@ describe('publish', () => {
 
     expect(recurrence).toEqual({ issue: 1, mutated: true, status: 'commented' })
     expect(instance.issues.get(repo)?.[0]?.state).toBe('open')
+    expect(instance.comments(repo, 1)).toHaveLength(1)
+  })
+
+  test('behavior: scans comments once when locating a report', async () => {
+    const report = 'acme/app:entry-a'
+    const instance = await github({
+      [repo]: [
+        {
+          body: Github.renderBody({
+            body: 'Existing body.',
+            marker: { hash: Github.hash(title), origin: 'acme/app', path: 'existing.md' },
+            report: 'acme/app:existing',
+          }),
+          title,
+        },
+      ],
+    })
+    instance.addComment(
+      repo,
+      1,
+      Github.renderBody({
+        body: 'Untrusted body.',
+        marker: { hash: Github.hash(title) },
+        report,
+      }),
+      'contributor',
+    )
+    for (let index = 1; index < 100; index++)
+      instance.addComment(repo, 1, `Existing comment ${index}.`, 'frog-fm[bot]')
+    const octokit = client(instance.url)
+    const existing = await Github.get(octokit, { issue: 1, repo })
+    if (!existing) throw new Error('Expected seeded issue.')
+
+    await expect(
+      Github.publish(octokit, {
+        entry,
+        existing,
+        expectedAuthor: 'frog-fm[bot]',
+        labels: ['friction'],
+        marker: { hash: Github.hash(title), origin: 'acme/app', path: 'entry-a.md' },
+        occurrence: 'occurrence-a',
+        repo,
+        report,
+      }),
+    ).resolves.toEqual({ issue: 1, mutated: true, status: 'commented' })
+
+    expect(instance.comments(repo, 1)).toHaveLength(101)
+    expect(
+      instance.requests.filter(
+        (request) =>
+          request.method === 'GET' && request.path === `/repos/${repo}/issues/1/comments`,
+      ),
+    ).toHaveLength(2)
+  })
+
+  test('behavior: a revisionless recurrence replays without another update', async () => {
+    const instance = await github({
+      [repo]: [{ body: Github.renderMarker({ hash: Github.hash(title) }), title }],
+    })
+    const octokit = client(instance.url)
+    const existing = (await Github.index(octokit, { label: 'friction', repo })).get(
+      Github.hash(title),
+    )
+    if (!existing) throw new Error('Expected seeded issue.')
+    const publish = () =>
+      Github.publish(octokit, {
+        entry,
+        existing,
+        labels: ['friction'],
+        marker: { hash: Github.hash(title) },
+        occurrence: 'occurrence-a',
+        repo,
+        report: 'report-a',
+      })
+
+    await expect(publish()).resolves.toEqual({
+      issue: 1,
+      mutated: true,
+      status: 'commented',
+    })
+    await expect(publish()).resolves.toEqual({
+      issue: 1,
+      mutated: false,
+      status: 'commented',
+    })
     expect(instance.comments(repo, 1)).toHaveLength(1)
   })
 

--- a/src/Github.ts
+++ b/src/Github.ts
@@ -170,11 +170,23 @@ export function hash(title: string): string {
   return createHash('sha256').update(Entry.normalizeTitle(title)).digest('hex').slice(0, 12)
 }
 
-/**
- * Stable key for one report of one friction.
- *
- * Includes the body verbatim so editing an entry creates a new occurrence.
- */
+/** Stable identity for one reported entry. */
+export function report(options: report.Options): string {
+  const { entry, origin } = options
+  return [origin, entry.id].join(':')
+}
+
+export declare namespace report {
+  /** Options for {@link report}. */
+  type Options = {
+    /** Entry being reported. */
+    entry: Entry.Entry
+    /** Repository holding the entry, as `owner/name`. */
+    origin: string
+  }
+}
+
+/** Compatibility key for one report body. */
 export function occurrence(options: occurrence.Options): string {
   const { entry, origin } = options
   return [origin, entry.id, entry.body].join(':')
@@ -182,6 +194,22 @@ export function occurrence(options: occurrence.Options): string {
 
 export declare namespace occurrence {
   /** Options for {@link occurrence}. */
+  type Options = {
+    /** Entry being reported. */
+    entry: Entry.Entry
+    /** Repository holding the entry, as `owner/name`. */
+    origin: string
+  }
+}
+
+/** Content revision for one report. */
+export function revision(options: revision.Options): string {
+  const { entry } = options
+  return JSON.stringify([report(options), entry.body, entry.severity, entry.title])
+}
+
+export declare namespace revision {
+  /** Options for {@link revision}. */
   type Options = {
     /** Entry being reported. */
     entry: Entry.Entry
@@ -218,15 +246,29 @@ function lastMarker(value: string): RegExpExecArray | undefined {
 /** Format version of the marker that makes one external publish occurrence replay-safe. */
 const occurrenceVersion = 'v1'
 
+function renderDigest(kind: 'occurrence' | 'report' | 'revision', value: string): string {
+  const digest = createHash('sha256').update(value).digest('hex')
+  return `<!-- frog:${kind}:v1 ${digest} -->`
+}
+
 function renderOccurrence(occurrence: string): string {
-  const digest = createHash('sha256').update(occurrence).digest('hex')
-  return `<!-- frog:occurrence:${occurrenceVersion} ${digest} -->`
+  return renderDigest('occurrence', occurrence)
+}
+
+function renderReport(report: string): string {
+  return renderDigest('report', report)
+}
+
+function renderRevision(revision: string): string {
+  return renderDigest('revision', revision)
 }
 
 const occurrenceRegex = new RegExp(
   `<!-- frog:occurrence:${occurrenceVersion} [0-9a-f]{64} -->`,
   'g',
 )
+
+const reportRegex = /<!-- frog:report:v1 [0-9a-f]{64} -->/g
 
 function commentIssueNumber(value: string, repo: string): number | undefined {
   try {
@@ -258,12 +300,23 @@ export async function findOccurrence(
   client: Client,
   options: findOccurrence.Options,
 ): Promise<Result['status'] | undefined> {
-  const marker = renderOccurrence(options.occurrence)
+  return (await locateMarker(client, options, renderOccurrence(options.occurrence)))?.status
+}
+
+type MarkerLocation =
+  | { body: string | null | undefined; status: 'created' }
+  | { body: string | null | undefined; comment: number; status: 'commented' }
+
+async function locateMarker(
+  client: Client,
+  options: Pick<findOccurrence.Options, 'existing' | 'expectedAuthor' | 'repo'>,
+  marker: string,
+): Promise<MarkerLocation | undefined> {
   if (
     (!options.expectedAuthor || options.existing.author === options.expectedAuthor) &&
     options.existing.body?.includes(marker)
   )
-    return 'created'
+    return { body: options.existing.body, status: 'created' }
 
   for (let page = 1; ; page++) {
     const response = await client.issues.listComments({
@@ -272,14 +325,59 @@ export async function findOccurrence(
       page,
       per_page: 100,
     })
-    if (
-      response.data.some(
-        (comment) =>
-          (!options.expectedAuthor || comment.user?.login === options.expectedAuthor) &&
-          comment.body?.includes(marker),
-      )
+    const comment = response.data.find(
+      (comment) =>
+        (!options.expectedAuthor || comment.user?.login === options.expectedAuthor) &&
+        comment.body?.includes(marker),
     )
-      return 'commented'
+    if (comment)
+      return {
+        body: comment.body,
+        comment: comment.id,
+        status: 'commented',
+      }
+    if (response.data.length < 100) return undefined
+  }
+}
+
+function legacyCommentBody(value: string | null | undefined): string | undefined {
+  if (!value?.startsWith('Hit again')) return undefined
+  const note = value.indexOf('\n\n')
+  const marker = value.lastIndexOf('\n\n<!-- frog:occurrence:v1 ')
+  if (note < 0 || marker <= note) return undefined
+  return value.slice(note + 2, marker).trim()
+}
+
+async function locateLegacyReport(
+  client: Client,
+  options: Pick<findOccurrence.Options, 'existing' | 'expectedAuthor' | 'repo'>,
+  report: string,
+): Promise<MarkerLocation | undefined> {
+  const issueBody = parseBody(options.existing.body)
+  if (
+    (!options.expectedAuthor || options.existing.author === options.expectedAuthor) &&
+    options.existing.body?.includes(renderOccurrence(`${report}:${issueBody}`))
+  )
+    return { body: options.existing.body, status: 'created' }
+
+  for (let page = 1; ; page++) {
+    const response = await client.issues.listComments({
+      ...split(options.repo),
+      issue_number: options.existing.number,
+      page,
+      per_page: 100,
+    })
+    const comment = response.data.find((comment) => {
+      if (options.expectedAuthor && comment.user?.login !== options.expectedAuthor) return false
+      const body = legacyCommentBody(comment.body)
+      return body !== undefined && comment.body?.includes(renderOccurrence(`${report}:${body}`))
+    })
+    if (comment)
+      return {
+        body: comment.body,
+        comment: comment.id,
+        status: 'commented',
+      }
     if (response.data.length < 100) return undefined
   }
 }
@@ -291,8 +389,60 @@ export declare namespace findOccurrence {
     expectedAuthor?: string | undefined
     /** Issue that may already carry the occurrence. */
     existing: Issue
-    /** Stable occurrence key from {@link occurrence}. */
+    /** Compatibility key from {@link occurrence}. */
     occurrence: string
+    /** Repository holding the issue, as `owner/name`. */
+    repo: string
+  }
+}
+
+/**
+ * Finds where a stable report identity is already recorded on an issue.
+ *
+ * @returns `created` for the issue body, `commented` for a comment, or `undefined`.
+ */
+export async function findReport(
+  client: Client,
+  options: findReport.Options,
+): Promise<Result['status'] | undefined> {
+  return (await locateMarker(client, options, renderReport(options.report)))?.status
+}
+
+export declare namespace findReport {
+  /** Options for {@link findReport}. */
+  type Options = {
+    /** Author whose report markers are trusted. Every author is trusted when omitted. */
+    expectedAuthor?: string | undefined
+    /** Issue that may already carry the report. */
+    existing: Issue
+    /** Stable identity from {@link report}. */
+    report: string
+    /** Repository holding the issue, as `owner/name`. */
+    repo: string
+  }
+}
+
+/**
+ * Finds where an exact report revision is already recorded on an issue.
+ *
+ * @returns `created` for the issue body, `commented` for a comment, or `undefined`.
+ */
+export async function findRevision(
+  client: Client,
+  options: findRevision.Options,
+): Promise<Result['status'] | undefined> {
+  return (await locateMarker(client, options, renderRevision(options.revision)))?.status
+}
+
+export declare namespace findRevision {
+  /** Options for {@link findRevision}. */
+  type Options = {
+    /** Author whose revision markers are trusted. Every author is trusted when omitted. */
+    expectedAuthor?: string | undefined
+    /** Issue that may already carry the revision. */
+    existing: Issue
+    /** Exact content revision from {@link revision}. */
+    revision: string
     /** Repository holding the issue, as `owner/name`. */
     repo: string
   }
@@ -380,7 +530,7 @@ export type Provenance = {
  * @returns The issue body. {@link parseBody} inverts this exactly.
  */
 export function renderBody(options: renderBody.Options): string {
-  const { body, marker, occurrence, provenance = {} } = options
+  const { body, marker, occurrence, provenance = {}, report, revision } = options
 
   const credits = [
     provenance.author ? `Logged by ${provenance.author}` : 'Logged',
@@ -393,7 +543,12 @@ export function renderBody(options: renderBody.Options): string {
 
   const footer = `<sub>${credits}. Filed by [Frog](https://github.com/wevm/frog).</sub>`
 
-  const markers = [renderMarker(marker), occurrence ? renderOccurrence(occurrence) : undefined]
+  const markers = [
+    renderMarker(marker),
+    report ? renderReport(report) : undefined,
+    revision ? renderRevision(revision) : undefined,
+    occurrence ? renderOccurrence(occurrence) : undefined,
+  ]
     .filter(Boolean)
     .join('\n')
 
@@ -407,10 +562,14 @@ export declare namespace renderBody {
     body: string
     /** Hidden state to embed. Its `origin` also appears in the footer. */
     marker: Marker
-    /** Stable key for one external publish occurrence. */
+    /** Compatibility identity for one report body. */
     occurrence?: string | undefined
     /** Attribution for the footer. Omitted entirely when nothing is known. */
     provenance?: Provenance | undefined
+    /** Stable identity for the report. */
+    report?: string | undefined
+    /** Exact content revision for one external publish. */
+    revision?: string | undefined
   }
 }
 
@@ -837,7 +996,7 @@ export type Result = {
   issue: number
   /** Whether this call changed GitHub state. */
   mutated?: boolean | undefined
-  /** `created` opened a new issue, `commented` added to one that already existed. */
+  /** Whether the report lives in the issue body or a comment. */
   status: 'commented' | 'created'
 }
 
@@ -846,10 +1005,10 @@ export type Matcher = {
   /** Whether the token may label issues here. When false, the receiver's labels are dropped. */
   labelled: boolean
   /**
-   * Finds the issue already covering an occurrence or title.
+   * Finds the issue already covering a report, compatibility occurrence, or title.
    *
    * @param title - Entry title.
-   * @param options - Stable occurrence, when one is available.
+   * @param options - Stable report identity or compatibility occurrence, when available.
    */
   match: (title: string, options?: matcher.MatchOptions) => Promise<Issue | undefined>
 }
@@ -900,8 +1059,9 @@ export async function matcher(client: Client, options: matcher.Options): Promise
           const number = commentIssueNumber(comment.issue_url, options.repo)
           const issue = number ? accepted.get(number) : undefined
           if (!issue) continue
-          for (const marker of comment.body?.match(occurrenceRegex) ?? [])
-            indexed.set(marker, preferred(indexed.get(marker), issue))
+          for (const pattern of [reportRegex, occurrenceRegex])
+            for (const marker of comment.body?.match(pattern) ?? [])
+              indexed.set(marker, preferred(indexed.get(marker), issue))
         }
         if (response.data.length < 100) break
       }
@@ -913,8 +1073,11 @@ export async function matcher(client: Client, options: matcher.Options): Promise
   return {
     labelled: push,
     match: async (title, parameters = {}) => {
-      if (parameters.occurrence) {
-        const marker = renderOccurrence(parameters.occurrence)
+      const markers = [
+        parameters.report ? renderReport(parameters.report) : undefined,
+        parameters.occurrence ? renderOccurrence(parameters.occurrence) : undefined,
+      ].filter((marker): marker is string => Boolean(marker))
+      for (const marker of markers) {
         let existing: Issue | undefined
         for (const issue of labelledIssues)
           if (issue.body?.includes(marker)) existing = preferred(existing, issue)
@@ -940,10 +1103,12 @@ export async function matcher(client: Client, options: matcher.Options): Promise
 }
 
 export declare namespace matcher {
-  /** Optional stable identity used before title deduplication. */
+  /** Optional identities used before title deduplication. */
   type MatchOptions = {
-    /** Stable occurrence key from {@link occurrence}. */
+    /** Compatibility key from {@link occurrence}. */
     occurrence?: string | undefined
+    /** Stable identity from {@link report}. */
+    report?: string | undefined
   }
   /** Options for {@link matcher}. */
   type Options = index.Options & {
@@ -952,6 +1117,14 @@ export declare namespace matcher {
     /** Issue author eligible for matching. Every author is eligible when omitted. */
     expectedAuthor?: string | undefined
   }
+}
+
+function appendReportMarkers(
+  body: string | null | undefined,
+  report: string,
+  revision: string,
+): string {
+  return `${body?.trimEnd() ?? ''}\n\n${renderReport(report)}\n${renderRevision(revision)}\n`
 }
 
 /**
@@ -964,7 +1137,8 @@ export declare namespace matcher {
  * @returns The issue number and whether it was opened or commented on.
  */
 export async function publish(client: Client, options: publish.Options): Promise<Result> {
-  const { entry, expectedAuthor, labels, marker, occurrence, provenance, repo } = options
+  const { entry, expectedAuthor, labels, marker, occurrence, provenance, repo, report, revision } =
+    options
   const existing =
     options.existing && (!expectedAuthor || options.existing.author === expectedAuthor)
       ? options.existing
@@ -974,13 +1148,118 @@ export async function publish(client: Client, options: publish.Options): Promise
     marker,
     ...(occurrence ? { occurrence } : {}),
     ...(provenance ? { provenance } : {}),
+    ...(report ? { report } : {}),
+    ...(revision ? { revision } : {}),
   })
 
   if (existing) {
     // A replay of a report already made, whatever the issue's state. Reopening here would fight a
     // maintainer who closed the issue while its entry was still in the log, on every push. A genuine
-    // recurrence carries a new entry id, so its occurrence differs and it falls through to reopen.
-    if (occurrence) {
+    // recurrence carries a new entry id, so its report identity differs and falls through to reopen.
+    if (report) {
+      const reportLocation = await locateMarker(
+        client,
+        {
+          existing,
+          repo,
+          ...(expectedAuthor ? { expectedAuthor } : {}),
+        },
+        renderReport(report),
+      )
+      const occurrenceLocation =
+        !reportLocation && occurrence
+          ? await locateMarker(
+              client,
+              {
+                existing,
+                repo,
+                ...(expectedAuthor ? { expectedAuthor } : {}),
+              },
+              renderOccurrence(occurrence),
+            )
+          : undefined
+      const legacyLocation =
+        !reportLocation && !occurrenceLocation
+          ? await locateLegacyReport(
+              client,
+              {
+                existing,
+                repo,
+                ...(expectedAuthor ? { expectedAuthor } : {}),
+              },
+              report,
+            )
+          : undefined
+      const existingMarker = parseMarker(existing.body)
+      const mirrorLocation =
+        !reportLocation &&
+        !occurrenceLocation &&
+        !legacyLocation &&
+        marker.origin &&
+        marker.path &&
+        existingMarker?.origin === marker.origin &&
+        existingMarker.path === marker.path
+          ? ({ body: existing.body, status: 'created' } as const)
+          : undefined
+      const location = reportLocation ?? occurrenceLocation ?? legacyLocation ?? mirrorLocation
+      if (location) {
+        const current = reportLocation
+          ? revision
+            ? location.body?.includes(renderRevision(revision))
+            : location.status === 'created'
+              ? existing.body === body && existing.title === entry.title
+              : location.body === renderRecurrence({ body: entry.body, marker, provenance, report })
+          : false
+        if (current) return { issue: existing.number, mutated: false, status: location.status }
+
+        const unchangedLegacy =
+          occurrenceLocation &&
+          revision &&
+          (location.status === 'commented' ||
+            (existingMarker && renderMarker(existingMarker) === renderMarker(marker)))
+        if (unchangedLegacy) {
+          const migrated = appendReportMarkers(location.body, report, revision)
+          if (location.status === 'created')
+            await client.issues.update({
+              ...split(repo),
+              body: migrated,
+              issue_number: existing.number,
+            })
+          else
+            await client.issues.updateComment({
+              ...split(repo),
+              body: migrated,
+              comment_id: location.comment,
+            })
+          return { issue: existing.number, mutated: true, status: location.status }
+        }
+
+        if (location.status === 'created') {
+          await client.issues.update({
+            ...split(repo),
+            body,
+            issue_number: existing.number,
+            title: entry.title,
+          })
+        } else {
+          await client.issues.updateComment({
+            ...split(repo),
+            body: renderRecurrence({
+              body: entry.body,
+              marker,
+              occurrence,
+              provenance,
+              report,
+              revision,
+            }),
+            comment_id: location.comment,
+          })
+        }
+        return { issue: existing.number, mutated: true, status: location.status }
+      }
+    }
+
+    if (!report && occurrence) {
       const status = await findOccurrence(client, {
         existing,
         occurrence,
@@ -997,20 +1276,16 @@ export async function publish(client: Client, options: publish.Options): Promise
         state: 'open',
       })
 
-    const note = [
-      'Hit again',
-      provenance?.author ? `by ${provenance.author}` : undefined,
-      marker.origin ? `in \`${marker.origin}\`` : undefined,
-      provenance?.pr ? `via ${provenance.pr}` : undefined,
-    ]
-      .filter(Boolean)
-      .join(' ')
-
     await client.issues.createComment({
       ...split(repo),
-      body: `${note}.\n\n${stripMarkers(entry.body)}${
-        occurrence ? `\n\n${renderOccurrence(occurrence)}` : ''
-      }\n`,
+      body: renderRecurrence({
+        body: entry.body,
+        marker,
+        occurrence,
+        provenance,
+        report,
+        revision,
+      }),
       issue_number: existing.number,
     })
     return { issue: existing.number, mutated: true, status: 'commented' }
@@ -1023,6 +1298,47 @@ export async function publish(client: Client, options: publish.Options): Promise
     title: entry.title,
   })
   return { issue: created.data.number, mutated: true, status: 'created' }
+}
+
+function renderRecurrence(options: {
+  body: string
+  marker: Marker
+  occurrence?: string | undefined
+  provenance?: Provenance | undefined
+  report?: string | undefined
+  revision?: string | undefined
+}): string {
+  const { body, marker, occurrence, provenance = {}, report, revision } = options
+  const author = provenance.author?.startsWith('@') ? provenance.author.slice(1) : undefined
+  const link = provenance.pr ? parseLink(provenance.pr) : undefined
+  const note = [
+    'Hit again',
+    author && /^[\w-]+$/.test(author)
+      ? `by [**@${author}**](https://github.com/${author})`
+      : provenance.author
+        ? `by ${provenance.author}`
+        : undefined,
+    marker.origin ? `in ${marker.origin}` : undefined,
+    link
+      ? `via [#${link.issue}](https://github.com/${link.repo}/pull/${link.issue})`
+      : provenance.pr
+        ? `via ${provenance.pr}`
+        : undefined,
+  ]
+    .filter(Boolean)
+    .join(' ')
+
+  const markers = [
+    report ? renderReport(report) : undefined,
+    revision ? renderRevision(revision) : undefined,
+    occurrence ? renderOccurrence(occurrence) : undefined,
+  ]
+    .filter(Boolean)
+    .join('\n')
+
+  return `${note}.\n\n<details>\n<summary>Details</summary>\n\n${stripMarkers(
+    body,
+  )}\n\n</details>${markers ? `\n\n${markers}` : ''}\n`
 }
 
 export declare namespace publish {
@@ -1042,11 +1358,15 @@ export declare namespace publish {
     labels: readonly string[]
     /** Hidden state to embed, from {@link hash} plus the file path and origin repository. */
     marker: Marker
-    /** Stable key used to suppress a replay of this exact create or comment. */
+    /** Compatibility identity for one report body. */
     occurrence?: string | undefined
     /** Attribution for the footer and the comment. */
     provenance?: Provenance | undefined
     /** Repository to file in, as `owner/name`. */
     repo: string
+    /** Stable identity used to update this report in place. */
+    report?: string | undefined
+    /** Exact content revision used to suppress a replay. */
+    revision?: string | undefined
   }
 }

--- a/src/Github.ts
+++ b/src/Github.ts
@@ -1164,17 +1164,6 @@ export async function matcher(client: Client, options: matcher.Options): Promise
         for (const issue of (await fallback()).issues)
           if (issue.body?.includes(marker)) existing = preferred(existing, issue)
         if (existing) return reindex(existing, title)
-
-        existing = (await commentOccurrences()).markers.get(marker)
-        if (existing) return existing
-      }
-
-      if (parameters.report) {
-        let existing: Issue | undefined
-        for (const comment of (await commentOccurrences()).legacy)
-          if (comment.value.includes(renderOccurrence(`${parameters.report}:${comment.body}`)))
-            existing = preferred(existing, comment.issue)
-        if (existing) return existing
       }
 
       if (parameters.marker) {
@@ -1186,6 +1175,22 @@ export async function matcher(client: Client, options: matcher.Options): Promise
         for (const issue of (await fallback()).issues)
           if (matchesMirror(issue, parameters.marker)) existing = preferred(existing, issue)
         if (existing) return reindex(existing, title)
+      }
+
+      if (markers.length > 0) {
+        const comments = await commentOccurrences()
+        for (const marker of markers) {
+          const existing = comments.markers.get(marker)
+          if (existing) return existing
+        }
+
+        if (parameters.report) {
+          let existing: Issue | undefined
+          for (const comment of comments.legacy)
+            if (comment.value.includes(renderOccurrence(`${parameters.report}:${comment.body}`)))
+              existing = preferred(existing, comment.issue)
+          if (existing) return existing
+        }
       }
 
       const key = hash(title)
@@ -1228,14 +1233,33 @@ function appendReportMarkers(
 
 const footerEnd = '. Filed by [Frog](https://github.com/wevm/frog).</sub>'
 
-function preserveBodySuffix(body: string, existing: string | null | undefined): string {
-  const value = existing ?? ''
+function footerRange(value: string): { end: number; start: number } | undefined {
   const marker = lastMarker(value)
-  if (!marker) return body
-  const end = value.indexOf(footerEnd, marker.index + marker[0].length)
-  if (end < 0) return body
-  const suffix = stripMarkers(value.slice(end + footerEnd.length))
-  return suffix ? `${body.trimEnd()}\n\n${suffix}\n` : body
+  if (!marker) return undefined
+  const start = value.indexOf('<sub>', marker.index + marker[0].length)
+  if (start < 0) return undefined
+  const end = value.indexOf(footerEnd, start)
+  if (end < 0) return undefined
+  return { end: end + footerEnd.length, start }
+}
+
+function preserveIssueAttribution(body: string, existing: string | null | undefined): string {
+  const value = existing ?? ''
+  const current = footerRange(body)
+  const previous = footerRange(value)
+  if (!current || !previous) return body
+  const footer = value.slice(previous.start, previous.end)
+  const suffix = stripMarkers(value.slice(previous.end))
+  const updated = `${body.slice(0, current.start)}${footer}\n`
+  return suffix ? `${updated.trimEnd()}\n\n${suffix}\n` : updated
+}
+
+function preserveRecurrenceAttribution(body: string, existing: string | null | undefined): string {
+  const value = existing ?? ''
+  const current = body.indexOf('\n\n')
+  const previous = value.indexOf('\n\n')
+  if (current < 0 || previous < 0 || !value.startsWith('Hit again')) return body
+  return `${value.slice(0, previous)}${body.slice(current)}`
 }
 
 /**
@@ -1278,14 +1302,27 @@ export async function publish(client: Client, options: publish.Options): Promise
       })
       const existingMarker = parseMarker(existing.body)
       if (location) {
+        const updatedBody =
+          location.status === 'created'
+            ? preserveIssueAttribution(body, location.body)
+            : preserveRecurrenceAttribution(
+                renderRecurrence({
+                  body: entry.body,
+                  marker,
+                  occurrence,
+                  provenance,
+                  report,
+                  revision,
+                }),
+                location.body,
+              )
         const current =
           location.kind === 'report'
             ? revision
               ? location.body?.includes(renderRevision(revision))
               : location.status === 'created'
-                ? existing.body === body && existing.title === entry.title
-                : location.body ===
-                  renderRecurrence({ body: entry.body, marker, occurrence, provenance, report })
+                ? existing.body === updatedBody && existing.title === entry.title
+                : location.body === updatedBody
             : false
         if (current) return { issue: existing.number, mutated: false, status: location.status }
 
@@ -1315,21 +1352,14 @@ export async function publish(client: Client, options: publish.Options): Promise
         if (location.status === 'created') {
           await client.issues.update({
             ...split(repo),
-            body: preserveBodySuffix(body, location.body),
+            body: updatedBody,
             issue_number: existing.number,
             title: entry.title,
           })
         } else {
           await client.issues.updateComment({
             ...split(repo),
-            body: renderRecurrence({
-              body: entry.body,
-              marker,
-              occurrence,
-              provenance,
-              report,
-              revision,
-            }),
+            body: updatedBody,
             comment_id: location.comment,
           })
         }

--- a/src/Github.ts
+++ b/src/Github.ts
@@ -352,40 +352,6 @@ function legacyCommentBody(value: string | null | undefined): string | undefined
   return value.slice(note + 2, marker).trim()
 }
 
-async function locateLegacyReport(
-  client: Client,
-  options: Pick<findOccurrence.Options, 'existing' | 'expectedAuthor' | 'repo'>,
-  report: string,
-): Promise<MarkerLocation | undefined> {
-  const issueBody = parseBody(options.existing.body)
-  if (
-    (!options.expectedAuthor || options.existing.author === options.expectedAuthor) &&
-    options.existing.body?.includes(renderOccurrence(`${report}:${issueBody}`))
-  )
-    return { body: options.existing.body, status: 'created' }
-
-  for (let page = 1; ; page++) {
-    const response = await client.issues.listComments({
-      ...split(options.repo),
-      issue_number: options.existing.number,
-      page,
-      per_page: 100,
-    })
-    const comment = response.data.find((comment) => {
-      if (options.expectedAuthor && comment.user?.login !== options.expectedAuthor) return false
-      const body = legacyCommentBody(comment.body)
-      return body !== undefined && comment.body?.includes(renderOccurrence(`${report}:${body}`))
-    })
-    if (comment)
-      return {
-        body: comment.body,
-        comment: comment.id,
-        status: 'commented',
-      }
-    if (response.data.length < 100) return undefined
-  }
-}
-
 function matchesMirror(issue: Issue, marker: Marker | undefined): boolean {
   if (!marker?.origin || !marker.path) return false
   const existing = parseMarker(issue.body)
@@ -396,26 +362,66 @@ async function locateReport(
   client: Client,
   options: findReport.Options,
 ): Promise<ReportLocation | undefined> {
-  const parameters = {
-    existing: options.existing,
-    repo: options.repo,
-    ...(options.expectedAuthor ? { expectedAuthor: options.expectedAuthor } : {}),
+  const reportMarker = renderReport(options.report)
+  const occurrenceMarker = options.occurrence ? renderOccurrence(options.occurrence) : undefined
+  const trustedIssue = !options.expectedAuthor || options.existing.author === options.expectedAuthor
+  let occurrence: ReportLocation | undefined
+  let legacy: ReportLocation | undefined
+
+  if (trustedIssue) {
+    if (options.existing.body?.includes(reportMarker))
+      return { body: options.existing.body, kind: 'report', status: 'created' }
+    if (occurrenceMarker && options.existing.body?.includes(occurrenceMarker))
+      occurrence = { body: options.existing.body, kind: 'occurrence', status: 'created' }
+    const body = parseBody(options.existing.body)
+    if (options.existing.body?.includes(renderOccurrence(`${options.report}:${body}`)))
+      legacy = { body: options.existing.body, kind: 'legacy', status: 'created' }
   }
-  const report = await locateMarker(client, parameters, renderReport(options.report))
-  if (report) return { ...report, kind: 'report' }
 
-  const occurrence = options.occurrence
-    ? await locateMarker(client, parameters, renderOccurrence(options.occurrence))
-    : undefined
-  if (occurrence) return { ...occurrence, kind: 'occurrence' }
+  for (let page = 1; ; page++) {
+    const response = await client.issues.listComments({
+      ...split(options.repo),
+      issue_number: options.existing.number,
+      page,
+      per_page: 100,
+    })
+    for (const comment of response.data) {
+      if (options.expectedAuthor && comment.user?.login !== options.expectedAuthor) continue
+      if (comment.body?.includes(reportMarker))
+        return {
+          body: comment.body,
+          comment: comment.id,
+          kind: 'report',
+          status: 'commented',
+        }
+      if (!occurrence && occurrenceMarker && comment.body?.includes(occurrenceMarker))
+        occurrence = {
+          body: comment.body,
+          comment: comment.id,
+          kind: 'occurrence',
+          status: 'commented',
+        }
+      if (!legacy) {
+        const body = legacyCommentBody(comment.body)
+        if (
+          body !== undefined &&
+          comment.body?.includes(renderOccurrence(`${options.report}:${body}`))
+        )
+          legacy = {
+            body: comment.body,
+            comment: comment.id,
+            kind: 'legacy',
+            status: 'commented',
+          }
+      }
+    }
+    // Keep scanning after lower-priority matches because an exact report may appear later.
+    if (response.data.length < 100) break
+  }
 
-  const legacy = await locateLegacyReport(client, parameters, options.report)
-  if (legacy) return { ...legacy, kind: 'legacy' }
-
-  if (
-    (!options.expectedAuthor || options.existing.author === options.expectedAuthor) &&
-    matchesMirror(options.existing, options.marker)
-  )
+  if (occurrence) return occurrence
+  if (legacy) return legacy
+  if (trustedIssue && matchesMirror(options.existing, options.marker))
     return { body: options.existing.body, kind: 'mirror', status: 'created' }
   return undefined
 }
@@ -1070,12 +1076,25 @@ export async function matcher(client: Client, options: matcher.Options): Promise
     !options.exclude?.(issue) &&
     (!options.expectedAuthor || issue.author === options.expectedAuthor)
   const labelledIssues = push ? (await list(client, options)).filter(accepts) : []
-  const labelled = toIndex(labelledIssues)
+  const titleOverrides = new Map<number, string>()
+  const updateIndex = (index: Map<string, Issue>, issues: readonly Issue[]) => {
+    index.clear()
+    for (const issue of issues) {
+      const title = titleOverrides.get(issue.number)
+      const key =
+        title === undefined ? (parseMarker(issue.body)?.hash ?? hash(issue.title)) : hash(title)
+      index.set(key, preferred(index.get(key), issue))
+    }
+  }
+  const labelled = new Map<string, Issue>()
+  updateIndex(labelled, labelledIssues)
   let unlabelled: Promise<{ index: Map<string, Issue>; issues: readonly Issue[] }> | undefined
   const fallback = () => {
     unlabelled ??= listAll(client, options).then((issues) => {
       const accepted = issues.filter(accepts)
-      return { index: toIndex(accepted), issues: accepted }
+      const index = new Map<string, Issue>()
+      updateIndex(index, accepted)
+      return { index, issues: accepted }
     })
     return unlabelled
   }
@@ -1120,20 +1139,11 @@ export async function matcher(client: Client, options: matcher.Options): Promise
     return commented
   }
   const reindex = async (issue: Issue, title: string) => {
-    const update = (index: Map<string, Issue>, issues: readonly Issue[]) => {
-      index.clear()
-      for (const candidate of issues) {
-        const key =
-          candidate.number === issue.number
-            ? hash(title)
-            : (parseMarker(candidate.body)?.hash ?? hash(candidate.title))
-        index.set(key, preferred(index.get(key), candidate))
-      }
-    }
-    update(labelled, labelledIssues)
+    titleOverrides.set(issue.number, title)
+    updateIndex(labelled, labelledIssues)
     if (unlabelled) {
       const fallback = await unlabelled
-      update(fallback.index, fallback.issues)
+      updateIndex(fallback.index, fallback.issues)
     }
     return issue
   }
@@ -1275,7 +1285,7 @@ export async function publish(client: Client, options: publish.Options): Promise
               : location.status === 'created'
                 ? existing.body === body && existing.title === entry.title
                 : location.body ===
-                  renderRecurrence({ body: entry.body, marker, provenance, report })
+                  renderRecurrence({ body: entry.body, marker, occurrence, provenance, report })
             : false
         if (current) return { issue: existing.number, mutated: false, status: location.status }
 

--- a/src/Github.ts
+++ b/src/Github.ts
@@ -307,6 +307,10 @@ type MarkerLocation =
   | { body: string | null | undefined; status: 'created' }
   | { body: string | null | undefined; comment: number; status: 'commented' }
 
+type ReportLocation = MarkerLocation & {
+  kind: 'legacy' | 'mirror' | 'occurrence' | 'report'
+}
+
 async function locateMarker(
   client: Client,
   options: Pick<findOccurrence.Options, 'existing' | 'expectedAuthor' | 'repo'>,
@@ -382,6 +386,40 @@ async function locateLegacyReport(
   }
 }
 
+function matchesMirror(issue: Issue, marker: Marker | undefined): boolean {
+  if (!marker?.origin || !marker.path) return false
+  const existing = parseMarker(issue.body)
+  return existing?.origin === marker.origin && existing.path === marker.path
+}
+
+async function locateReport(
+  client: Client,
+  options: findReport.Options,
+): Promise<ReportLocation | undefined> {
+  const parameters = {
+    existing: options.existing,
+    repo: options.repo,
+    ...(options.expectedAuthor ? { expectedAuthor: options.expectedAuthor } : {}),
+  }
+  const report = await locateMarker(client, parameters, renderReport(options.report))
+  if (report) return { ...report, kind: 'report' }
+
+  const occurrence = options.occurrence
+    ? await locateMarker(client, parameters, renderOccurrence(options.occurrence))
+    : undefined
+  if (occurrence) return { ...occurrence, kind: 'occurrence' }
+
+  const legacy = await locateLegacyReport(client, parameters, options.report)
+  if (legacy) return { ...legacy, kind: 'legacy' }
+
+  if (
+    (!options.expectedAuthor || options.existing.author === options.expectedAuthor) &&
+    matchesMirror(options.existing, options.marker)
+  )
+    return { body: options.existing.body, kind: 'mirror', status: 'created' }
+  return undefined
+}
+
 export declare namespace findOccurrence {
   /** Options for {@link findOccurrence}. */
   type Options = {
@@ -405,7 +443,7 @@ export async function findReport(
   client: Client,
   options: findReport.Options,
 ): Promise<Result['status'] | undefined> {
-  return (await locateMarker(client, options, renderReport(options.report)))?.status
+  return (await locateReport(client, options))?.status
 }
 
 export declare namespace findReport {
@@ -415,6 +453,10 @@ export declare namespace findReport {
     expectedAuthor?: string | undefined
     /** Issue that may already carry the report. */
     existing: Issue
+    /** Hidden mirror identity used by v1 issue bodies. */
+    marker?: Marker | undefined
+    /** Compatibility key from {@link occurrence}. */
+    occurrence?: string | undefined
     /** Stable identity from {@link report}. */
     report: string
     /** Repository holding the issue, as `owner/name`. */
@@ -1037,12 +1079,18 @@ export async function matcher(client: Client, options: matcher.Options): Promise
     })
     return unlabelled
   }
-  let commented: Promise<Map<string, Issue>> | undefined
+  let commented:
+    | Promise<{
+        legacy: { body: string; issue: Issue; value: string }[]
+        markers: Map<string, Issue>
+      }>
+    | undefined
   const commentOccurrences = () => {
     commented ??= (async () => {
       const accepted = new Map((await fallback()).issues.map((issue) => [issue.number, issue]))
-      const indexed = new Map<string, Issue>()
-      if (accepted.size === 0) return indexed
+      const legacy: { body: string; issue: Issue; value: string }[] = []
+      const markers = new Map<string, Issue>()
+      if (accepted.size === 0) return { legacy, markers }
 
       // One bounded repository scan is cached for this filing group. Markers require exact issue and
       // comment authors.
@@ -1061,13 +1109,33 @@ export async function matcher(client: Client, options: matcher.Options): Promise
           if (!issue) continue
           for (const pattern of [reportRegex, occurrenceRegex])
             for (const marker of comment.body?.match(pattern) ?? [])
-              indexed.set(marker, preferred(indexed.get(marker), issue))
+              markers.set(marker, preferred(markers.get(marker), issue))
+          const body = legacyCommentBody(comment.body)
+          if (body !== undefined && comment.body) legacy.push({ body, issue, value: comment.body })
         }
         if (response.data.length < 100) break
       }
-      return indexed
+      return { legacy, markers }
     })()
     return commented
+  }
+  const reindex = async (issue: Issue, title: string) => {
+    const update = (index: Map<string, Issue>, issues: readonly Issue[]) => {
+      index.clear()
+      for (const candidate of issues) {
+        const key =
+          candidate.number === issue.number
+            ? hash(title)
+            : (parseMarker(candidate.body)?.hash ?? hash(candidate.title))
+        index.set(key, preferred(index.get(key), candidate))
+      }
+    }
+    update(labelled, labelledIssues)
+    if (unlabelled) {
+      const fallback = await unlabelled
+      update(fallback.index, fallback.issues)
+    }
+    return issue
   }
 
   return {
@@ -1081,14 +1149,33 @@ export async function matcher(client: Client, options: matcher.Options): Promise
         let existing: Issue | undefined
         for (const issue of labelledIssues)
           if (issue.body?.includes(marker)) existing = preferred(existing, issue)
-        if (existing) return existing
+        if (existing) return reindex(existing, title)
 
         for (const issue of (await fallback()).issues)
           if (issue.body?.includes(marker)) existing = preferred(existing, issue)
-        if (existing) return existing
+        if (existing) return reindex(existing, title)
 
-        existing = (await commentOccurrences()).get(marker)
+        existing = (await commentOccurrences()).markers.get(marker)
         if (existing) return existing
+      }
+
+      if (parameters.report) {
+        let existing: Issue | undefined
+        for (const comment of (await commentOccurrences()).legacy)
+          if (comment.value.includes(renderOccurrence(`${parameters.report}:${comment.body}`)))
+            existing = preferred(existing, comment.issue)
+        if (existing) return existing
+      }
+
+      if (parameters.marker) {
+        let existing: Issue | undefined
+        for (const issue of labelledIssues)
+          if (matchesMirror(issue, parameters.marker)) existing = preferred(existing, issue)
+        if (existing) return reindex(existing, title)
+
+        for (const issue of (await fallback()).issues)
+          if (matchesMirror(issue, parameters.marker)) existing = preferred(existing, issue)
+        if (existing) return reindex(existing, title)
       }
 
       const key = hash(title)
@@ -1107,6 +1194,8 @@ export declare namespace matcher {
   type MatchOptions = {
     /** Compatibility key from {@link occurrence}. */
     occurrence?: string | undefined
+    /** Hidden mirror identity used by v1 issue bodies. */
+    marker?: Marker | undefined
     /** Stable identity from {@link report}. */
     report?: string | undefined
   }
@@ -1125,6 +1214,18 @@ function appendReportMarkers(
   revision: string,
 ): string {
   return `${body?.trimEnd() ?? ''}\n\n${renderReport(report)}\n${renderRevision(revision)}\n`
+}
+
+const footerEnd = '. Filed by [Frog](https://github.com/wevm/frog).</sub>'
+
+function preserveBodySuffix(body: string, existing: string | null | undefined): string {
+  const value = existing ?? ''
+  const marker = lastMarker(value)
+  if (!marker) return body
+  const end = value.indexOf(footerEnd, marker.index + marker[0].length)
+  if (end < 0) return body
+  const suffix = stripMarkers(value.slice(end + footerEnd.length))
+  return suffix ? `${body.trimEnd()}\n\n${suffix}\n` : body
 }
 
 /**
@@ -1157,63 +1258,29 @@ export async function publish(client: Client, options: publish.Options): Promise
     // maintainer who closed the issue while its entry was still in the log, on every push. A genuine
     // recurrence carries a new entry id, so its report identity differs and falls through to reopen.
     if (report) {
-      const reportLocation = await locateMarker(
-        client,
-        {
-          existing,
-          repo,
-          ...(expectedAuthor ? { expectedAuthor } : {}),
-        },
-        renderReport(report),
-      )
-      const occurrenceLocation =
-        !reportLocation && occurrence
-          ? await locateMarker(
-              client,
-              {
-                existing,
-                repo,
-                ...(expectedAuthor ? { expectedAuthor } : {}),
-              },
-              renderOccurrence(occurrence),
-            )
-          : undefined
-      const legacyLocation =
-        !reportLocation && !occurrenceLocation
-          ? await locateLegacyReport(
-              client,
-              {
-                existing,
-                repo,
-                ...(expectedAuthor ? { expectedAuthor } : {}),
-              },
-              report,
-            )
-          : undefined
+      const location = await locateReport(client, {
+        existing,
+        marker,
+        repo,
+        report,
+        ...(expectedAuthor ? { expectedAuthor } : {}),
+        ...(occurrence ? { occurrence } : {}),
+      })
       const existingMarker = parseMarker(existing.body)
-      const mirrorLocation =
-        !reportLocation &&
-        !occurrenceLocation &&
-        !legacyLocation &&
-        marker.origin &&
-        marker.path &&
-        existingMarker?.origin === marker.origin &&
-        existingMarker.path === marker.path
-          ? ({ body: existing.body, status: 'created' } as const)
-          : undefined
-      const location = reportLocation ?? occurrenceLocation ?? legacyLocation ?? mirrorLocation
       if (location) {
-        const current = reportLocation
-          ? revision
-            ? location.body?.includes(renderRevision(revision))
-            : location.status === 'created'
-              ? existing.body === body && existing.title === entry.title
-              : location.body === renderRecurrence({ body: entry.body, marker, provenance, report })
-          : false
+        const current =
+          location.kind === 'report'
+            ? revision
+              ? location.body?.includes(renderRevision(revision))
+              : location.status === 'created'
+                ? existing.body === body && existing.title === entry.title
+                : location.body ===
+                  renderRecurrence({ body: entry.body, marker, provenance, report })
+            : false
         if (current) return { issue: existing.number, mutated: false, status: location.status }
 
         const unchangedLegacy =
-          occurrenceLocation &&
+          location.kind === 'occurrence' &&
           revision &&
           (location.status === 'commented' ||
             (existingMarker && renderMarker(existingMarker) === renderMarker(marker)))
@@ -1224,6 +1291,7 @@ export async function publish(client: Client, options: publish.Options): Promise
               ...split(repo),
               body: migrated,
               issue_number: existing.number,
+              title: entry.title,
             })
           else
             await client.issues.updateComment({
@@ -1237,7 +1305,7 @@ export async function publish(client: Client, options: publish.Options): Promise
         if (location.status === 'created') {
           await client.issues.update({
             ...split(repo),
-            body,
+            body: preserveBodySuffix(body, location.body),
             issue_number: existing.number,
             title: entry.title,
           })

--- a/src/cli/commands/publish.test.ts
+++ b/src/cli/commands/publish.test.ts
@@ -279,6 +279,40 @@ test('behavior: a replayed issue does not consume the next run ceiling', async (
   expect(instance.comments(repo, 1)).toEqual([])
 })
 
+test('behavior: --dry-run classifies an edited v1 issue by its actual location', async () => {
+  const cwd = await helpers.repo({ remote })
+  const report = `${repo}:a`
+  const path = Store.toPath('a')
+  const instance = await github({
+    [repo]: [
+      {
+        body: Github.renderBody({
+          body: 'Old body.',
+          marker: {
+            hash: Github.hash('Old title'),
+            origin: repo,
+            path,
+            severity: 'minor',
+          },
+          occurrence: `${report}:Old body.`,
+        }),
+        title: 'Old title',
+      },
+    ],
+  })
+  await Store.write(
+    { body: 'Edited body.', severity: 'minor', title: 'Renamed friction' },
+    { id: 'a', root: cwd },
+  )
+
+  const result = await cli.data<Outcome>(['publish', '--cwd', cwd, '--dry-run'], env(instance.url))
+
+  expect(result.created).toEqual([{ id: 'a', issue: `${repo}#1`, title: 'Renamed friction' }])
+  expect(result.commented).toEqual([])
+  expect(instance.issues.get(repo)?.[0]?.title).toBe('Old title')
+  expect((await Store.get('a', { root: cwd })).issue).toBeUndefined()
+})
+
 test('behavior: commits the links by default', async () => {
   const cwd = await helpers.repo({ remote })
   const instance = await github()

--- a/src/cli/commands/publish.test.ts
+++ b/src/cli/commands/publish.test.ts
@@ -45,18 +45,60 @@ test('behavior: files a pending entry and writes the link back', async () => {
   })
 })
 
-test('behavior: skips entries already linked', async () => {
+test('behavior: updates an already-linked entry in place', async () => {
   const cwd = await helpers.repo({ remote })
   const instance = await github()
+  await Store.write({ body, severity: 'minor', title: 'Already filed' }, { id: 'a', root: cwd })
+
+  await cli.data<Outcome>(['publish', '--cwd', cwd], env(instance.url))
   await Store.write(
-    { body, issue: `${repo}#7`, severity: 'minor', title: 'Already filed' },
+    {
+      body: 'Updated details.',
+      issue: `${repo}#1`,
+      severity: 'major',
+      title: 'Updated title',
+    },
     { id: 'a', root: cwd },
   )
 
   const result = await cli.data<Outcome>(['publish', '--cwd', cwd], env(instance.url))
 
-  expect(result).toMatchObject({ commented: [], created: [], deferred: [] })
-  expect(instance.issues.get(repo)).toBeUndefined()
+  expect(result).toMatchObject({
+    commented: [],
+    committed: false,
+    created: [{ id: 'a', issue: `${repo}#1`, title: 'Updated title' }],
+    deferred: [],
+  })
+  expect(instance.issues.get(repo)).toHaveLength(1)
+  expect(instance.issues.get(repo)?.[0]?.title).toBe('Updated title')
+  expect(Github.parseBody(instance.issues.get(repo)?.[0]?.body)).toBe('Updated details.')
+  expect(Github.parseMarker(instance.issues.get(repo)?.[0]?.body)?.severity).toBe('major')
+  expect(instance.comments(repo, 1)).toEqual([])
+})
+
+test('behavior: defers an invalid linked issue without mutating it', async () => {
+  const cwd = await helpers.repo({ remote })
+  const instance = await github({ [repo]: [{ title: 'Unrelated issue' }] })
+  await Store.write(
+    { body, issue: `${repo}#1`, severity: 'minor', title: 'Already filed' },
+    { id: 'a', root: cwd },
+  )
+
+  const result = await cli.data<Outcome>(['publish', '--cwd', cwd], env(instance.url))
+
+  expect(result).toMatchObject({
+    commented: [],
+    created: [],
+    deferred: [
+      {
+        code: 'LINK_INVALID',
+        id: 'a',
+        reason: 'The linked issue `wevm/demo#1` is missing or does not carry this Frog report.',
+      },
+    ],
+  })
+  expect(instance.issues.get(repo)?.[0]?.title).toBe('Unrelated issue')
+  expect(instance.comments(repo, 1)).toEqual([])
 })
 
 test('behavior: comments rather than duplicating when an issue already covers it', async () => {

--- a/src/cli/commands/publish.test.ts
+++ b/src/cli/commands/publish.test.ts
@@ -255,6 +255,20 @@ test('behavior: a replayed issue does not consume the next run ceiling', async (
     { id: 'b', issue: '(new)', title: 'Friction b' },
   ])
 
+  await Store.write(
+    { body: 'Edited.', severity: 'minor', title: 'Friction a' },
+    { id: 'a', root: cwd },
+  )
+  const edited = await cli.data<Outcome>(
+    ['publish', '--cwd', cwd, '--max', '1', '--dry-run'],
+    env(instance.url),
+  )
+  expect(edited.created).toEqual([{ id: 'a', issue: `${repo}#1`, title: 'Friction a' }])
+  expect(edited.deferred).toEqual([
+    { code: 'OVER_CEILING', id: 'b', reason: 'over the ceiling of 1 per run' },
+  ])
+
+  await Store.write({ body, severity: 'minor', title: 'Friction a' }, { id: 'a', root: cwd })
   const result = await cli.data<Outcome>(['publish', '--cwd', cwd, '--max', '1'], env(instance.url))
 
   expect(result.created).toEqual([

--- a/src/cli/commands/publish.test.ts
+++ b/src/cli/commands/publish.test.ts
@@ -130,6 +130,47 @@ test('behavior: two entries with the same title in one run collapse onto one iss
   expect(instance.issues.get(repo)).toHaveLength(1)
 })
 
+test('behavior: stable identity wins over a same-title issue filed earlier in the run', async () => {
+  const cwd = await helpers.repo({ remote })
+  const previous = {
+    body: 'Old body.',
+    id: 'b',
+    severity: 'minor',
+    title: 'Old title',
+  } as const
+  const instance = await github({
+    [repo]: [
+      {
+        body: Github.renderBody({
+          body: previous.body,
+          marker: {
+            hash: Github.hash(previous.title),
+            origin: repo,
+            path: Store.toPath(previous.id),
+            severity: previous.severity,
+          },
+          report: Github.report({ entry: previous, origin: repo }),
+        }),
+        title: previous.title,
+      },
+    ],
+  })
+  for (const id of ['a', 'b'])
+    await Store.write({ body, severity: 'minor', title: 'Shared title' }, { id, root: cwd })
+
+  const result = await cli.data<Outcome>(['publish', '--cwd', cwd], env(instance.url))
+
+  expect(result.created).toEqual([
+    { id: 'a', issue: `${repo}#2`, title: 'Shared title' },
+    { id: 'b', issue: `${repo}#1`, title: 'Shared title' },
+  ])
+  expect(result.commented).toEqual([])
+  expect((await Store.get('a', { root: cwd })).issue).toBe(`${repo}#2`)
+  expect((await Store.get('b', { root: cwd })).issue).toBe(`${repo}#1`)
+  expect(instance.comments(repo, 1)).toEqual([])
+  expect(instance.comments(repo, 2)).toEqual([])
+})
+
 test('behavior: a same-destination failure preserves earlier links and defers the tail', async () => {
   const cwd = await helpers.repo({ remote })
   const errors = {} as Record<string, number>

--- a/src/cli/commands/publish.ts
+++ b/src/cli/commands/publish.ts
@@ -1,6 +1,7 @@
 import { Cli, z } from 'incur'
 import type * as Entry from '../../Entry.js'
 import * as Git from '../../Git.js'
+import * as Github from '../../Github.js'
 import * as Store from '../../Store.js'
 import * as Target from '../../Target.js'
 import { attempt } from '../internal/attempt.js'
@@ -14,7 +15,7 @@ function toPr(value: string, repo: string): string {
 }
 
 export const publish = Cli.create('publish', {
-  description: 'File pending entries as GitHub issues.',
+  description: 'Publish friction entries as GitHub issues.',
   env: z.object({
     GH_TOKEN: z.string().optional().describe('Fallback when GITHUB_TOKEN is unset.'),
     GITHUB_API_URL: z
@@ -77,13 +78,18 @@ export const publish = Cli.create('publish', {
     if (!entries.ok) return c.error({ code: entries.code, message: entries.message })
 
     const deferred: { code: string; id: string; reason: string }[] = []
-    const pending = entries.value.filter((entry) => !entry.issue)
+    const publishable = entries.value
 
     const max = c.options.max ?? config.maxPerRun
-    if (pending.length === 0)
+    if (publishable.length === 0)
       return c.ok({ commented: [], committed: false, created: [], deferred, unlabelled: [] })
 
-    if (c.options.commit !== false && !c.options.dryRun && !(await Git.identity({ cwd: root })))
+    if (
+      publishable.some((entry) => !entry.issue) &&
+      c.options.commit !== false &&
+      !c.options.dryRun &&
+      !(await Git.identity({ cwd: root }))
+    )
       return c.error({
         code: 'NO_GIT_IDENTITY',
         message: 'Configure both `user.name` and `user.email` before Frog commits issue links.',
@@ -120,8 +126,9 @@ export const publish = Cli.create('publish', {
     }
     const candidates: Candidate[] = []
 
-    for (const entry of pending) {
-      const resolution = await attempt(Target.resolve(entry.target, resolvers))
+    for (const entry of publishable) {
+      const link = entry.issue ? Github.parseLink(entry.issue) : undefined
+      const resolution = await attempt(Target.resolve(link?.repo ?? entry.target, resolvers))
       if (!resolution.ok) {
         deferred.push({ code: resolution.code, id: entry.id, reason: resolution.message })
         continue
@@ -213,6 +220,7 @@ export const publish = Cli.create('publish', {
           result.value instanceof publisher.PartialError ? result.value.outcome : result.value
         commented.push(...outcome.commented)
         created.push(...outcome.created)
+        deferred.push(...outcome.deferred)
         for (const destination of outcome.unlabelled)
           if (!unlabelled.includes(destination)) unlabelled.push(destination)
         written.push(...outcome.written)
@@ -244,7 +252,7 @@ export const publish = Cli.create('publish', {
     )
     if (!commit.ok) return c.error({ code: 'COMMIT_FAILED', message: commit.message })
 
-    const position = new Map(pending.map((entry, index) => [entry.id, index]))
+    const position = new Map(publishable.map((entry, index) => [entry.id, index]))
     deferred.sort((a, b) => (position.get(a.id) ?? 0) - (position.get(b.id) ?? 0))
 
     return c.ok(

--- a/src/cli/internal/publish.ts
+++ b/src/cli/internal/publish.ts
@@ -162,8 +162,10 @@ export async function file(options: file.Options): Promise<Outcome> {
       const report = Github.report({ entry, origin })
       const occurrence = Github.occurrence({ entry, origin })
       const revision = Github.revision({ entry, origin })
-      const existing = seen.get(hash) ?? (await matcher.match(entry.title, { occurrence, report }))
       const path = Store.toPath(entry.id)
+      const marker = { hash, origin, path, severity: entry.severity }
+      const existing =
+        seen.get(hash) ?? (await matcher.match(entry.title, { marker, occurrence, report }))
 
       if (dryRun) {
         const link = existing ? Github.toLink({ issue: existing.number, repo }) : '(new)'
@@ -180,15 +182,9 @@ export async function file(options: file.Options): Promise<Outcome> {
           (existing
             ? await Github.findReport(client, {
                 existing,
-                report,
-                repo,
-                ...(expectedAuthor ? { expectedAuthor } : {}),
-              })
-            : undefined) ??
-          (existing
-            ? await Github.findOccurrence(client, {
-                existing,
+                marker,
                 occurrence,
+                report,
                 repo,
                 ...(expectedAuthor ? { expectedAuthor } : {}),
               })
@@ -219,7 +215,7 @@ export async function file(options: file.Options): Promise<Outcome> {
         }),
         // `origin` is the repository holding the file, not the destination when reporting upstream. A
         // wrong value leaves a closed issue unable to find its mirror.
-        marker: { hash, origin, path, severity: entry.severity },
+        marker,
         occurrence,
         provenance: { ...provenance, ...(pr ? { pr } : {}) },
         repo,

--- a/src/cli/internal/publish.ts
+++ b/src/cli/internal/publish.ts
@@ -159,21 +159,41 @@ export async function file(options: file.Options): Promise<Outcome> {
     let reserved = false
     try {
       const hash = Github.hash(entry.title)
-      const existing = seen.get(hash) ?? (await matcher.match(entry.title))
+      const report = Github.report({ entry, origin })
       const occurrence = Github.occurrence({ entry, origin })
+      const revision = Github.revision({ entry, origin })
+      const existing = seen.get(hash) ?? (await matcher.match(entry.title, { occurrence, report }))
       const path = Store.toPath(entry.id)
 
       if (dryRun) {
         const link = existing ? Github.toLink({ issue: existing.number, repo }) : '(new)'
         const status = existing
-          ? await Github.findOccurrence(client, {
+          ? await Github.findRevision(client, {
               existing,
-              occurrence,
               repo,
+              revision,
               ...(expectedAuthor ? { expectedAuthor } : {}),
             })
           : undefined
-        const category = status ?? (existing ? 'commented' : 'created')
+        const location =
+          status ??
+          (existing
+            ? await Github.findReport(client, {
+                existing,
+                report,
+                repo,
+                ...(expectedAuthor ? { expectedAuthor } : {}),
+              })
+            : undefined) ??
+          (existing
+            ? await Github.findOccurrence(client, {
+                existing,
+                occurrence,
+                repo,
+                ...(expectedAuthor ? { expectedAuthor } : {}),
+              })
+            : undefined)
+        const category = location ?? (existing ? 'commented' : 'created')
         ;(category === 'commented' ? commented : created).push({
           id: entry.id,
           issue: link,
@@ -203,6 +223,8 @@ export async function file(options: file.Options): Promise<Outcome> {
         occurrence,
         provenance: { ...provenance, ...(pr ? { pr } : {}) },
         repo,
+        report,
+        revision,
         ...(existing ? { existing } : {}),
       })
       if (result.mutated) consumed += 1

--- a/src/cli/internal/publish.ts
+++ b/src/cli/internal/publish.ts
@@ -13,6 +13,8 @@ export type Outcome = {
   /** Entries whose GitHub mutation succeeded or may have happened. */
   consumed: number
   created: Link[]
+  /** Linked entries that could not safely update their established issue. */
+  deferred: { code: string; id: string; reason: string }[]
   /** Destinations whose labels were dropped because the token cannot label there. */
   unlabelled: string[]
   /** Paths written, for the caller to stage. */
@@ -141,6 +143,7 @@ export async function file(options: file.Options): Promise<Outcome> {
   const commented: Link[] = []
   let consumed = 0
   const created: Link[] = []
+  const deferred: Outcome['deferred'] = []
   const written: string[] = []
   /** Filed during this run, so two entries with one title collapse onto one issue. */
   const seen = new Map<string, Github.Issue>()
@@ -148,6 +151,7 @@ export async function file(options: file.Options): Promise<Outcome> {
     commented,
     consumed,
     created,
+    deferred,
     written,
     unlabelled:
       !matcher.labelled && applied.length > 0 && !dryRun && commented.length + created.length > 0
@@ -164,8 +168,32 @@ export async function file(options: file.Options): Promise<Outcome> {
       const revision = Github.revision({ entry, origin })
       const path = Store.toPath(entry.id)
       const marker = { hash, origin, path, severity: entry.severity }
-      const existing =
-        (await matcher.match(entry.title, { marker, occurrence, report })) ?? seen.get(hash)
+      const link = entry.issue ? Github.parseLink(entry.issue) : undefined
+      let existing: Github.Issue | undefined
+      if (link) {
+        existing = await Github.get(client, { issue: link.issue, repo: link.repo })
+        const location = existing
+          ? await Github.findReport(client, {
+              existing,
+              marker,
+              occurrence,
+              report,
+              repo,
+              ...(expectedAuthor ? { expectedAuthor } : {}),
+            })
+          : undefined
+        if (!location) {
+          deferred.push({
+            code: 'LINK_INVALID',
+            id: entry.id,
+            reason: `The linked issue \`${entry.issue}\` is missing or does not carry this Frog report.`,
+          })
+          continue
+        }
+        if (location === 'created') await matcher.match(entry.title, { marker, occurrence, report })
+      } else
+        existing =
+          (await matcher.match(entry.title, { marker, occurrence, report })) ?? seen.get(hash)
 
       if (dryRun) {
         const link = existing ? Github.toLink({ issue: existing.number, repo }) : '(new)'
@@ -190,6 +218,7 @@ export async function file(options: file.Options): Promise<Outcome> {
               })
             : undefined)
         const category = location ?? (existing ? 'commented' : 'created')
+        if (entry.issue && status) continue
         ;(category === 'commented' ? commented : created).push({
           id: entry.id,
           issue: link,
@@ -225,6 +254,7 @@ export async function file(options: file.Options): Promise<Outcome> {
       })
       if (result.mutated) consumed += 1
       reserved = false
+      if (entry.issue && !result.mutated) continue
 
       const issue = Github.toLink({ issue: result.issue, repo })
       ;(result.status === 'commented' ? commented : created).push({
@@ -232,8 +262,10 @@ export async function file(options: file.Options): Promise<Outcome> {
         issue,
         title: entry.title,
       })
-      await Store.write({ ...entry, issue }, { id: entry.id, root })
-      written.push(path)
+      if (entry.issue !== issue) {
+        await Store.write({ ...entry, issue }, { id: entry.id, root })
+        written.push(path)
+      }
 
       if (!existing)
         seen.set(hash, {

--- a/src/cli/internal/publish.ts
+++ b/src/cli/internal/publish.ts
@@ -165,7 +165,7 @@ export async function file(options: file.Options): Promise<Outcome> {
       const path = Store.toPath(entry.id)
       const marker = { hash, origin, path, severity: entry.severity }
       const existing =
-        seen.get(hash) ?? (await matcher.match(entry.title, { marker, occurrence, report }))
+        (await matcher.match(entry.title, { marker, occurrence, report })) ?? seen.get(hash)
 
       if (dryRun) {
         const link = existing ? Github.toLink({ issue: existing.number, repo }) : '(new)'

--- a/test/github.ts
+++ b/test/github.ts
@@ -354,8 +354,14 @@ export async function github(seed: Seed = {}, options: Options = {}): Promise<In
         const repo = `${one[1]}/${one[2]}`
         const found = (issues.get(repo) ?? []).find((issue) => issue.number === Number(one[3]))
         if (!found) return json(response, 404, { message: 'Not Found' })
-        const payload = await readBody<{ state?: 'closed' | 'open' }>(request)
+        const payload = await readBody<{
+          body?: string
+          state?: 'closed' | 'open'
+          title?: string
+        }>(request)
+        if (payload.body !== undefined) found.body = payload.body
         if (payload.state) found.state = payload.state
+        if (payload.title !== undefined) found.title = payload.title
         return json(response, 200, found)
       }
 


### PR DESCRIPTION
Uses stable report identities and content revisions to update existing issues or comments in place. New entry IDs alone create recurrence comments, while legacy occurrence markers migrate without duplicates.