### PR TITLE
fix: detect project package manager

### DIFF
--- a/.changeset/project-package-manager.md
+++ b/.changeset/project-package-manager.md
@@ -1,0 +1,5 @@
+---
+'frog': patch
+---
+
+Used the project package manager for generated Frog commands when declared.

--- a/src/cli/Cli.ts
+++ b/src/cli/Cli.ts
@@ -5,6 +5,7 @@ import { log } from './commands/log.js'
 import { publish } from './commands/publish.js'
 import { sync } from './commands/sync.js'
 import { targets } from './commands/targets.js'
+import * as context from './internal/context.js'
 import * as packageManager from './internal/packageManager.js'
 
 const globalOptionValues = new Set([
@@ -31,13 +32,16 @@ export const cli = Cli.create('frog', {
   .command(sync)
   .command(targets)
 
-/** Serves init with the invoking runner so Incur preserves absolute CTA commands. */
-export function serve(argv: string[] = process.argv.slice(2), options: Cli.serve.Options = {}) {
-  const root =
-    command(argv) === 'init'
-      ? Cli.create(packageManager.current({ env: options.env })).command(init)
-      : cli
-  return root.serve(argv, options)
+/** Serves init with the project runner so Incur preserves absolute CTA commands. */
+export async function serve(
+  argv: string[] = process.argv.slice(2),
+  options: Cli.serve.Options = {},
+) {
+  if (command(argv) !== 'init') return cli.serve(argv, options)
+
+  const { root } = await context.resolve({ cwd: option(argv, '--cwd') })
+  const runner = await packageManager.resolve({ env: options.env, root })
+  return Cli.create(runner).command(init).serve(argv, options)
 }
 
 export default cli
@@ -51,6 +55,15 @@ function command(argv: readonly string[]): string | undefined {
       continue
     }
     if (!value.startsWith('-')) return value
+  }
+  return undefined
+}
+
+function option(argv: readonly string[], name: string): string | undefined {
+  for (let index = 0; index < argv.length; index++) {
+    const value = argv[index]
+    if (value === name) return argv[index + 1]
+    if (value?.startsWith(`${name}=`)) return value.slice(name.length + 1)
   }
   return undefined
 }

--- a/src/cli/commands/init.test.ts
+++ b/src/cli/commands/init.test.ts
@@ -89,10 +89,16 @@ test('behavior: scaffolds the directory', async () => {
 })
 
 test.each([
-  ['pnpx frog', 'pnpm/11.0.0 npm/? node/v24'],
-  ['bunx frog', 'bun/1.2.0 npm/? node/v24'],
-])('behavior: uses the %s runner in generated guidance', async (command, userAgent) => {
+  ['pnpx frog', 'npm/11.0.0 node/v24', 'pnpm@11.15.0'],
+  ['bunx frog', 'bun/1.2.0 npm/? node/v24', undefined],
+])('behavior: uses the %s runner in generated guidance', async (command, userAgent, manager) => {
   const cwd = await helpers.repo()
+  if (manager)
+    await fs.writeFile(
+      path.join(cwd, 'package.json'),
+      JSON.stringify({ packageManager: manager }),
+      'utf8',
+    )
 
   const { envelope } = await cli.run(['--format', 'json', 'init', '--cwd', cwd], {
     npm_config_user_agent: userAgent,

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -132,7 +132,7 @@ export const init = Cli.create('init', {
   }),
   async run(c) {
     const { root } = await context.resolve({ cwd: c.options.cwd })
-    const command = packageManager.current({ env: c.env })
+    const command = await packageManager.resolve({ env: c.env, root })
     const guidelines = rules({ command })
 
     const files = [

--- a/src/cli/internal/packageManager.test.ts
+++ b/src/cli/internal/packageManager.test.ts
@@ -1,6 +1,9 @@
+import * as fs from 'node:fs/promises'
+import * as path from 'node:path'
+import * as helpers from '../../../test/helpers.js'
 import * as packageManager from './packageManager.js'
 
-describe('current', () => {
+describe('resolve', () => {
   test.each([
     [{ npm_config_user_agent: 'npm/11.0.0 node/v24' }, 'npx frog'],
     [{ npm_config_user_agent: 'pnpm/11.0.0 npm/? node/v24' }, 'pnpx frog'],
@@ -24,7 +27,32 @@ describe('current', () => {
     ],
     [{ npm_execpath: '/home/bunny/.nvm/npm-cli.js' }, 'npx frog'],
     [{}, 'npx frog'],
-  ])('behavior: resolves the invoking package manager', (env, expected) => {
-    expect(packageManager.current({ env })).toBe(expected)
+  ])('behavior: resolves the invoking package manager', async (env, expected) => {
+    expect(await packageManager.resolve({ env })).toBe(expected)
+  })
+
+  test('behavior: prefers the project package manager', async () => {
+    const root = await helpers.tmpdir()
+    await fs.writeFile(
+      path.join(root, 'package.json'),
+      JSON.stringify({ packageManager: 'pnpm@11.15.0' }),
+      'utf8',
+    )
+
+    expect(
+      await packageManager.resolve({
+        env: { npm_config_user_agent: 'npm/11.0.0 node/v24' },
+        root,
+      }),
+    ).toBe('pnpx frog')
+  })
+
+  test('behavior: falls back to the invoking package manager', async () => {
+    expect(
+      await packageManager.resolve({
+        env: { npm_config_user_agent: 'bun/1.2.0 npm/? node/v24' },
+        root: await helpers.tmpdir(),
+      }),
+    ).toBe('bunx frog')
   })
 })

--- a/src/cli/internal/packageManager.ts
+++ b/src/cli/internal/packageManager.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs/promises'
 import * as path from 'node:path'
 
 type Environment = {
@@ -5,6 +6,10 @@ type Environment = {
   npm_config_user_agent?: string | undefined
   /** Package-manager executable path. */
   npm_execpath?: string | undefined
+}
+
+type Manifest = {
+  packageManager?: string | undefined
 }
 
 type Manager = 'bun' | 'npm' | 'pnpm' | 'yarn'
@@ -27,16 +32,24 @@ const managers = {
   yarnpkg: 'yarn',
 } as const satisfies Record<string, Manager>
 
-/** Returns the Frog command for the invoking package manager. */
-export function current(options: current.Options = {}) {
-  return commands[fromEnvironment(options.env ?? process.env) ?? 'npm']
+/** Returns the Frog command for the project package manager, falling back to the invoking manager. */
+export async function resolve(options: resolve.Options = {}) {
+  const manager = options.root
+    ? await fs
+        .readFile(path.join(options.root, 'package.json'), 'utf8')
+        .then((contents) => fromIdentifier((JSON.parse(contents) as Manifest).packageManager))
+        .catch(() => undefined)
+    : undefined
+  return commands[manager ?? fromEnvironment(options.env ?? process.env) ?? 'npm']
 }
 
-export declare namespace current {
-  /** Options for selecting a package-manager runner. */
+export declare namespace resolve {
+  /** Options for selecting a project's Frog runner. */
   type Options = {
-    /** Environment used to identify the invoking package manager. */
+    /** Environment used when the project does not declare a package manager. */
     env?: Environment | undefined
+    /** Repository root that may hold a `package.json`. */
+    root?: string | undefined
   }
 }
 
@@ -49,7 +62,7 @@ function fromEnvironment(env: Environment | undefined): Manager | undefined {
 function fromIdentifier(value: string | undefined): Manager | undefined {
   if (!value) return undefined
   const name = value
-    .split('/', 1)[0]
+    .split(/[/@]/, 1)[0]
     ?.replace(/\.(?:c|m)?js$/i, '')
     .toLowerCase()
   if (!name) return undefined


### PR DESCRIPTION
Uses the repository root `package.json#packageManager` for generated Frog commands, falling back to the invoking manager. This prevents `npx frog init` from emitting npm guidance in pnpm projects.