### PR TITLE
ci: restore action tag updates

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,6 +45,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Update Action tag
+        if: steps.changesets.outputs.published == 'true'
+        run: |
+          major="$(node -p "require('./package.json').version.split('.')[0]")"
+          tag="v$major"
+          git tag --annotate --force "$tag" "$GITHUB_SHA" --message "$tag"
+          git push --force origin "refs/tags/$tag"
+
       - name: Release standalone binaries
         if: steps.changesets.outputs.published == 'true'
         uses: wevm/incur/release@1adcd9b9df2525d311a3cec5c3419552987641b3 # incur@0.4.24

--- a/README.md
+++ b/README.md
@@ -271,8 +271,8 @@ Both methods update one accumulating `frog/sync` pull request:
 
 - A protected default branch needs a human to merge `frog/sync`. Complete runs force-update the branch;
   deferrals preserve the existing pull request. Do not hand-edit it.
-- The examples pin Frog's action source to a full commit SHA. Add an exact `version` input to pin the
-  installed package; the default `1` tracks compatible npm releases.
+- `@v1` moves with compatible releases. Pin both a full action commit SHA and an exact `version` input
+  to fix Frog itself; npm still resolves the published package's dependency ranges at install time.
 - Never run it on `pull_request`. Fork tokens are read-only, and pull-request config is untrusted.
   `pull_request_target` is unsafe for the same reason.
 - One malformed `friction.md` fails the run because the log cannot be read partially.
@@ -322,7 +322,7 @@ jobs:
           ref: ${{ github.sha }}
 
       - name: Report and reconcile frictions
-        uses: wevm/frog/reconcile@b01b51b94a2cac4242e861c1d63fcd0ac1ab6df8 # frog@1.0.10
+        uses: wevm/frog/reconcile@v1
 ```
 
 The App has read access to repository contents and write access to issues and pull requests, but it
@@ -373,7 +373,7 @@ jobs:
           ref: ${{ github.sha }}
 
       - name: Report and reconcile frictions
-        uses: wevm/frog/action@b01b51b94a2cac4242e861c1d63fcd0ac1ab6df8 # frog@1.0.10
+        uses: wevm/frog/action@v1
         with:
           issue-author: github-actions[bot]
 ```

--- a/app/README.md
+++ b/app/README.md
@@ -23,7 +23,7 @@ token to one repository and requests Pull requests write without Contents access
 
 Source reconciliation runs in `.github/workflows/friction-log.yml`. The workflow grants
 `contents: write`, `pull-requests: write`, and `id-token: write` to
-`wevm/frog/reconcile@b01b51b94a2cac4242e861c1d63fcd0ac1ab6df8`; it grants no issue access.
+`wevm/frog/reconcile@v1`; it grants no issue access.
 
 The Action exchanges GitHub's OIDC token for a content-free snapshot. The Worker verifies the
 repository id, repository name, default-branch ref, workflow, event, and exact commit before returning
@@ -31,9 +31,8 @@ only opaque occurrence hashes and issue state. Report bodies, paths, patches, co
 credentials never cross that boundary. The Action derives every change from its own exact checkout,
 validates the resulting diff, and updates `frog/sync` with the repository's token.
 
-Users who do not want to grant the App access can instead run
-`wevm/frog/action@b01b51b94a2cac4242e861c1d63fcd0ac1ab6df8`. Action-only reports after merge with
-the repository's token and handles same-repository friction only.
+Users who do not want to grant the App access can instead run `wevm/frog/action@v1`. Action-only reports
+after merge with the repository's token and handles same-repository friction only.
 
 ## Why the App is richer
 

--- a/src/cli/commands/init.test.ts
+++ b/src/cli/commands/init.test.ts
@@ -59,7 +59,7 @@ test('behavior: scaffolds the directory', async () => {
   expect(readme).not.toContain('| Area | GitHub App | Action-only |')
   expect(readme).not.toContain('github.com/apps/frog-fm')
   expect(readme).not.toContain('Create `.github/workflows/friction-log.yml`')
-  expect(readme).not.toContain('uses: wevm/frog/action@')
+  expect(readme).not.toContain('uses: wevm/frog/action@v1')
   expect(readme).toContain('## Logging Friction')
   expect(readme).toContain('## For Agents')
   expect(readme).toContain(


### PR DESCRIPTION
Restores `@v1` action references and moves the major tag after successful Changesets publications. Binary release compatibility remains tracked by https://github.com/wevm/incur/pull/218.