### PR TITLE
ci: track latest incur release action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Release standalone binaries
         if: steps.changesets.outputs.published == 'true'
-        uses: wevm/incur/release@1adcd9b9df2525d311a3cec5c3419552987641b3 # incur@0.4.24
+        uses: wevm/incur/release@main
 
   deploy:
     name: Deploy


### PR DESCRIPTION
Tracks the Incur release action's main branch so Frog receives the fix that appends binaries to the latest Changesets release instead of creating an untagged draft.