### PR TITLE
chore: add no-op changeset

### DIFF
--- a/.changeset/updated-package.md
+++ b/.changeset/updated-package.md
@@ -1,4 +1,5 @@
 ---
+'frog': patch
 ---
 
-Updated package
+Updated package.

--- a/.changeset/updated-package.md
+++ b/.changeset/updated-package.md
@@ -1,0 +1,4 @@
+---
+---
+
+Updated package


### PR DESCRIPTION
Adds a no-op changeset with the release note `Updated package` to exercise the release workflow without bumping the `frog` package.