### PR TITLE
fix: update incur binary release

### DIFF
--- a/.changeset/quiet-binaries-build.md
+++ b/.changeset/quiet-binaries-build.md
@@ -1,0 +1,5 @@
+---
+'frog': patch
+---
+
+Fixed standalone binary releases for package-scoped tags.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,8 +25,8 @@ catalogs:
       specifier: latest
       version: 4.1.10
     incur:
-      specifier: 0.4.24
-      version: 0.4.24
+      specifier: 0.4.25
+      version: 0.4.25
     octokit:
       specifier: ^5.0.5
       version: 5.0.5
@@ -61,7 +61,7 @@ importers:
         version: 22.0.1
       incur:
         specifier: 'catalog:'
-        version: 0.4.24
+        version: 0.4.25
       yaml:
         specifier: 'catalog:'
         version: 2.9.0
@@ -1930,8 +1930,8 @@ packages:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
 
-  incur@0.4.24:
-    resolution: {integrity: sha512-W9HbrqXkCD4h6b5mkcyx+qV9mhb/gYe45xllsE17Di5E832MNOMPOvxQKiBW+tWp8BxsSZovxtCjhsDEov8KbA==}
+  incur@0.4.25:
+    resolution: {integrity: sha512-UHMc8OAafcalvhtfPs8rIPAUksRQ7gbR59zq8CWYFUaX1kVssfFQ6aYEb3mWglP4NMfh5HO+IfvzqhwPuCyMmg==}
     engines: {node: '>=22'}
     hasBin: true
 
@@ -3990,7 +3990,7 @@ snapshots:
 
   ignore@5.3.2: {}
 
-  incur@0.4.24:
+  incur@0.4.25:
     dependencies:
       '@cfworker/json-schema': 4.1.1
       '@modelcontextprotocol/server': 2.0.0-alpha.4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,7 +9,7 @@ catalog:
   '@octokit/rest': ^22.0.1
   '@types/node': latest
   '@vitest/coverage-v8': latest
-  incur: 0.4.24
+  incur: 0.4.25
   octokit: ^5.0.5
   tsx: ^4.23.1
   typescript: latest
@@ -23,4 +23,4 @@ allowBuilds:
   workerd: true
 
 minimumReleaseAgeExclude:
-  - incur@0.4.24
+  - incur@0.4.25


### PR DESCRIPTION
Updates Incur to 0.4.25 so Frog’s standalone build accepts package-scoped release tags, restoring binary publication for Changesets releases.