### PR TITLE
fix: enforce local friction templates

### DIFF
--- a/.changeset/tidy-forms-guard.md
+++ b/.changeset/tidy-forms-guard.md
@@ -1,0 +1,5 @@
+---
+'frog': patch
+---
+
+Validated supplied bodies against local issue forms before writing friction entries.

--- a/src/IssueForm.test.ts
+++ b/src/IssueForm.test.ts
@@ -69,6 +69,29 @@ describe('parse', () => {
         "I checked there isn't [already an issue](https://github.com/wevm/viem/issues) for the bug I encountered.",
       ]
     `)
+    expect(checkbox?.requiredOptions).toEqual(checkbox?.options)
+  })
+
+  test('behavior: preserves each individually required checkbox option', () => {
+    const [checkbox] =
+      IssueForm.parse(
+        [
+          'name: Bug',
+          'body:',
+          '  - type: checkboxes',
+          '    attributes:',
+          '      label: Agreements',
+          '      options:',
+          '        - label: Optional',
+          '        - label: Required One',
+          '          required: true',
+          '        - label: Required Two',
+          '          required: true',
+        ].join('\n'),
+      )?.fields ?? []
+
+    expect(checkbox?.options).toEqual(['Optional', 'Required One', 'Required Two'])
+    expect(checkbox?.requiredOptions).toEqual(['Required One', 'Required Two'])
   })
 
   test('behavior: reads the labels a project applies', () => {

--- a/src/IssueForm.ts
+++ b/src/IssueForm.ts
@@ -27,6 +27,8 @@ export type Field = {
   options?: readonly string[] | undefined
   /** Whether the project requires an answer. */
   required: boolean
+  /** Checkbox choices that the project requires individually. */
+  requiredOptions?: readonly string[] | undefined
 }
 
 /** A project's issue form, reduced to what authoring an entry needs. */
@@ -202,22 +204,25 @@ function toField(element: Element): Field | undefined {
   const label = element.attributes?.label
   if (typeof label !== 'string' || !label) return undefined
 
-  const options = element.attributes?.options
+  const parsedOptions = element.attributes?.options
     ?.map((option) =>
       typeof option === 'string'
-        ? option
+        ? { label: option, required: false }
         : typeof (option as { label?: unknown })?.label === 'string'
-          ? (option as { label: string }).label
+          ? {
+              label: (option as { label: string }).label,
+              required: (option as { required?: unknown }).required === true,
+            }
           : undefined,
     )
-    .filter((option): option is string => Boolean(option))
+    .filter((option): option is { label: string; required: boolean } => option !== undefined)
+  const options = parsedOptions?.map((option) => option.label)
+  const requiredOptions =
+    kind === 'checkboxes'
+      ? parsedOptions?.filter((option) => option.required).map((option) => option.label)
+      : undefined
 
-  // A checkbox carries `required` per option, and any one of them makes the field required.
-  const required =
-    element.validations?.required === true ||
-    (element.attributes?.options ?? []).some(
-      (option) => (option as { required?: unknown })?.required === true,
-    )
+  const required = element.validations?.required === true || Boolean(requiredOptions?.length)
 
   const description = element.attributes?.description
 
@@ -227,5 +232,6 @@ function toField(element: Element): Field | undefined {
     required,
     ...(typeof description === 'string' && description ? { description } : {}),
     ...(options?.length ? { options } : {}),
+    ...(requiredOptions?.length ? { requiredOptions } : {}),
   }
 }

--- a/src/cli/commands/log.test.ts
+++ b/src/cli/commands/log.test.ts
@@ -80,6 +80,118 @@ test('behavior: scaffolds from this repository own issue form', async () => {
   `)
 })
 
+test('error: a supplied body must preserve this repository own issue form', async () => {
+  const cwd = await helpers.repo()
+  await helpers.writeFile(
+    '.github/ISSUE_TEMPLATE/friction.yml',
+    [
+      'name: Friction',
+      'body:',
+      '  - type: textarea',
+      '    attributes:',
+      '      label: Expected Behavior',
+      '  - type: textarea',
+      '    attributes:',
+      '      label: Current Behavior',
+      '    validations:',
+      '      required: true',
+      '  - type: textarea',
+      '    attributes:',
+      '      label: Possible Solution',
+    ].join('\n'),
+    cwd,
+  )
+
+  const result = await cli.error(['log', title, '--body', body, '--cwd', cwd])
+
+  expect(result).toMatchInlineSnapshot(`
+    {
+      "code": "BODY_DOES_NOT_MATCH_FORM",
+      "message": "Body does not match this repository's issue form. Missing or out-of-order headings: \`Expected Behavior\`, \`Current Behavior\`, \`Possible Solution\`.",
+    }
+  `)
+  expect(await Store.list({ root: cwd })).toEqual([])
+})
+
+test('behavior: a supplied body may leave optional form sections empty', async () => {
+  const cwd = await helpers.repo()
+  await helpers.writeFile(
+    '.github/ISSUE_TEMPLATE/friction.yml',
+    [
+      'name: Friction',
+      'body:',
+      '  - type: textarea',
+      '    attributes:',
+      '      label: Expected Behavior',
+      '  - type: textarea',
+      '    attributes:',
+      '      label: Current Behavior',
+      '    validations:',
+      '      required: true',
+      '  - type: textarea',
+      '    attributes:',
+      '      label: Possible Solution',
+    ].join('\n'),
+    cwd,
+  )
+  const formBody = [
+    '### Expected Behavior',
+    '',
+    '### Current Behavior',
+    '',
+    'The filter was swallowed.',
+    '',
+    '### Possible Solution',
+  ].join('\n')
+
+  const { id } = await cli.data<Logged>(['log', title, '--body', formBody, '--cwd', cwd])
+
+  expect((await Store.get(id, { root: cwd })).body).toBe(formBody)
+})
+
+test('error: a supplied body must answer required form fields', async () => {
+  const cwd = await helpers.repo()
+  await helpers.writeFile(
+    '.github/ISSUE_TEMPLATE/friction.yml',
+    [
+      'name: Friction',
+      'body:',
+      '  - type: checkboxes',
+      '    attributes:',
+      '      label: Check Existing Issues',
+      '      options:',
+      '        - label: I checked for an existing issue.',
+      '    validations:',
+      '      required: true',
+      '  - type: textarea',
+      '    attributes:',
+      '      label: Current Behavior',
+      '    validations:',
+      '      required: true',
+    ].join('\n'),
+    cwd,
+  )
+  const formBody = [
+    '### Check Existing Issues',
+    '',
+    '- [ ] I checked for an existing issue.',
+    '',
+    '### Current Behavior',
+    '',
+    '<!-- Required. -->',
+  ].join('\n')
+
+  const result = await cli.error(['log', title, '--body', formBody, '--cwd', cwd])
+
+  expect(result).toMatchInlineSnapshot(`
+    {
+      "code": "BODY_DOES_NOT_MATCH_FORM",
+      "message": "Body does not match this repository's issue form. Required fields without answers: \`Check Existing Issues\`, \`Current Behavior\`.",
+    }
+  `)
+  expect(await Store.list({ root: cwd })).toEqual([])
+})
+
 test('error: a title is required', async () => {
   const cwd = await helpers.repo()
   expect(await cli.error(['log', '--body', body, '--cwd', cwd])).toMatchInlineSnapshot(`

--- a/src/cli/commands/log.test.ts
+++ b/src/cli/commands/log.test.ts
@@ -10,8 +10,53 @@ import * as Store from '../../Store.js'
 
 const title = '`pnpm test -- <files>` ignores file filters'
 const body = '## Description\n\nThe filter was swallowed.'
+const ownForm = [
+  'name: Friction',
+  'body:',
+  '  - type: textarea',
+  '    attributes:',
+  '      label: Expected Behavior',
+  '  - type: textarea',
+  '    attributes:',
+  '      label: Current Behavior',
+  '    validations:',
+  '      required: true',
+  '  - type: textarea',
+  '    attributes:',
+  '      label: Possible Solution',
+].join('\n')
+const ownBody = [
+  '### Expected Behavior',
+  '',
+  '### Current Behavior',
+  '',
+  'The filter was swallowed.',
+  '',
+  '### Possible Solution',
+].join('\n')
 
 type Logged = { file: string; id: string; title: string }
+
+async function writeOwnForm(cwd: string, contents = ownForm, filename = 'friction.yml') {
+  await helpers.writeFile(`.github/ISSUE_TEMPLATE/${filename}`, contents, cwd)
+}
+
+async function editor(body: string) {
+  const file = path.join(await helpers.tmpdir(), 'editor.mjs')
+  await writeFile(
+    file,
+    [
+      "import fs from 'node:fs'",
+      'const file = process.argv[2]',
+      "const contents = fs.readFileSync(file, 'utf8')",
+      'const frontmatter = /^---[^]*?\\n---\\n/.exec(contents)?.[0]',
+      "if (!frontmatter) throw new Error('frontmatter missing')",
+      `fs.writeFileSync(file, frontmatter + '\\n' + ${JSON.stringify(body)} + '\\n')`,
+    ].join('\n'),
+    'utf8',
+  )
+  return `node ${file}`
+}
 
 test('behavior: writes an entry', async () => {
   const cwd = await helpers.repo()
@@ -82,25 +127,7 @@ test('behavior: scaffolds from this repository own issue form', async () => {
 
 test('error: a supplied body must preserve this repository own issue form', async () => {
   const cwd = await helpers.repo()
-  await helpers.writeFile(
-    '.github/ISSUE_TEMPLATE/friction.yml',
-    [
-      'name: Friction',
-      'body:',
-      '  - type: textarea',
-      '    attributes:',
-      '      label: Expected Behavior',
-      '  - type: textarea',
-      '    attributes:',
-      '      label: Current Behavior',
-      '    validations:',
-      '      required: true',
-      '  - type: textarea',
-      '    attributes:',
-      '      label: Possible Solution',
-    ].join('\n'),
-    cwd,
-  )
+  await writeOwnForm(cwd)
 
   const result = await cli.error(['log', title, '--body', body, '--cwd', cwd])
 
@@ -115,38 +142,107 @@ test('error: a supplied body must preserve this repository own issue form', asyn
 
 test('behavior: a supplied body may leave optional form sections empty', async () => {
   const cwd = await helpers.repo()
+  await writeOwnForm(cwd)
+
+  const { id } = await cli.data<Logged>(['log', title, '--body', ownBody, '--cwd', cwd])
+
+  expect((await Store.get(id, { root: cwd })).body).toBe(ownBody)
+})
+
+test('error: an explicitly empty body must preserve this repository own issue form', async () => {
+  const cwd = await helpers.repo()
+  await writeOwnForm(cwd)
+
+  const result = await cli.error(['log', title, '--body', '', '--cwd', cwd])
+
+  expect(result.code).toBe('BODY_DOES_NOT_MATCH_FORM')
+  expect(await Store.list({ root: cwd })).toEqual([])
+})
+
+test('error: an explicit self target must preserve this repository own issue form', async () => {
+  const cwd = await helpers.repo({ remote: 'git@github.com:acme/app.git' })
+  await writeOwnForm(cwd)
+
+  const result = await cli.error([
+    'log',
+    title,
+    '--body',
+    body,
+    '--target',
+    'acme/app',
+    '--cwd',
+    cwd,
+  ])
+
+  expect(result.code).toBe('BODY_DOES_NOT_MATCH_FORM')
+  expect(await Store.list({ root: cwd })).toEqual([])
+})
+
+test('error: a package target resolving to self must preserve this repository own issue form', async () => {
+  const cwd = await helpers.repo({ remote: 'git@github.com:acme/app.git' })
+  await writeOwnForm(cwd)
   await helpers.writeFile(
-    '.github/ISSUE_TEMPLATE/friction.yml',
+    'node_modules/self-package/package.json',
+    JSON.stringify({ repository: 'https://github.com/acme/app.git' }),
+    cwd,
+  )
+
+  const result = await cli.error([
+    'log',
+    title,
+    '--body',
+    body,
+    '--target',
+    'self-package',
+    '--cwd',
+    cwd,
+  ])
+
+  expect(result.code).toBe('BODY_DOES_NOT_MATCH_FORM')
+  expect(await Store.list({ root: cwd })).toEqual([])
+})
+
+test('behavior: this repository configured issue form wins', async () => {
+  const cwd = await helpers.repo()
+  await writeOwnForm(
+    cwd,
+    'name: Default\nbody:\n  - type: textarea\n    attributes:\n      label: Default Field\n',
+  )
+  await writeOwnForm(
+    cwd,
     [
-      'name: Friction',
+      'name: Configured',
       'body:',
       '  - type: textarea',
       '    attributes:',
-      '      label: Expected Behavior',
-      '  - type: textarea',
-      '    attributes:',
-      '      label: Current Behavior',
+      '      label: Configured Field',
       '    validations:',
       '      required: true',
-      '  - type: textarea',
-      '    attributes:',
-      '      label: Possible Solution',
     ].join('\n'),
+    'configured.yml',
+  )
+  await helpers.writeFile(
+    Config.file,
+    JSON.stringify({ inbound: { template: 'configured.yml' } }),
     cwd,
   )
-  const formBody = [
-    '### Expected Behavior',
-    '',
-    '### Current Behavior',
-    '',
-    'The filter was swallowed.',
-    '',
-    '### Possible Solution',
-  ].join('\n')
+  const configuredBody = '### Configured Field\n\nThe configured answer.'
 
-  const { id } = await cli.data<Logged>(['log', title, '--body', formBody, '--cwd', cwd])
+  const { id } = await cli.data<Logged>(['log', title, '--body', configuredBody, '--cwd', cwd])
 
-  expect((await Store.get(id, { root: cwd })).body).toBe(formBody)
+  expect((await Store.get(id, { root: cwd })).body).toBe(configuredBody)
+})
+
+test('error: a body broken in the editor must preserve this repository own issue form', async () => {
+  const cwd = await helpers.repo()
+  await writeOwnForm(cwd)
+
+  const result = await cli.error(['log', title, '--open', '--cwd', cwd], {
+    VISUAL: await editor(body),
+  })
+
+  expect(result.code).toBe('BODY_DOES_NOT_MATCH_FORM')
+  expect((await Store.read({ root: cwd }))[0]?.body).toBe(body)
 })
 
 test('error: a supplied body must answer required form fields', async () => {
@@ -384,6 +480,20 @@ describe('--publish', () => {
     expect(result.issue).toBe(`${repo}#1`)
     expect((await Store.get(result.id, { root: cwd })).issue).toBe(`${repo}#1`)
     expect(instance.issues.get(repo)?.[0]?.title).toBe(title)
+  })
+
+  test('error: does not file an unanswered issue-form scaffold', async () => {
+    const cwd = await helpers.repo({ remote })
+    await writeOwnForm(cwd)
+    const instance = await github()
+
+    const result = await cli.error(['log', title, '--publish', '--cwd', cwd], {
+      GITHUB_API_URL: instance.url,
+      GITHUB_TOKEN: 'test-token',
+    })
+
+    expect(result.code).toBe('BODY_DOES_NOT_MATCH_FORM')
+    expect(instance.issues.get(repo)).toBeUndefined()
   })
 
   // Filing is opt-in even when GitHub is reachable: the entry belongs in the same commit as the work,

--- a/src/cli/commands/log.ts
+++ b/src/cli/commands/log.ts
@@ -140,14 +140,20 @@ export const log = Cli.create('log', {
 
     const body = c.options.body ?? (input?.body || undefined)
 
-    // Always load this repository's form from disk so a supplied body cannot bypass it.
-    const own = !c.options.target ? await attempt(form.own(root)) : undefined
+    // An explicit target can still resolve to this repository, directly or through a package.
+    const targetRepo = c.options.target ? await target.repository(c.options.target, root) : repo
+    const ownTarget = !c.options.target || (repo !== undefined && targetRepo === repo)
+
+    // Always load this repository's configured form from disk so a supplied body cannot bypass it.
+    const own = ownTarget
+      ? await attempt(form.own(root, { named: config.inbound.template }))
+      : undefined
 
     // Scaffold from the target's own issue form rather than from Frog's sections. An upstream project
     // judges a report against its own form. Fetched only when the answers would be used. Never fatal:
     // an unreachable target costs the scaffold, not the entry.
     const upstream =
-      !body && c.options.target
+      body === undefined && c.options.target && !ownTarget
         ? await attempt(
             form.scaffold(c.options.target, {
               outbound: config.outbound,
@@ -162,8 +168,11 @@ export const log = Cli.create('log', {
       (upstream?.ok ? upstream.value : undefined) ??
       (own?.ok && own.value ? IssueForm.scaffold(own.value) : undefined)
 
-    const validation = body && own?.ok && own.value ? form.validate(own.value, body) : undefined
-    if (validation && (validation.missing.length > 0 || validation.unanswered.length > 0)) {
+    const ownForm = own?.ok ? own.value : undefined
+    const validateBody = (value: string) => {
+      if (!ownForm) return undefined
+      const validation = form.validate(ownForm, value)
+      if (validation.missing.length === 0 && validation.unanswered.length === 0) return undefined
       const details = [
         validation.missing.length > 0
           ? `Missing or out-of-order headings: ${validation.missing
@@ -176,7 +185,7 @@ export const log = Cli.create('log', {
               .join(', ')}.`
           : undefined,
       ].filter(Boolean)
-      return c.error({
+      return {
         code: 'BODY_DOES_NOT_MATCH_FORM',
         message: `Body does not match this repository's issue form. ${details.join(' ')}`,
         cta: {
@@ -188,8 +197,11 @@ export const log = Cli.create('log', {
           ],
           description: 'Try:',
         },
-      })
+      }
     }
+
+    const initialBodyError = body !== undefined ? validateBody(body) : undefined
+    if (initialBodyError) return c.error(initialBodyError)
 
     // A scaffold satisfies the guard: it asks for the same detail, one question at a time. Without a
     // terminal it is the only way to reach a template.
@@ -249,6 +261,8 @@ export const log = Cli.create('log', {
           .then(() => Store.get(id, { root })),
       )
       if (!edited.ok) return c.error({ code: edited.code, message: edited.message })
+      const editedBodyError = validateBody(edited.value.body)
+      if (editedBodyError) return c.error(editedBodyError)
     }
 
     if (!c.options.publish)
@@ -265,8 +279,13 @@ export const log = Cli.create('log', {
         },
       )
 
-    // The entry is already on disk. Every failure past this point reports why it stayed pending
-    // rather than failing the command.
+    const entry = await attempt(Store.get(id, { root }))
+    if (!entry.ok) return c.error({ code: entry.code, message: entry.message })
+    const publishBodyError = validateBody(entry.value.body)
+    if (publishBodyError) return c.error(publishBodyError)
+
+    // The entry is already on disk. Every publishing failure past this point reports why it stayed
+    // pending rather than failing the command.
     const filed = await attempt(
       (async () => {
         const ready = await publisher.prepare({
@@ -277,9 +296,8 @@ export const log = Cli.create('log', {
         })
         if ('code' in ready) return ready
 
-        const entry = await Store.get(id, { root })
         const resolution = await Target.resolve(
-          entry.target,
+          entry.value.target,
           target.resolvers({
             outbound: config.outbound,
             client: ready.client,
@@ -293,7 +311,7 @@ export const log = Cli.create('log', {
         const outcome = await publisher.file({
           ...ready,
           config,
-          entries: [entry],
+          entries: [entry.value],
           origin: ready.repo,
           repo: resolution.target.repo,
           root,

--- a/src/cli/commands/log.ts
+++ b/src/cli/commands/log.ts
@@ -1,6 +1,7 @@
 import * as clack from '@clack/prompts'
 import { Cli, z } from 'incur'
 import * as Entry from '../../Entry.js'
+import * as IssueForm from '../../IssueForm.js'
 import * as Store from '../../Store.js'
 import * as Target from '../../Target.js'
 import { attempt } from '../internal/attempt.js'
@@ -60,7 +61,9 @@ export const log = Cli.create('log', {
     body: z
       .string()
       .optional()
-      .describe('Markdown body. Also read from piped input, or from an editor when interactive.'),
+      .describe(
+        'Complete Markdown body. Must preserve this repository issue form when one exists. Also read from piped input, or from an editor when interactive.',
+      ),
     cwd: context.cwdOption,
     force: z.boolean().optional().describe('Log it even if a similar entry already exists.'),
     label: z.array(z.string().min(1)).optional().describe('Extra issue label. Repeatable.'),
@@ -85,7 +88,6 @@ export const log = Cli.create('log', {
     {
       args: { title: '`pnpm test -- <files>` ignores file filters' },
       description: 'Log friction in this repository',
-      options: { body: '## Description\n\nThe filter was swallowed.' },
     },
     {
       args: { title: '`getBalance` rejects a checksummed address' },
@@ -138,12 +140,12 @@ export const log = Cli.create('log', {
 
     const body = c.options.body ?? (input?.body || undefined)
 
+    // Always load this repository's form from disk so a supplied body cannot bypass it.
+    const own = !c.options.target ? await attempt(form.own(root)) : undefined
+
     // Scaffold from the target's own issue form rather than from Frog's sections. An upstream project
     // judges a report against its own form. Fetched only when the answers would be used. Never fatal:
     // an unreachable target costs the scaffold, not the entry.
-    // With no target, use this repository's own form.
-    const own = !body && !c.options.target ? await attempt(form.own(root)) : undefined
-
     const upstream =
       !body && c.options.target
         ? await attempt(
@@ -157,7 +159,37 @@ export const log = Cli.create('log', {
           )
         : undefined
     const scaffold =
-      (upstream?.ok ? upstream.value : undefined) ?? (own?.ok ? own.value : undefined)
+      (upstream?.ok ? upstream.value : undefined) ??
+      (own?.ok && own.value ? IssueForm.scaffold(own.value) : undefined)
+
+    const validation = body && own?.ok && own.value ? form.validate(own.value, body) : undefined
+    if (validation && (validation.missing.length > 0 || validation.unanswered.length > 0)) {
+      const details = [
+        validation.missing.length > 0
+          ? `Missing or out-of-order headings: ${validation.missing
+              .map((label) => `\`${label}\``)
+              .join(', ')}.`
+          : undefined,
+        validation.unanswered.length > 0
+          ? `Required fields without answers: ${validation.unanswered
+              .map((label) => `\`${label}\``)
+              .join(', ')}.`
+          : undefined,
+      ].filter(Boolean)
+      return c.error({
+        code: 'BODY_DOES_NOT_MATCH_FORM',
+        message: `Body does not match this repository's issue form. ${details.join(' ')}`,
+        cta: {
+          commands: [
+            {
+              command: 'log',
+              description: "Omit --body to scaffold from this repository's issue form",
+            },
+          ],
+          description: 'Try:',
+        },
+      })
+    }
 
     // A scaffold satisfies the guard: it asks for the same detail, one question at a time. Without a
     // terminal it is the only way to reach a template.

--- a/src/cli/internal/form.test.ts
+++ b/src/cli/internal/form.test.ts
@@ -1,0 +1,40 @@
+import type * as IssueForm from '../../IssueForm.js'
+import * as form from './form.js'
+
+test('behavior: validates each individually required checkbox option', () => {
+  const issueForm: IssueForm.Form = {
+    fields: [
+      {
+        kind: 'checkboxes',
+        label: 'Agreements',
+        options: ['Optional', 'Required One', 'Required Two'],
+        required: true,
+        requiredOptions: ['Required One', 'Required Two'],
+      },
+    ],
+  }
+
+  expect(form.validate(issueForm, '### Agreements\n\n- [x] Optional')).toEqual({
+    missing: [],
+    unanswered: ['Agreements'],
+  })
+  expect(
+    form.validate(issueForm, '### Agreements\n\n- [x] Required One\n- [x] Required Two'),
+  ).toEqual({ missing: [], unanswered: [] })
+})
+
+test.each(['```ts', '~~~~ markdown'])(
+  'behavior: ignores headings inside a %s fenced code block',
+  (opening) => {
+    const issueForm: IssueForm.Form = {
+      fields: [{ kind: 'textarea', label: 'Current Behavior', required: true }],
+    }
+    const marker = opening.startsWith('`') ? '```' : '~~~~'
+    const body = [opening, '### Current Behavior', '', 'Not a form answer.', marker].join('\n')
+
+    expect(form.validate(issueForm, body)).toEqual({
+      missing: ['Current Behavior'],
+      unanswered: [],
+    })
+  },
+)

--- a/src/cli/internal/form.ts
+++ b/src/cli/internal/form.ts
@@ -69,10 +69,10 @@ export declare namespace scaffold {
  * The same discovery as an upstream target, off disk rather than over the API.
  *
  * @param root - Repository root.
- * @returns The scaffold, or `undefined` when this repository publishes no form.
+ * @returns The form, or `undefined` when this repository publishes no form.
  */
-export async function own(root: string): Promise<string | undefined> {
-  const form = await IssueForm.find({
+export async function own(root: string): Promise<IssueForm.Form | undefined> {
+  return IssueForm.find({
     list: (at) =>
       fs
         .readdir(path.join(root, at))
@@ -80,6 +80,65 @@ export async function own(root: string): Promise<string | undefined> {
         .catch(() => []),
     read: (at) => fs.readFile(path.join(root, at), 'utf8').catch(() => undefined),
   })
+}
 
-  return form ? IssueForm.scaffold(form) : undefined
+/**
+ * Checks that a supplied body preserves an issue form's headings and required answers.
+ *
+ * Optional fields still need their headings because the project chose the complete form shape. Their
+ * answers may remain empty.
+ *
+ * @param issueForm - The repository's issue form.
+ * @param body - Markdown supplied by the author.
+ * @returns Missing or out-of-order headings and required fields without answers.
+ */
+export function validate(issueForm: IssueForm.Form, body: string): validate.Result {
+  const headings = [...body.matchAll(/^(#{1,6})[ \t]+(.+?)(?:[ \t]+#+)?[ \t]*$/gm)].map(
+    (match) => ({
+      end: (match.index ?? 0) + match[0].length,
+      label: match[2]?.trim() ?? '',
+      start: match.index ?? 0,
+    }),
+  )
+
+  const missing: string[] = []
+  const matched: { field: IssueForm.Field; heading: (typeof headings)[number] }[] = []
+  let cursor = -1
+
+  for (const field of issueForm.fields) {
+    const index = headings.findIndex(
+      (heading, index) => index > cursor && heading.label === field.label,
+    )
+    if (index === -1) {
+      missing.push(field.label)
+      continue
+    }
+    matched.push({ field, heading: headings[index]! })
+    cursor = index
+  }
+
+  const unanswered = matched
+    .filter(({ field }, index) => {
+      if (!field.required) return false
+      const current = matched[index]!
+      const next = matched[index + 1]
+      const answer = body
+        .slice(current.heading.end, next?.heading.start)
+        .replace(/<!--[^]*?-->/g, '')
+        .trim()
+      if (field.kind === 'checkboxes') return !/(?:^|\n)\s*-\s*\[[xX]\]/.test(answer)
+      return answer.length === 0
+    })
+    .map(({ field }) => field.label)
+
+  return { missing, unanswered }
+}
+
+export declare namespace validate {
+  type Result = {
+    /** Form headings absent from the body or appearing in the wrong order. */
+    missing: readonly string[]
+    /** Required fields whose sections contain no answer. */
+    unanswered: readonly string[]
+  }
 }

--- a/src/cli/internal/form.ts
+++ b/src/cli/internal/form.ts
@@ -71,7 +71,10 @@ export declare namespace scaffold {
  * @param root - Repository root.
  * @returns The form, or `undefined` when this repository publishes no form.
  */
-export async function own(root: string): Promise<IssueForm.Form | undefined> {
+export async function own(
+  root: string,
+  options: own.Options = {},
+): Promise<IssueForm.Form | undefined> {
   return IssueForm.find({
     list: (at) =>
       fs
@@ -79,7 +82,15 @@ export async function own(root: string): Promise<IssueForm.Form | undefined> {
         .then((names) => names.map((name) => `${at}/${name}`))
         .catch(() => []),
     read: (at) => fs.readFile(path.join(root, at), 'utf8').catch(() => undefined),
+    ...(options.named ? { named: options.named } : {}),
   })
+}
+
+export declare namespace own {
+  type Options = {
+    /** Form named by this repository's inbound configuration. */
+    named?: string | undefined
+  }
 }
 
 /**
@@ -93,13 +104,7 @@ export async function own(root: string): Promise<IssueForm.Form | undefined> {
  * @returns Missing or out-of-order headings and required fields without answers.
  */
 export function validate(issueForm: IssueForm.Form, body: string): validate.Result {
-  const headings = [...body.matchAll(/^(#{1,6})[ \t]+(.+?)(?:[ \t]+#+)?[ \t]*$/gm)].map(
-    (match) => ({
-      end: (match.index ?? 0) + match[0].length,
-      label: match[2]?.trim() ?? '',
-      start: match.index ?? 0,
-    }),
-  )
+  const headings = parseHeadings(body)
 
   const missing: string[] = []
   const matched: { field: IssueForm.Field; heading: (typeof headings)[number] }[] = []
@@ -126,12 +131,59 @@ export function validate(issueForm: IssueForm.Form, body: string): validate.Resu
         .slice(current.heading.end, next?.heading.start)
         .replace(/<!--[^]*?-->/g, '')
         .trim()
-      if (field.kind === 'checkboxes') return !/(?:^|\n)\s*-\s*\[[xX]\]/.test(answer)
+      if (field.kind === 'checkboxes') {
+        const checked = new Set(
+          [...answer.matchAll(/^\s*-\s*\[[xX]\]\s+(.+?)\s*$/gm)].map(
+            (match) => match[1]?.trim() ?? '',
+          ),
+        )
+        if (field.requiredOptions?.some((option) => !checked.has(option))) return true
+        return field.required && checked.size === 0
+      }
       return answer.length === 0
     })
     .map(({ field }) => field.label)
 
   return { missing, unanswered }
+}
+
+/** ATX headings outside fenced code blocks, with body offsets for section slicing. */
+function parseHeadings(body: string) {
+  const headings: { end: number; label: string; start: number }[] = []
+  let fence: { marker: '`' | '~'; size: number } | undefined
+  let offset = 0
+
+  for (const terminated of body.match(/[^\n]*(?:\n|$)/g) ?? []) {
+    if (!terminated) continue
+    const line = terminated.replace(/\r?\n$/, '')
+
+    if (fence) {
+      const currentFence = fence
+      const closing = /^ {0,3}(`+|~+)[ \t]*$/.exec(line)?.[1]
+      if (closing?.startsWith(currentFence.marker) && closing.length >= currentFence.size)
+        fence = undefined
+      offset += terminated.length
+      continue
+    }
+
+    const opening = /^ {0,3}(`{3,}|~{3,})/.exec(line)?.[1]
+    if (opening) {
+      fence = { marker: opening[0] as '`' | '~', size: opening.length }
+      offset += terminated.length
+      continue
+    }
+
+    const heading = /^ {0,3}(#{1,6})[ \t]+(.+?)(?:[ \t]+#+)?[ \t]*$/.exec(line)
+    if (heading)
+      headings.push({
+        end: offset + line.length,
+        label: heading[2]?.trim() ?? '',
+        start: offset,
+      })
+    offset += terminated.length
+  }
+
+  return headings
 }
 
 export declare namespace validate {

--- a/src/cli/internal/target.ts
+++ b/src/cli/internal/target.ts
@@ -4,7 +4,7 @@ import * as Cache from '../../Cache.js'
 import * as Config from '../../Config.js'
 import type * as Github from '../../Github.js'
 import * as GithubModule from '../../Github.js'
-import type * as Target from '../../Target.js'
+import * as Target from '../../Target.js'
 
 /** Concurrent config lookups, bounded so a large dependency list does not open one socket each. */
 const concurrency = 8
@@ -40,6 +40,20 @@ export declare namespace resolvers {
     /** Where to keep config lookups. Absent reads fresh every time. */
     store?: Cache.Cache | undefined
   }
+}
+
+/**
+ * Resolves a target to its declared repository using local data only.
+ *
+ * Repository targets need no lookup. Package targets read their installed `package.json`.
+ *
+ * @param value - Target as written.
+ * @param root - Repository root, holding `node_modules`.
+ * @returns The declared repository, or `undefined` when a package cannot be resolved.
+ */
+export async function repository(value: string, root: string): Promise<string | undefined> {
+  const { kind, name } = Target.classify(value)
+  return kind === 'repo' ? name : repoOf(name, root)
 }
 
 /**


### PR DESCRIPTION
Validated supplied friction bodies against a repository's local issue form before writing entries. Supplied `--body` values previously skipped form discovery and could bypass required headings and answers.