### PR TITLE
fix: preserve release note formatting

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,5 @@
+{
+  "printWidth": 100,
+  "semi": false,
+  "singleQuote": true
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,17 @@
 - 5225ab5: Added pluggable friction stores, a Postgres.js-backed `Store.postgres({ connectionString })` factory, and the `Frog.create` logging API.
 
   ```ts
-  import { Frog, Store } from "frog";
+  import { Frog, Store } from 'frog'
 
-  const store = Store.postgres({ connectionString: process.env.DATABASE_URL! });
-  const frog = Frog.create({ store });
+  const store = Store.postgres({ connectionString: process.env.DATABASE_URL! })
+  const frog = Frog.create({ store })
   await frog.log({
-    body: "The workaround used.",
-    severity: "minor",
-    title: "Tool required a workaround",
-  });
-  const logs = await frog.logs();
-  await store.close();
+    body: 'The workaround used.',
+    severity: 'minor',
+    title: 'Tool required a workaround',
+  })
+  const logs = await frog.logs()
+  await store.close()
   ```
 
 ## 1.0.15


### PR DESCRIPTION
Add a Prettier compatibility configuration and format the generated changelog so Changesets release PRs remain compatible with Vite+ formatting.